### PR TITLE
chore: remove loki logging driver block

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -9,10 +9,6 @@ services:
             JWT_PUBLIC_KEY: "${JWT_PUBLIC_KEY}"
             JWT_SECRET_KEY: "${JWT_SECRET_KEY}"
             JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
-        logging:
-            driver: loki
-            options:
-                loki-url: "http://176.31.100.99:3100/loki/api/v1/push"
         tty: true
         deploy:
             labels:


### PR DESCRIPTION
## Why

The observability stack is migrating from the `loki-docker-driver` plugin to **Alloy** (barlito/observability-stack#1). Alloy discovers every container via the Docker socket and ships logs to Loki over the overlay network, so per-stack `logging:` blocks are no longer needed.

The plugin will be uninstalled from the server afterwards — any stack still referencing `driver: loki` would then fail to start its containers.

Logs keep flowing to Loki automatically (labels: `container`, `service`, `stack`).

⚠️ Merge + redeploy **before** uninstalling the loki plugin on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
