### PR TITLE
feat(phase 1d): booster hub UI + animation de reveal séquentiel

### DIFF
--- a/.env
+++ b/.env
@@ -32,3 +32,7 @@ LOGOUT_URL='https://yc.barlito.fr/logout'
 ###> lexik/jwt-authentication-bundle ###
 JWT_COOKIE_DOMAIN=.barlito.fr
 ###< lexik/jwt-authentication-bundle ###
+
+###> Booster claims ###
+BOOSTER_DAILY_LIMIT_ENABLED=true
+###< Booster claims ###

--- a/.env
+++ b/.env
@@ -32,7 +32,3 @@ LOGOUT_URL='https://yc.barlito.fr/logout'
 ###> lexik/jwt-authentication-bundle ###
 JWT_COOKIE_DOMAIN=.barlito.fr
 ###< lexik/jwt-authentication-bundle ###
-
-###> Booster claims ###
-BOOSTER_DAILY_LIMIT_ENABLED=true
-###< Booster claims ###

--- a/.env.dev
+++ b/.env.dev
@@ -14,3 +14,9 @@ JWT_COOKIE_DOMAIN=.local.barlito.fr
 REFRESH_TOKEN_URL='https://yc.local.barlito.fr/refresh_token'
 LOGOUT_URL='https://yc.local.barlito.fr/logout'
 ###< Project external URLS ###
+
+###> Booster claims ###
+# Limite quotidienne désactivée en dev pour tester les ouvertures en boucle.
+# Repasser à true pour tester le quota/countdown.
+BOOSTER_DAILY_LIMIT_ENABLED=false
+###< Booster claims ###

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,9 @@ jobs:
           make doctrine.migrate.ci
           make doctrine.load_fixtures.ci
 
+      - name: Build Tailwind CSS
+        run: make tailwind.build
+
       - name: Run phpunit
         run: make phpunit
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@
 ###> lexik/jwt-authentication-bundle ###
 /config/jwt/*.pem
 ###< lexik/jwt-authentication-bundle ###
+
+###> Claude Code (settings locaux et handoffs design uniquement) ###
+/.claude/settings.local.json
+/.claude/design_handoff_youl/
+###< Claude Code ###

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 **Core Entities:**
 - **Card**: Trading cards with multi-image support (main image, mask, foil)
-  - Fields: name, description, status (DRAFT/PUBLISHED), rarity (CardRarityEnum: common/uncommon/rare/legendary), type (CardTypeEnum, nullable, matches the CSS type glow classes), uniqueFlag
+  - Fields: name, description, status (DRAFT/PUBLISHED), rarity (CardRarityEnum: common/uncommon/rare/epic/legendary — white/green/blue/purple/orange glows), type (CardTypeEnum, nullable, matches the CSS type glow classes), uniqueFlag
   - Uses VichUploaderBundle for file uploads
   - ManyToOne with Extension
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Youl TCG** is a Trading Card Game (TCG) application built with Symfony 7.2. Users authenticate via Discord OAuth2 and can view/collect trading cards organized into extensions. The application features advanced 3D interactive card rendering with JavaScript-based animations.
+**Youl TCG** is a Trading Card Game (TCG) application built with Symfony 7.4 LTS. Users authenticate via Discord OAuth2, claim free daily boosters, open them with an animated card reveal and collect trading cards organized into extensions. The application features advanced 3D interactive card rendering with JavaScript-based animations.
 
 ## Development Environment
 
 ### Stack & Tools
-- **Framework:** Symfony 7.2 (PHP 8.2+)
-- **Database:** PostgreSQL 13 (production), SQLite (dev)
-- **Web Server:** FrankenPHP (Caddy-based)
+- **Framework:** Symfony 7.4 LTS (PHP 8.4)
+- **Database:** PostgreSQL 18
+- **Web Server:** FrankenPHP (Caddy-based, non-root user `www`)
 - **Authentication:** JWT (cookie-based) + Discord OAuth2
-- **Admin Panel:** EasyAdminBundle 4.11
+- **Admin Panel:** EasyAdminBundle 4.x
+- **Frontend interactivity:** Stimulus + symfony/ux-live-component (AssetMapper, no build step)
 - **Task Runner:** Castor + Makefile (uses barlito/php-make-rules submodule)
 - **Container Orchestration:** Docker Swarm (stack name: `ytcg`)
-- **Reverse Proxy:** Traefik (external traefik_traefik_proxy network)
+- **Reverse Proxy:** Traefik (external traefik_traefik_proxy network, TLS terminated by Traefik)
 
 ### Common Commands
 
@@ -99,7 +100,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 **Core Entities:**
 - **Card**: Trading cards with multi-image support (main image, mask, foil)
-  - Fields: name, description, status (DRAFT/PUBLISHED), uniqueFlag
+  - Fields: name, description, status (DRAFT/PUBLISHED), rarity (CardRarityEnum: common/uncommon/rare/legendary), type (CardTypeEnum, nullable, matches the CSS type glow classes), uniqueFlag
   - Uses VichUploaderBundle for file uploads
   - ManyToOne with Extension
 
@@ -108,8 +109,8 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
   - OneToMany with Card and Booster
 
 - **Booster**: Booster packs containing cards
-  - Fields: price, quantity, rarityRate[], holoRate[]
-  - ManyToOne with Extension
+  - Fields: rarityRates (JSON, one `{rarity: weight}` map per card slot — the slot count IS the card count), holoRate (0-100 % holo chance per drawn card), imageName
+  - ManyToOne with Extension; boosters are free (no currency in v2)
 
 **User System:**
 - **DiscordUser**: Main user entity (implements UserInterface)
@@ -117,8 +118,19 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
   - Discord OAuth2 integration for authentication
   - OneToMany with UserCard and UserBooster
 
-- **UserCard**: User card inventory (composite key: DiscordUser + Card)
-- **UserBooster**: User booster inventory (composite key: DiscordUser + Booster)
+- **UserCard**: User card inventory (composite key: DiscordUser + Card, quantity + holoQuantity)
+- **UserBooster**: User unopened booster inventory (composite key: DiscordUser + Booster)
+
+**Audit Entities (booster opening):**
+- **BoosterClaim**: one row per daily free claim; the daily quota (2/day, reset midnight Europe/Paris) is a COUNT since midnight — no mutable counter anywhere
+- **BoosterOpening** + **BoosterOpeningCard**: opening history with the RNG seed (reproducible draws); duplicates aggregated per card (composite PK)
+
+### Booster Opening Flow (`src/Service/Booster/`)
+
+1. **BoosterClaimService::claim()** — checks the daily quota, credits `UserBooster` via UserInventoryService, persists a `BoosterClaim`
+2. **BoosterOpeningService::open()** — one transaction: pessimistic-locked inventory debit, seeded `CardDrawer::draw()` (per-slot weighted rarity roll, uniform pick in the tier, fallback to the nearest tier with cards, holo roll), duplicate aggregation, `UserCard` credit, audit persistence
+3. **RandomService** (`src/Service/Random/`) — seedable `Random\Randomizer` wrapper; the seed is stored on `BoosterOpening`
+4. UI: **BoosterHub** Live Component (`src/Twig/Components/`) renders `/boosters`; the reveal animation is driven by `assets/controllers/booster_opening_controller.js`
 
 **Common Traits:**
 - `IdUuidTrait` (from barlito/utils): UUID primary keys
@@ -139,28 +151,30 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 **Frontend (`src/Controller/`):**
 - **BaseController**: Homepage with 3 random published cards (cached daily)
-  - Routes: `/` (homepage), `/extensions` (coming soon), `/boosters` (coming soon)
+  - Routes: `/` (homepage), `/extensions` (coming soon), `/boosters` (booster hub)
   - Uses custom `CardRepository::findRandomCardId()` with RANDOM() DQL function
 
 **Admin (`src/Controller/Admin/`):**
 - **DashboardController**: EasyAdmin dashboard entry
-- **CardCrudController**: Card management with custom ImageField
+- **CardCrudController**: Card management with custom ImageField (rarity/type choice fields)
 - **ExtensionCrudController**: Extension management
+- **BoosterCrudController**: Booster management (rarityRates edited as JSON via CodeEditorField, validated by the ValidRarityRates constraint)
 - Access: Requires ROLE_ADMIN
 
 ### Frontend Architecture
 
 **3D Card Rendering System:**
-- **CSS**: `assets/styles/cards/base.css` (347 lines of advanced 3D CSS)
+- **CSS**: `assets/styles/cards/base.css` (advanced 3D CSS)
   - Hardware-accelerated transforms with perspective
   - Multi-layer effects: shine, glare, foil masks
   - Type-specific glows (water, fire, grass, etc.)
+- **CSS**: `assets/styles/cards/rarity.css`
+  - Rarity glow colors (`data-rarity`), face-down/revealed states, card back, holo badge
 
-- **JavaScript**: `assets/scripts/card/card.js`
-  - Real-time mouse-tracking 3D rotation
-  - Anime.js animations for smooth transitions
-  - Touch event support
-  - Key functions: `computePositions()`, `updateCard()`, `resetElement()`
+- **JavaScript (Stimulus controllers in `assets/controllers/`):**
+  - `card_controller.js`: real-time mouse-tracking 3D rotation (anime.js); attached via `data-controller="card"`, so dynamically rendered cards (Live Components) work too
+  - `booster_opening_controller.js`: sequential flip reveal in the opening modal (click to skip)
+  - `countdown_controller.js`: live countdown to the daily quota reset
 
 **Asset Pipeline:**
 - Uses Symfony AssetMapper (no Webpack/build step)
@@ -174,6 +188,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 - `cards`: Main card artwork → `/public/images/cards/`
 - `masks`: Foil/holo masks → `/public/images/masks/`
 - `foils`: Foil textures → `/public/images/foils/`
+- `boosters`: Booster images → `/public/images/boosters/`
 - `extensions`: Extension images → `/public/images/extensions/`
 
 **Upload Routes:**
@@ -221,9 +236,9 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 ### Modifying Card Display
 
-- **CSS changes**: Edit `assets/styles/cards/base.css`
-- **JavaScript interactions**: Edit `assets/scripts/card/card.js`
-- **Template structure**: Edit `templates/components/CardComponent.html.twig`
+- **CSS changes**: Edit `assets/styles/cards/base.css` (3D core) or `assets/styles/cards/rarity.css` (rarity/reveal states)
+- **JavaScript interactions**: Edit `assets/controllers/card_controller.js`
+- **Template structure**: Edit `templates/components/CardComponent.html.twig` (optional params: `holo`, `facedown`, `id`)
 - **Card selection logic**: Modify `CardRepository::findRandomCardId()`
 
 ### Adding JWT Event Listeners

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 ### Booster Opening Flow (`src/Service/Booster/`)
 
-1. **BoosterClaimService::claim()** — checks the daily quota, credits `UserBooster` via UserInventoryService, persists a `BoosterClaim`
+1. **BoosterClaimService::claim()** — checks the daily quota, credits `UserBooster` via UserInventoryService, persists a `BoosterClaim`. The quota can be bypassed with `BOOSTER_DAILY_LIMIT_ENABLED=false` (default in `.env.dev`, for repeated opening tests)
 2. **BoosterOpeningService::open()** — one transaction: pessimistic-locked inventory debit, seeded `CardDrawer::draw()` (per-slot weighted rarity roll, uniform pick in the tier, fallback to the nearest tier with cards, holo roll), duplicate aggregation, `UserCard` credit, audit persistence
 3. **RandomService** (`src/Service/Random/`) — seedable `Random\Randomizer` wrapper; the seed is stored on `BoosterOpening`
 4. UI: **BoosterHub** Live Component (`src/Twig/Components/`) renders `/boosters`; the reveal animation is driven by `assets/controllers/booster_opening_controller.js`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,10 +54,8 @@ make cs-fix
 # PHP CodeSniffer (uses vendor/barlito/utils/config/phpcs.xml.dist)
 make cs-check
 
-# PHPMD (uses vendor/barlito/utils/config/phpmd.xml)
-make phpmd
-
-# Run all quality checks
+# Run all quality checks (composer validate, phpcs, cs-fixer, phpstan, rector)
+# Note: phpmd is disabled everywhere until pdepend supports PHP 8.4 syntax
 make quality
 ```
 
@@ -259,7 +257,7 @@ All JWT listeners must:
 ### Code Quality Standards
 
 - PSR-12 coding standard via PHP CS Fixer
-- PHPMD ruleset from `vendor/barlito/utils/config/phpmd.xml`
+- PHPStan level 8 (baseline in `phpstan-baseline.neon` — never add new entries)
 - Declare strict types: `declare(strict_types=1);`
 - Use typed properties and return types
 - Enum over constants for fixed value sets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 ### Booster Opening Flow (`src/Service/Booster/`)
 
-1. **BoosterClaimService::claim()** — checks the daily quota, credits `UserBooster` via UserInventoryService, persists a `BoosterClaim`. The quota can be bypassed with `BOOSTER_DAILY_LIMIT_ENABLED=false` (default in `.env.dev`, for repeated opening tests)
+1. **BoosterClaimService::claim()** — asks the quota policy (`BoosterClaimQuotaInterface` / `DailyBoosterClaimQuota`) for remaining claims, credits `UserBooster` via UserInventoryService, persists a `BoosterClaim`. In dev only, the `UnlimitedBoosterClaimQuota` decorator (`#[When(env: 'dev')]`) lifts the limit unless `BOOSTER_DAILY_LIMIT_ENABLED=true` is set in `.env.dev` — prod code carries no bypass
 2. **BoosterOpeningService::open()** — one transaction: pessimistic-locked inventory debit, seeded `CardDrawer::draw()` (per-slot weighted rarity roll, uniform pick in the tier, fallback to the nearest tier with cards, holo roll), duplicate aggregation, `UserCard` credit, audit persistence
 3. **RandomService** (`src/Service/Random/`) — seedable `Random\Randomizer` wrapper; the seed is stored on `BoosterOpening`
 4. UI: **BoosterHub** Live Component (`src/Twig/Components/`) renders `/boosters`; the reveal animation is driven by `assets/controllers/booster_opening_controller.js`

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ db.backup:
 		echo "ℹ  DB container introuvable, backup skippé (1er deploy ?)"; \
 	fi
 
+# Tailwind est requis pour rendre base.html.twig (TailwindCssAssetCompiler lève
+# une exception si var/tailwind/tailwind.built.css est absent) — nécessaire en CI
+# avant les tests fonctionnels qui rendent des pages.
+tailwind.build:
+	docker exec -t $(app_container_id) bin/console tailwind:build --minify
+
 # Smoke test : curl GET / → fail si non-2xx. Sert de garde-fou post-deploy/update.
 smoke.test:
 	@echo "🩺 Smoke test https://$(prod_host)/..."

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ backup_path=/srv/ytcg/backups
 # Config paths
 config_cs_fixer=vendor/barlito/utils/config/.php-cs-fixer.dist.php
 config_phpcs=vendor/barlito/utils/config/phpcs.xml.dist
-config_phpmd=vendor/barlito/utils/config/phpmd.xml
 
 # Include all make rules from submodule
 include make/entrypoint.mk

--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -1,0 +1,79 @@
+import { Controller } from '@hotwired/stimulus';
+import anime from '../scripts/card/lib/anime.es.js';
+
+/**
+ * Sequential reveal of the cards drawn from a booster.
+ *
+ * Cards start face-down (`.card.facedown`, rotator at rotateY(180deg)) and
+ * flip one by one with a stagger. Clicking anywhere in the grid skips the
+ * animation and reveals everything. Once revealed, the interactive 3D
+ * card_controller takes over (pointer-events are re-enabled by removing
+ * `.facedown`).
+ */
+export default class extends Controller {
+    static targets = ['card'];
+
+    connect() {
+        this.finished = false;
+
+        const rotators = this.cardTargets.map((wrapper) => wrapper.querySelector('.card__rotator'));
+        rotators.forEach((rotator) => rotator.style.setProperty('transform', 'rotateY(180deg)'));
+
+        this.timeline = anime.timeline({
+            autoplay: false,
+            complete: () => { this.finished = true; },
+        });
+
+        this.cardTargets.forEach((wrapper, index) => {
+            this.timeline.add({
+                targets: wrapper.querySelector('.card__rotator'),
+                rotateY: [180, 0],
+                scale: [
+                    { value: 1.08, duration: 250, easing: 'easeOutQuad' },
+                    { value: 1, duration: 350, easing: 'easeOutQuad' },
+                ],
+                duration: 700,
+                easing: 'easeOutBack',
+                begin: () => this.#flipStarted(wrapper),
+                complete: () => this.#reveal(wrapper),
+            }, 400 + index * 650);
+        });
+
+        this.timeline.play();
+    }
+
+    disconnect() {
+        if (this.timeline) {
+            this.timeline.pause();
+        }
+    }
+
+    skip() {
+        if (this.finished) {
+            return;
+        }
+
+        this.finished = true;
+        this.timeline.pause();
+        this.cardTargets.forEach((wrapper) => {
+            const rotator = wrapper.querySelector('.card__rotator');
+            rotator.style.removeProperty('transform');
+            this.#flipStarted(wrapper);
+            this.#reveal(wrapper);
+        });
+    }
+
+    #flipStarted(wrapper) {
+        // Half-way through the flip the front becomes visible: drop the
+        // facedown rotation class now, the inline transform drives the rest.
+        wrapper.querySelector('.card').classList.remove('facedown');
+    }
+
+    #reveal(wrapper) {
+        const card = wrapper.querySelector('.card');
+        card.classList.add('revealed');
+
+        const rotator = wrapper.querySelector('.card__rotator');
+        rotator.style.removeProperty('transform');
+    }
+}

--- a/assets/controllers/countdown_controller.js
+++ b/assets/controllers/countdown_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Live countdown to a target datetime (ISO 8601 in `data-countdown-target-value`).
+ * Reloads the page once the target is reached so quota-dependent UI refreshes.
+ */
+export default class extends Controller {
+    static values = {
+        target: String
+    }
+
+    connect() {
+        this.updateCountdown();
+        this.interval = setInterval(() => this.updateCountdown(), 1000);
+    }
+
+    disconnect() {
+        if (this.interval) {
+            clearInterval(this.interval);
+        }
+    }
+
+    updateCountdown() {
+        const now = new Date();
+        const target = new Date(this.targetValue);
+        const diff = target - now;
+
+        if (diff <= 0) {
+            window.location.reload();
+            return;
+        }
+
+        const hours = Math.floor(diff / (1000 * 60 * 60));
+        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+        const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+        this.element.textContent = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+    }
+}

--- a/assets/styles/cards/rarity.css
+++ b/assets/styles/cards/rarity.css
@@ -1,0 +1,88 @@
+/**
+
+  Rarity glow + booster opening reveal states.
+  Loaded after cards/base.css, relies on its .card / .card__rotator structure.
+
+**/
+
+.card[data-rarity="common"]    { --rarity-glow: hsl(0, 0%, 75%); }
+.card[data-rarity="uncommon"]  { --rarity-glow: hsl(96, 81%, 55%); }
+.card[data-rarity="rare"]      { --rarity-glow: hsl(220, 90%, 60%); }
+.card[data-rarity="legendary"] { --rarity-glow: hsl(45, 95%, 55%); }
+
+/* Face-down card waiting to be revealed (booster opening modal). */
+.card.facedown {
+  pointer-events: none;
+}
+
+.card.facedown .card__rotator {
+  transform: rotateY(180deg);
+}
+
+.card__back {
+  background: radial-gradient(circle at 50% 40%, hsl(263, 45%, 28%), hsl(240, 40%, 12%) 75%);
+  display: grid;
+  place-items: center;
+  backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
+  transform: rotateY(180deg) translateZ(1px);
+}
+
+.card__back img {
+  width: 55% !important;
+  aspect-ratio: auto !important;
+  filter: drop-shadow(0 0 12px rgba(0, 0, 0, 0.8));
+}
+
+/* Revealed card: glow tinted by rarity. */
+.card.revealed .card__rotator {
+  box-shadow:
+    0 0 3px -1px white,
+    0 0 3px 1px var(--card-edge),
+    0 0 14px 2px var(--rarity-glow),
+    0px 10px 20px -5px black,
+    0 0 40px -25px var(--rarity-glow),
+    0 0 60px -20px var(--rarity-glow);
+}
+
+.card.revealed[data-rarity="legendary"] .card__rotator {
+  animation: legendary-pulse 2s ease-in-out infinite;
+}
+
+@keyframes legendary-pulse {
+  0%, 100% {
+    box-shadow:
+      0 0 3px -1px white,
+      0 0 3px 1px var(--card-edge),
+      0 0 14px 2px var(--rarity-glow),
+      0px 10px 20px -5px black,
+      0 0 40px -25px var(--rarity-glow),
+      0 0 60px -20px var(--rarity-glow);
+  }
+  50% {
+    box-shadow:
+      0 0 3px -1px white,
+      0 0 5px 2px var(--card-edge),
+      0 0 24px 6px var(--rarity-glow),
+      0px 10px 20px -5px black,
+      0 0 50px -15px var(--rarity-glow),
+      0 0 80px -10px var(--rarity-glow);
+  }
+}
+
+/* Holo badge under the card name. */
+.holo-badge {
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: hsl(263, 70%, 20%);
+  background: linear-gradient(110deg, #b8e1ff, #e3b8ff 30%, #ffd6e8 55%, #c8ffe0 80%, #b8e1ff);
+  background-size: 200% 100%;
+  animation: holo-shimmer 2.5s linear infinite;
+}
+
+@keyframes holo-shimmer {
+  to { background-position: 200% 0; }
+}

--- a/assets/styles/cards/rarity.css
+++ b/assets/styles/cards/rarity.css
@@ -5,10 +5,13 @@
 
 **/
 
-.card[data-rarity="common"]    { --rarity-glow: hsl(0, 0%, 75%); }
-.card[data-rarity="uncommon"]  { --rarity-glow: hsl(96, 81%, 55%); }
-.card[data-rarity="rare"]      { --rarity-glow: hsl(220, 90%, 60%); }
-.card[data-rarity="legendary"] { --rarity-glow: hsl(45, 95%, 55%); }
+/* Tiers alignés sur la direction "Violet Arcade" :
+   blanc / vert / bleu / violet / orange. */
+.card[data-rarity="common"]    { --rarity-glow: hsl(0, 0%, 92%); }
+.card[data-rarity="uncommon"]  { --rarity-glow: hsl(140, 70%, 63%); }
+.card[data-rarity="rare"]      { --rarity-glow: hsl(212, 100%, 66%); }
+.card[data-rarity="epic"]      { --rarity-glow: hsl(277, 87%, 57%); }
+.card[data-rarity="legendary"] { --rarity-glow: hsl(33, 100%, 59%); }
 
 /* Face-down card waiting to be revealed (booster opening modal). */
 .card.facedown {

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,6 @@
         "dama/doctrine-test-bundle": "^8.6",
         "friendsofphp/php-cs-fixer": "^3.95",
         "hautelook/alice-bundle": "^2.16",
-        "phpmd/phpmd": "^2.15",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-doctrine": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47f1df85047522cb8354f09ab4378fc2",
+    "content-hash": "32369721db7a15db40d132e9626939b9",
     "packages": [
         {
             "name": "barlito/utils",
@@ -10316,69 +10316,6 @@
             "time": "2025-12-06T11:56:16+00:00"
         },
         {
-            "name": "pdepend/pdepend",
-            "version": "2.16.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "f942b208dc2a0868454d01b29f0c75bbcfc6ed58"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/f942b208dc2a0868454d01b29f0c75bbcfc6ed58",
-                "reference": "f942b208dc2a0868454d01b29f0c75bbcfc6ed58",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.7",
-                "symfony/config": "^2.3.0|^3|^4|^5|^6.0|^7.0",
-                "symfony/dependency-injection": "^2.3.0|^3|^4|^5|^6.0|^7.0",
-                "symfony/filesystem": "^2.3.0|^3|^4|^5|^6.0|^7.0",
-                "symfony/polyfill-mbstring": "^1.19"
-            },
-            "require-dev": {
-                "easy-doc/easy-doc": "0.0.0|^1.2.3",
-                "gregwar/rst": "^1.0",
-                "squizlabs/php_codesniffer": "^2.0.0"
-            },
-            "bin": [
-                "src/bin/pdepend"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PDepend\\": "src/main/php/PDepend"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Official version of pdepend to be handled with Composer",
-            "keywords": [
-                "PHP Depend",
-                "PHP_Depend",
-                "dev",
-                "pdepend"
-            ],
-            "support": {
-                "issues": "https://github.com/pdepend/pdepend/issues",
-                "source": "https://github.com/pdepend/pdepend/tree/2.16.2"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/pdepend/pdepend",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-12-17T18:09:59+00:00"
-        },
-        {
             "name": "phar-io/manifest",
             "version": "2.0.4",
             "source": {
@@ -10495,89 +10432,6 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
-        },
-        {
-            "name": "phpmd/phpmd",
-            "version": "2.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "74a1f56e33afad4128b886e334093e98e1b5e7c0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/74a1f56e33afad4128b886e334093e98e1b5e7c0",
-                "reference": "74a1f56e33afad4128b886e334093e98e1b5e7c0",
-                "shasum": ""
-            },
-            "require": {
-                "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0",
-                "ext-xml": "*",
-                "pdepend/pdepend": "^2.16.1",
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "easy-doc/easy-doc": "0.0.0 || ^1.3.2",
-                "ext-json": "*",
-                "ext-simplexml": "*",
-                "gregwar/rst": "^1.0",
-                "mikey179/vfsstream": "^1.6.8",
-                "squizlabs/php_codesniffer": "^2.9.2 || ^3.7.2"
-            },
-            "bin": [
-                "src/bin/phpmd"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "PHPMD\\": "src/main/php"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Manuel Pichler",
-                    "email": "github@manuel-pichler.de",
-                    "homepage": "https://github.com/manuelpichler",
-                    "role": "Project Founder"
-                },
-                {
-                    "name": "Marc Würth",
-                    "email": "ravage@bluewin.ch",
-                    "homepage": "https://github.com/ravage84",
-                    "role": "Project Maintainer"
-                },
-                {
-                    "name": "Other contributors",
-                    "homepage": "https://github.com/phpmd/phpmd/graphs/contributors",
-                    "role": "Contributors"
-                }
-            ],
-            "description": "PHPMD is a spin-off project of PHP Depend and aims to be a PHP equivalent of the well known Java tool PMD.",
-            "homepage": "https://phpmd.org/",
-            "keywords": [
-                "dev",
-                "mess detection",
-                "mess detector",
-                "pdepend",
-                "phpmd",
-                "pmd"
-            ],
-            "support": {
-                "irc": "irc://irc.freenode.org/phpmd",
-                "issues": "https://github.com/phpmd/phpmd/issues",
-                "source": "https://github.com/phpmd/phpmd/tree/2.15.0"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpmd/phpmd",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-12-11T08:22:20+00:00"
         },
         {
             "name": "phpstan/extension-installer",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,6 +20,11 @@ services:
             - '../src/Entity/'
             - '../src/Kernel.php'
 
+    # Explicit alias: in dev the UnlimitedBoosterClaimQuota decorator also
+    # implements the interface, which breaks the automatic alias. Pointing at
+    # the decorated service id resolves to the decorator chain when present.
+    App\Service\Booster\BoosterClaimQuotaInterface: '@App\Service\Booster\DailyBoosterClaimQuota'
+
 when@test:
     services:
         _defaults:

--- a/fixtures/Booster.yaml
+++ b/fixtures/Booster.yaml
@@ -6,7 +6,7 @@ App\Entity\Booster:
         rarityRates:
             - { common: 100 }
             - { common: 100 }
-            - { common: 60, rare: 30, legendary: 10 }
+            - { common: 55, rare: 25, epic: 15, legendary: 5 }
     booster_bleach:
         extension: '@extension_bleach'
         imageName: 'default_card.png'

--- a/fixtures/Card.yaml
+++ b/fixtures/Card.yaml
@@ -40,7 +40,7 @@ App\Entity\Card:
         unique: true
         imageName: 'default_card.png'
         status: 2
-        rarity: 'rare'
+        rarity: 'epic'
         type: 'water'
     card_magic_king_julian:
         name: 'Magic King Julian'

--- a/fixtures/UserBooster.yaml
+++ b/fixtures/UserBooster.yaml
@@ -1,0 +1,9 @@
+App\Entity\UserBooster:
+    user_booster_barlito_cyberpunk:
+        discordUser: '@discord_user_barlito'
+        booster: '@booster_cyberpunk'
+        quantity: 3
+    user_booster_barlito_bleach:
+        discordUser: '@discord_user_barlito'
+        booster: '@booster_bleach'
+        quantity: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,20 +55,8 @@ parameters:
 			path: src/Doctrine/DBAL/FunctionNode/Random.php
 
 		-
-			message: '#^Property App\\Entity\\Booster\:\:\$updatedAt \(DateTime\|null\) does not accept DateTimeImmutable\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Entity/Booster.php
-
-		-
 			message: '#^Method App\\Entity\\Card\:\:getExtension\(\) should return App\\Entity\\Extension but returns App\\Entity\\Extension\|null\.$#'
 			identifier: return.type
-			count: 1
-			path: src/Entity/Card.php
-
-		-
-			message: '#^Property App\\Entity\\Card\:\:\$imageFoilFile \(Symfony\\Component\\HttpFoundation\\File\\File\|null\) is never assigned Symfony\\Component\\HttpFoundation\\File\\File so it can be removed from the property type\.$#'
-			identifier: property.unusedType
 			count: 1
 			path: src/Entity/Card.php
 
@@ -76,12 +64,6 @@ parameters:
 			message: '#^Property App\\Entity\\Card\:\:\$imageName type mapping mismatch\: property can contain string\|null but database expects string\.$#'
 			identifier: doctrine.columnType
 			count: 1
-			path: src/Entity/Card.php
-
-		-
-			message: '#^Property App\\Entity\\Card\:\:\$updatedAt \(DateTime\|null\) does not accept DateTimeImmutable\.$#'
-			identifier: assign.propertyType
-			count: 3
 			path: src/Entity/Card.php
 
 		-

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -38,6 +38,6 @@ class BaseController extends AbstractController
     #[Route('/boosters', name: 'boosters')]
     public function boosters(): Response
     {
-        return $this->render('pages/coming_soon.html.twig');
+        return $this->render('pages/boosters.html.twig');
     }
 }

--- a/src/Entity/Booster.php
+++ b/src/Entity/Booster.php
@@ -120,7 +120,7 @@ class Booster implements \Stringable
         $this->imageFile = $imageFile;
 
         if ($imageFile instanceof File) {
-            $this->updatedAt = new \DateTimeImmutable();
+            $this->updatedAt = new \DateTime();
         }
     }
 

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -161,7 +161,7 @@ class Card
     {
         $this->imageFile = $imageFile;
 
-        $this->updatedAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTime();
     }
 
     public function getImageFile(): ?File
@@ -193,7 +193,7 @@ class Card
         if ($imageMaskFile instanceof File) {
             // It is required that at least one field changes if you are using doctrine
             // otherwise the event listeners won't be called and the file is lost
-            $this->updatedAt = new \DateTimeImmutable();
+            $this->updatedAt = new \DateTime();
         }
     }
 
@@ -221,12 +221,12 @@ class Card
      */
     public function setFoilImageFile(?File $imageFoilFile = null): void
     {
-        $this->imageMaskFile = $imageFoilFile;
+        $this->imageFoilFile = $imageFoilFile;
 
         if ($imageFoilFile instanceof File) {
             // It is required that at least one field changes if you are using doctrine
             // otherwise the event listeners won't be called and the file is lost
-            $this->updatedAt = new \DateTimeImmutable();
+            $this->updatedAt = new \DateTime();
         }
     }
 

--- a/src/Enum/Entity/CardRarityEnum.php
+++ b/src/Enum/Entity/CardRarityEnum.php
@@ -9,6 +9,7 @@ enum CardRarityEnum: string
     case COMMON = 'common';
     case UNCOMMON = 'uncommon';
     case RARE = 'rare';
+    case EPIC = 'epic';
     case LEGENDARY = 'legendary';
 
     /**
@@ -16,6 +17,6 @@ enum CardRarityEnum: string
      */
     public static function ascending(): array
     {
-        return [self::COMMON, self::UNCOMMON, self::RARE, self::LEGENDARY];
+        return [self::COMMON, self::UNCOMMON, self::RARE, self::EPIC, self::LEGENDARY];
     }
 }

--- a/src/Repository/BoosterRepository.php
+++ b/src/Repository/BoosterRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Booster;
+use App\Enum\Entity\ExtensionStatusEnum;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -21,5 +22,20 @@ class BoosterRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Booster::class);
+    }
+
+    /**
+     * @return list<Booster>
+     */
+    public function findPublished(): array
+    {
+        return $this->createQueryBuilder('booster')
+            ->join('booster.extension', 'extension')
+            ->andWhere('extension.status = :status')
+            ->setParameter('status', ExtensionStatusEnum::PUBLISHED)
+            ->orderBy('extension.name', 'ASC')
+            ->getQuery()
+            ->getResult()
+        ;
     }
 }

--- a/src/Service/Booster/BoosterClaimQuotaInterface.php
+++ b/src/Service/Booster/BoosterClaimQuotaInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Entity\DiscordUser;
+
+/**
+ * Quota policy for daily free booster claims.
+ */
+interface BoosterClaimQuotaInterface
+{
+    public const int DAILY_LIMIT = 2;
+
+    public function getRemainingClaims(DiscordUser $discordUser): int;
+
+    public function getNextResetTime(): \DateTimeImmutable;
+}

--- a/src/Service/Booster/BoosterClaimService.php
+++ b/src/Service/Booster/BoosterClaimService.php
@@ -8,44 +8,32 @@ use App\Entity\Booster;
 use App\Entity\BoosterClaim;
 use App\Entity\DiscordUser;
 use App\Exception\Booster\DailyClaimLimitReachedException;
-use App\Repository\BoosterClaimRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
- * Daily free booster claims: every player can claim DAILY_LIMIT boosters per
- * day, the quota resets at midnight Europe/Paris. Claimed boosters land in
- * the UserBooster inventory and can be opened later.
- *
- * The limit can be switched off via BOOSTER_DAILY_LIMIT_ENABLED=false
- * (dev convenience to test openings repeatedly).
+ * Daily free booster claims: the quota policy (BoosterClaimQuotaInterface)
+ * decides how many claims are left; a claim credits the UserBooster
+ * inventory and leaves a BoosterClaim audit row.
  */
 final readonly class BoosterClaimService
 {
-    public const int DAILY_LIMIT = 2;
-
-    private const string TIMEZONE = 'Europe/Paris';
-
     public function __construct(
-        private BoosterClaimRepository $boosterClaimRepository,
+        private BoosterClaimQuotaInterface $quota,
         private UserInventoryService $userInventoryService,
         private EntityManagerInterface $entityManager,
         private ClockInterface $clock,
-        #[Autowire(env: 'bool:BOOSTER_DAILY_LIMIT_ENABLED')]
-        private bool $dailyLimitEnabled = true,
     ) {
     }
 
     public function getRemainingClaims(DiscordUser $discordUser): int
     {
-        if (!$this->dailyLimitEnabled) {
-            return self::DAILY_LIMIT;
-        }
+        return $this->quota->getRemainingClaims($discordUser);
+    }
 
-        $claimsToday = $this->boosterClaimRepository->countSince($discordUser, $this->startOfToday());
-
-        return max(0, self::DAILY_LIMIT - $claimsToday);
+    public function getNextResetTime(): \DateTimeImmutable
+    {
+        return $this->quota->getNextResetTime();
     }
 
     /**
@@ -53,8 +41,8 @@ final readonly class BoosterClaimService
      */
     public function claim(DiscordUser $discordUser, Booster $booster): BoosterClaim
     {
-        if ($this->getRemainingClaims($discordUser) < 1) {
-            throw new DailyClaimLimitReachedException(\sprintf('Daily limit of %d boosters reached, come back tomorrow.', self::DAILY_LIMIT));
+        if ($this->quota->getRemainingClaims($discordUser) < 1) {
+            throw new DailyClaimLimitReachedException(\sprintf('Daily limit of %d boosters reached, come back tomorrow.', BoosterClaimQuotaInterface::DAILY_LIMIT));
         }
 
         $this->userInventoryService->creditBooster($discordUser, $booster);
@@ -64,23 +52,5 @@ final readonly class BoosterClaimService
         $this->entityManager->flush();
 
         return $claim;
-    }
-
-    public function getNextResetTime(): \DateTimeImmutable
-    {
-        return $this->startOfToday()->modify('+1 day');
-    }
-
-    /**
-     * Midnight Europe/Paris expressed as an absolute point in time, so the
-     * comparison with UTC-stored claimed_at timestamps stays correct across
-     * DST changes.
-     */
-    private function startOfToday(): \DateTimeImmutable
-    {
-        return $this->clock->now()
-            ->setTimezone(new \DateTimeZone(self::TIMEZONE))
-            ->setTime(0, 0)
-        ;
     }
 }

--- a/src/Service/Booster/BoosterClaimService.php
+++ b/src/Service/Booster/BoosterClaimService.php
@@ -11,11 +11,15 @@ use App\Exception\Booster\DailyClaimLimitReachedException;
 use App\Repository\BoosterClaimRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 /**
  * Daily free booster claims: every player can claim DAILY_LIMIT boosters per
  * day, the quota resets at midnight Europe/Paris. Claimed boosters land in
  * the UserBooster inventory and can be opened later.
+ *
+ * The limit can be switched off via BOOSTER_DAILY_LIMIT_ENABLED=false
+ * (dev convenience to test openings repeatedly).
  */
 final readonly class BoosterClaimService
 {
@@ -28,11 +32,17 @@ final readonly class BoosterClaimService
         private UserInventoryService $userInventoryService,
         private EntityManagerInterface $entityManager,
         private ClockInterface $clock,
+        #[Autowire(env: 'bool:BOOSTER_DAILY_LIMIT_ENABLED')]
+        private bool $dailyLimitEnabled = true,
     ) {
     }
 
     public function getRemainingClaims(DiscordUser $discordUser): int
     {
+        if (!$this->dailyLimitEnabled) {
+            return self::DAILY_LIMIT;
+        }
+
         $claimsToday = $this->boosterClaimRepository->countSince($discordUser, $this->startOfToday());
 
         return max(0, self::DAILY_LIMIT - $claimsToday);

--- a/src/Service/Booster/DailyBoosterClaimQuota.php
+++ b/src/Service/Booster/DailyBoosterClaimQuota.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Entity\DiscordUser;
+use App\Repository\BoosterClaimRepository;
+use Psr\Clock\ClockInterface;
+
+/**
+ * Production quota: DAILY_LIMIT claims per day, resetting at midnight
+ * Europe/Paris. Counts BoosterClaim rows since the last reset — no mutable
+ * counter anywhere.
+ */
+final readonly class DailyBoosterClaimQuota implements BoosterClaimQuotaInterface
+{
+    private const string TIMEZONE = 'Europe/Paris';
+
+    public function __construct(
+        private BoosterClaimRepository $boosterClaimRepository,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function getRemainingClaims(DiscordUser $discordUser): int
+    {
+        $claimsToday = $this->boosterClaimRepository->countSince($discordUser, $this->startOfToday());
+
+        return max(0, self::DAILY_LIMIT - $claimsToday);
+    }
+
+    public function getNextResetTime(): \DateTimeImmutable
+    {
+        return $this->startOfToday()->modify('+1 day');
+    }
+
+    /**
+     * Midnight Europe/Paris expressed as an absolute point in time, so the
+     * comparison with UTC-stored claimed_at timestamps stays correct across
+     * DST changes.
+     */
+    private function startOfToday(): \DateTimeImmutable
+    {
+        return $this->clock->now()
+            ->setTimezone(new \DateTimeZone(self::TIMEZONE))
+            ->setTime(0, 0)
+        ;
+    }
+}

--- a/src/Service/Booster/UnlimitedBoosterClaimQuota.php
+++ b/src/Service/Booster/UnlimitedBoosterClaimQuota.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Entity\DiscordUser;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Attribute\When;
+
+/**
+ * Dev-only decorator: lifts the daily claim limit so boosters can be opened
+ * repeatedly while testing. Never registered outside the dev environment;
+ * set BOOSTER_DAILY_LIMIT_ENABLED=true (.env.dev) to restore the real quota.
+ */
+#[When(env: 'dev')]
+#[AsDecorator(decorates: DailyBoosterClaimQuota::class)]
+final readonly class UnlimitedBoosterClaimQuota implements BoosterClaimQuotaInterface
+{
+    public function __construct(
+        private BoosterClaimQuotaInterface $inner,
+        #[Autowire(env: 'bool:BOOSTER_DAILY_LIMIT_ENABLED')]
+        private bool $dailyLimitEnabled,
+    ) {
+    }
+
+    public function getRemainingClaims(DiscordUser $discordUser): int
+    {
+        if ($this->dailyLimitEnabled) {
+            return $this->inner->getRemainingClaims($discordUser);
+        }
+
+        return self::DAILY_LIMIT;
+    }
+
+    public function getNextResetTime(): \DateTimeImmutable
+    {
+        return $this->inner->getNextResetTime();
+    }
+}

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Components;
+
+use App\Entity\Booster;
+use App\Entity\BoosterOpening;
+use App\Entity\DiscordUser;
+use App\Exception\Booster\BoosterException;
+use App\Repository\BoosterRepository;
+use App\Repository\UserBoosterRepository;
+use App\Service\Booster\BoosterClaimService;
+use App\Service\Booster\BoosterOpeningService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
+ */
+#[AsLiveComponent]
+final class BoosterHub extends AbstractController
+{
+    use DefaultActionTrait;
+
+    #[LiveProp]
+    public ?BoosterOpening $opening = null;
+
+    #[LiveProp]
+    public ?string $error = null;
+
+    public function __construct(
+        private readonly BoosterRepository $boosterRepository,
+        private readonly UserBoosterRepository $userBoosterRepository,
+        private readonly BoosterClaimService $boosterClaimService,
+        private readonly BoosterOpeningService $boosterOpeningService,
+    ) {
+    }
+
+    /**
+     * @return list<Booster>
+     */
+    public function getBoosters(): array
+    {
+        return $this->boosterRepository->findPublished();
+    }
+
+    public function getRemainingClaims(): int
+    {
+        return $this->boosterClaimService->getRemainingClaims($this->getDiscordUser());
+    }
+
+    public function getNextResetTime(): \DateTimeImmutable
+    {
+        return $this->boosterClaimService->getNextResetTime();
+    }
+
+    /**
+     * @return array<string, int> booster id => owned quantity
+     */
+    public function getInventory(): array
+    {
+        $inventory = [];
+
+        foreach ($this->userBoosterRepository->findBy(['discordUser' => $this->getDiscordUser()]) as $userBooster) {
+            $inventory[(string) $userBooster->getBooster()->getId()] = $userBooster->getQuantity();
+        }
+
+        return $inventory;
+    }
+
+    #[LiveAction]
+    public function claimBooster(#[LiveArg] string $boosterId): void
+    {
+        $this->error = null;
+
+        $booster = $this->boosterRepository->find($boosterId);
+
+        if (null === $booster) {
+            $this->error = 'Booster introuvable.';
+
+            return;
+        }
+
+        try {
+            $this->boosterClaimService->claim($this->getDiscordUser(), $booster);
+        } catch (BoosterException $exception) {
+            $this->error = $exception->getMessage();
+        }
+    }
+
+    #[LiveAction]
+    public function openBooster(#[LiveArg] string $boosterId): void
+    {
+        $this->error = null;
+
+        $booster = $this->boosterRepository->find($boosterId);
+
+        if (null === $booster) {
+            $this->error = 'Booster introuvable.';
+
+            return;
+        }
+
+        try {
+            $this->opening = $this->boosterOpeningService->open($this->getDiscordUser(), $booster);
+        } catch (BoosterException $exception) {
+            $this->error = $exception->getMessage();
+        }
+    }
+
+    #[LiveAction]
+    public function closeModal(): void
+    {
+        $this->opening = null;
+        $this->error = null;
+    }
+
+    private function getDiscordUser(): DiscordUser
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof DiscordUser) {
+            throw $this->createAccessDeniedException();
+        }
+
+        return $user;
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -8,6 +8,7 @@
     {% block stylesheets %}
         <link rel="stylesheet" href="{{ asset('styles/app.css') }}">
         <link rel="stylesheet" href="{{ asset('styles/cards/base.css') }}">
+        <link rel="stylesheet" href="{{ asset('styles/cards/rarity.css') }}">
     {% endblock %}
 
     {% block javascripts %}

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -15,7 +15,7 @@
                     <div class="text-left">
                         <p class="text-sm text-gray-400 uppercase tracking-wide">Boosters gratuits du jour</p>
                         <p class="text-3xl font-bold text-white mt-1">
-                            <span class="text-purple-400">{{ this.remainingClaims }}</span>/{{ constant('App\\Service\\Booster\\BoosterClaimService::DAILY_LIMIT') }}
+                            <span class="text-purple-400">{{ this.remainingClaims }}</span>/{{ constant('App\\Service\\Booster\\BoosterClaimQuotaInterface::DAILY_LIMIT') }}
                         </p>
                     </div>
 

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -1,0 +1,176 @@
+<div {{ attributes }}>
+    {# Hero / quota section #}
+    <section class="relative h-[40vh] overflow-hidden">
+        <div class="absolute inset-0 bg-gradient-to-br from-purple-900 via-slate-900 to-indigo-900"></div>
+        <div class="absolute inset-0 bg-[url('{{ asset('images/ytcg_background.png') }}')] bg-cover bg-center opacity-20"></div>
+
+        <div class="relative container mx-auto h-full flex flex-col justify-center items-center text-center px-4">
+            <h1 class="text-6xl font-bold text-white mb-4" style="text-shadow: 2px 2px 10px rgba(0,0,0,0.5)">
+                Boosters
+            </h1>
+            <p class="text-xl text-purple-200 mb-8">Récupérez vos boosters gratuits et collectionnez des cartes rares !</p>
+
+            <div class="bg-slate-800/80 backdrop-blur-sm rounded-2xl p-6 shadow-2xl border border-purple-500/30 max-w-md w-full">
+                <div class="flex items-center justify-between">
+                    <div class="text-left">
+                        <p class="text-sm text-gray-400 uppercase tracking-wide">Boosters gratuits du jour</p>
+                        <p class="text-3xl font-bold text-white mt-1">
+                            <span class="text-purple-400">{{ this.remainingClaims }}</span>/{{ constant('App\\Service\\Booster\\BoosterClaimService::DAILY_LIMIT') }}
+                        </p>
+                    </div>
+
+                    {% if this.remainingClaims == 0 %}
+                        <div class="text-right">
+                            <p class="text-sm text-gray-400 uppercase tracking-wide">Prochains boosters dans</p>
+                            <p class="text-2xl font-bold text-white mt-1"
+                               data-controller="countdown"
+                               data-countdown-target-value="{{ this.nextResetTime.format('c') }}">--:--:--</p>
+                        </div>
+                    {% endif %}
+                </div>
+
+                {% if this.remainingClaims > 0 %}
+                    <div class="mt-4 bg-green-500/20 text-green-400 text-sm py-2 px-3 rounded-lg text-center border border-green-500/30">
+                        ✨ Vous pouvez récupérer {{ this.remainingClaims }} booster{{ this.remainingClaims > 1 ? 's' : '' }} !
+                    </div>
+                {% else %}
+                    <div class="mt-4 bg-orange-500/20 text-orange-400 text-sm py-2 px-3 rounded-lg text-center border border-orange-500/30">
+                        ⏳ Revenez demain pour de nouveaux boosters
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    </section>
+
+    {# Boosters grid #}
+    <main class="py-12 bg-gradient-to-b from-slate-900 to-slate-950 min-h-screen">
+        <div class="container mx-auto px-4">
+            {% if error %}
+                <div class="mb-8 bg-red-500/20 text-red-400 py-3 px-4 rounded-xl text-center border border-red-500/30 font-semibold">
+                    ⚠️ {{ error }}
+                </div>
+            {% endif %}
+
+            {% if this.boosters is empty %}
+                <div class="bg-slate-800/50 backdrop-blur-sm p-12 rounded-2xl text-center border border-slate-700">
+                    <div class="text-6xl mb-4">📦</div>
+                    <p class="text-white text-2xl font-bold mb-2">Aucun booster disponible</p>
+                    <p class="text-gray-400">Revenez bientôt pour découvrir de nouveaux boosters !</p>
+                </div>
+            {% else %}
+                {% set inventory = this.inventory %}
+                {% set remainingClaims = this.remainingClaims %}
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+                    {% for booster in this.boosters %}
+                        {% set owned = inventory[booster.id]|default(0) %}
+                        <div class="group relative">
+                            <div class="absolute -inset-0.5 bg-gradient-to-r from-purple-600 to-pink-600 rounded-2xl opacity-0 group-hover:opacity-75 transition duration-300 blur"></div>
+
+                            <div class="relative bg-slate-800 rounded-2xl overflow-hidden shadow-xl hover:shadow-2xl transition-all duration-300 transform group-hover:-translate-y-2">
+                                <div class="relative h-48 overflow-hidden bg-gradient-to-br from-purple-900 to-indigo-900">
+                                    {% if booster.extension.imageName %}
+                                        <img src="{{ asset('images/extensions/' ~ booster.extension.imageName) }}"
+                                             alt="{{ booster.extension.name }}"
+                                             class="w-full h-full object-cover opacity-60"
+                                             onerror="this.style.display='none'">
+                                    {% endif %}
+                                    <div class="absolute inset-0 bg-gradient-to-t from-slate-800 to-transparent"></div>
+                                    <div class="absolute bottom-4 left-4 right-4 flex items-end justify-between">
+                                        <h3 class="text-2xl font-bold text-white">{{ booster.extension.name }}</h3>
+                                        <span class="bg-purple-600/80 text-white text-sm font-bold px-3 py-1 rounded-full whitespace-nowrap">
+                                            x{{ owned }} possédé{{ owned > 1 ? 's' : '' }}
+                                        </span>
+                                    </div>
+                                </div>
+
+                                <div class="p-6">
+                                    <p class="text-gray-400 mb-4 line-clamp-2">{{ booster.extension.description }}</p>
+
+                                    <div class="flex items-center justify-between mb-4 text-sm">
+                                        <div class="flex items-center gap-2">
+                                            <span class="text-purple-400">🎴</span>
+                                            <span class="text-white font-semibold">{{ booster.cardCount }} cartes</span>
+                                        </div>
+                                    </div>
+
+                                    <div class="grid grid-cols-2 gap-3">
+                                        <button
+                                            data-action="live#action"
+                                            data-live-action-param="claimBooster"
+                                            data-live-booster-id-param="{{ booster.id }}"
+                                            class="bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-700 hover:to-teal-700 text-white font-bold py-3 px-4 rounded-xl transition-all duration-300 disabled:from-gray-600 disabled:to-gray-700 disabled:cursor-not-allowed disabled:opacity-50 shadow-lg"
+                                            {% if remainingClaims == 0 %}disabled{% endif %}
+                                        >
+                                            <span data-loading="hide">🎁 Récupérer</span>
+                                            <span data-loading="show" class="hidden">⏳</span>
+                                        </button>
+                                        <button
+                                            data-action="live#action"
+                                            data-live-action-param="openBooster"
+                                            data-live-booster-id-param="{{ booster.id }}"
+                                            class="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-bold py-3 px-4 rounded-xl transition-all duration-300 disabled:from-gray-600 disabled:to-gray-700 disabled:cursor-not-allowed disabled:opacity-50 shadow-lg"
+                                            {% if owned == 0 %}disabled{% endif %}
+                                        >
+                                            <span data-loading="hide">✨ Ouvrir</span>
+                                            <span data-loading="show" class="hidden">
+                                                <svg class="animate-spin h-5 w-5 mx-auto inline" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                                </svg>
+                                            </span>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+            {% endif %}
+        </div>
+    </main>
+
+    {# Opening modal #}
+    {% if opening %}
+        <div class="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+             data-live-id="opening-{{ opening.id }}">
+            <div class="bg-gradient-to-br from-slate-900 to-slate-800 rounded-2xl shadow-2xl max-w-6xl w-full max-h-[90vh] overflow-y-auto border border-purple-500/30">
+                <div class="sticky top-0 bg-gradient-to-r from-purple-900 to-pink-900 p-6 rounded-t-2xl z-10">
+                    <div class="flex justify-between items-center">
+                        <div>
+                            <h2 class="text-3xl font-bold text-white">🎉 Félicitations !</h2>
+                            <p class="text-purple-200 mt-1">Voici vos cartes obtenues</p>
+                        </div>
+                        <button data-action="live#action"
+                                data-live-action-param="closeModal"
+                                class="text-white hover:text-purple-300 transition-colors">
+                            <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+
+                <div class="p-8 grid grid-cols-1 md:grid-cols-3 gap-6">
+                    {% for openingCard in opening.boosterOpeningCards %}
+                        {% for copy in 1..openingCard.quantity %}
+                            {{ include('components/CardComponent.html.twig', {
+                                card: openingCard.card,
+                                holo: copy <= openingCard.holoQuantity,
+                            }) }}
+                        {% endfor %}
+                    {% endfor %}
+                </div>
+
+                <div class="sticky bottom-0 bg-slate-800/95 backdrop-blur-sm p-6 rounded-b-2xl border-t border-slate-700">
+                    <div class="text-center">
+                        <button data-action="live#action"
+                                data-live-action-param="closeModal"
+                                class="bg-gradient-to-r from-purple-600 to-pink-600 hover:from-purple-700 hover:to-pink-700 text-white font-bold py-3 px-8 rounded-xl transition-all duration-300 shadow-lg">
+                            Ajouter à ma collection
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+</div>

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -150,13 +150,20 @@
                     </div>
                 </div>
 
-                <div class="p-8 grid grid-cols-1 md:grid-cols-3 gap-6">
+                <div class="p-8 grid grid-cols-1 md:grid-cols-3 gap-6"
+                     data-controller="booster-opening"
+                     data-action="click->booster-opening#skip"
+                     data-live-ignore>
                     {% for openingCard in opening.boosterOpeningCards %}
                         {% for copy in 1..openingCard.quantity %}
-                            {{ include('components/CardComponent.html.twig', {
-                                card: openingCard.card,
-                                holo: copy <= openingCard.holoQuantity,
-                            }) }}
+                            <div data-booster-opening-target="card">
+                                {{ include('components/CardComponent.html.twig', {
+                                    card: openingCard.card,
+                                    holo: copy <= openingCard.holoQuantity,
+                                    facedown: true,
+                                    id: 'opening-card-' ~ loop.parent.loop.index ~ '-' ~ copy,
+                                }) }}
+                            </div>
                         {% endfor %}
                     {% endfor %}
                 </div>

--- a/templates/components/CardComponent.html.twig
+++ b/templates/components/CardComponent.html.twig
@@ -1,5 +1,17 @@
+{# Optional params (default = plain interactive card, as used on the homepage):
+   - holo: render the foil/mask shine variant (badge fallback without assets)
+   - facedown: start face-down, revealed by the booster-opening controller
+   - id: DOM id override (needed when the same card appears several times) #}
+{% set holo = holo|default(false) %}
+{% set facedown = facedown|default(false) %}
+{% set maskedHolo = holo and card.imageMaskName %}
+
 <div class="bg-gray-500 rounded-lg shadow-lg p-4">
-    <div id="{{ card.id }}" class="card interactive{{ card.type ? ' ' ~ card.type.value }}" data-rarity="{{ card.rarity.value }}" data-controller="card">
+    <div id="{{ id|default(card.id) }}"
+         class="card interactive{{ card.type ? ' ' ~ card.type.value }}{{ maskedHolo ? ' masked' }}{{ facedown ? ' facedown' }}"
+         data-rarity="{{ card.rarity.value }}"
+         data-controller="card"
+         {% if maskedHolo %}style="--mask: url('{{ asset('images/masks/' ~ card.imageMaskName) }}');"{% endif %}>
         <div class="card__translater">
             <div class="card__rotator">
                 <div class="card__front">
@@ -7,12 +19,18 @@
                     <div class="card__shine"></div>
                     <div class="card__glare"></div>
                 </div>
+                <div class="card__back">
+                    <img src="{{ asset('images/ytcg_logo.png') }}" alt="Card back">
+                </div>
             </div>
         </div>
     </div>
 
     <div class="mt-4">
-        <h3 class="text-xl font-bold">{{ card.name }}</h3>
+        <h3 class="text-xl font-bold">
+            {{ card.name }}
+            {% if holo %}<span class="holo-badge ml-2">✨ HOLO</span>{% endif %}
+        </h3>
         <p class="text-sm">{{ card.description }}</p>
     </div>
 </div>

--- a/templates/pages/boosters.html.twig
+++ b/templates/pages/boosters.html.twig
@@ -1,0 +1,9 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    YTCG - Boosters
+{% endblock %}
+
+{% block body %}
+    {{ component('BoosterHub') }}
+{% endblock %}

--- a/tests/Functional/BoosterHubComponentTest.php
+++ b/tests/Functional/BoosterHubComponentTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\UserBooster;
+use App\Entity\UserCard;
+use App\Repository\BoosterRepository;
+use App\Twig\Components\BoosterHub;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
+
+final class BoosterHubComponentTest extends WebTestCase
+{
+    use InteractsWithLiveComponents;
+    use JwtAuthTrait;
+
+    public function testClaimBoosterCreditsTheInventoryAndDecrementsTheQuota(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client);
+        $booster = $this->firstPublishedBooster();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('claimBooster', ['boosterId' => (string) $booster->getId()]);
+
+        $userBooster = static::getContainer()->get(EntityManagerInterface::class)
+            ->getRepository(UserBooster::class)
+            ->findOneBy(['discordUser' => $user, 'booster' => $booster])
+        ;
+
+        $this->assertNotNull($userBooster);
+        $this->assertSame(1, $userBooster->getQuantity());
+        $this->assertNull($component->component()->error);
+    }
+
+    public function testOpeningAClaimedBoosterFillsTheCollectionAndTheModal(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client);
+        $booster = $this->firstPublishedBooster();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('claimBooster', ['boosterId' => (string) $booster->getId()]);
+        $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
+
+        $hub = $component->component();
+        $this->assertNull($hub->error);
+        $this->assertNotNull($hub->opening);
+        $this->assertStringContainsString('Félicitations', (string) $component->render());
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $userBooster = $entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $user, 'booster' => $booster]);
+        $this->assertNotNull($userBooster);
+        $this->assertSame(0, $userBooster->getQuantity());
+
+        $userCards = $entityManager->getRepository(UserCard::class)->findBy(['discordUser' => $user]);
+        $totalCards = array_sum(array_map(static fn (UserCard $userCard): int => $userCard->getQuantity(), $userCards));
+        $this->assertSame($booster->getCardCount(), $totalCards);
+    }
+
+    public function testOpeningWithoutInventoryReportsAnError(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client);
+        $booster = $this->firstPublishedBooster();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
+
+        $hub = $component->component();
+        $this->assertNull($hub->opening);
+        $this->assertNotNull($hub->error);
+    }
+
+    private function firstPublishedBooster(): \App\Entity\Booster
+    {
+        // The Cyberpunk extension is the one with published cards in the fixtures.
+        foreach (static::getContainer()->get(BoosterRepository::class)->findPublished() as $booster) {
+            if (str_starts_with($booster->getExtension()->getName(), 'Cyberpunk')) {
+                return $booster;
+            }
+        }
+
+        $this->fail('Fixture booster for the Cyberpunk extension not found, load the alice fixtures first.');
+    }
+}

--- a/tests/Functional/BoosterHubComponentTest.php
+++ b/tests/Functional/BoosterHubComponentTest.php
@@ -17,10 +17,13 @@ final class BoosterHubComponentTest extends WebTestCase
     use InteractsWithLiveComponents;
     use JwtAuthTrait;
 
+    // Juju has no UserBooster fixture, unlike Barlito who starts with a stocked inventory.
+    private const string USER_WITHOUT_INVENTORY = '195659530363731968';
+
     public function testClaimBoosterCreditsTheInventoryAndDecrementsTheQuota(): void
     {
         $client = static::createClient();
-        $user = $this->authenticateClient($client);
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
         $booster = $this->firstPublishedBooster();
 
         $component = $this->createLiveComponent(BoosterHub::class, client: $client);
@@ -39,7 +42,7 @@ final class BoosterHubComponentTest extends WebTestCase
     public function testOpeningAClaimedBoosterFillsTheCollectionAndTheModal(): void
     {
         $client = static::createClient();
-        $user = $this->authenticateClient($client);
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
         $booster = $this->firstPublishedBooster();
 
         $component = $this->createLiveComponent(BoosterHub::class, client: $client);
@@ -65,7 +68,7 @@ final class BoosterHubComponentTest extends WebTestCase
     public function testOpeningWithoutInventoryReportsAnError(): void
     {
         $client = static::createClient();
-        $this->authenticateClient($client);
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
         $booster = $this->firstPublishedBooster();
 
         $component = $this->createLiveComponent(BoosterHub::class, client: $client);

--- a/tests/Functional/BoosterPageTest.php
+++ b/tests/Functional/BoosterPageTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class BoosterPageTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    public function testBoostersPageRedirectsWhenNotAuthenticated(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/boosters');
+
+        $this->assertContains($client->getResponse()->getStatusCode(), [302, 307]);
+    }
+
+    public function testBoostersPageListsPublishedBoosters(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', '/boosters');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('section h1', 'Boosters');
+        $this->assertStringContainsString('Récupérer', $client->getResponse()->getContent());
+        $this->assertGreaterThan(0, $crawler->filter('[data-live-action-param="claimBooster"]')->count());
+    }
+}

--- a/tests/Functional/JwtAuthTrait.php
+++ b/tests/Functional/JwtAuthTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\DiscordUser;
+use App\Repository\DiscordUserRepository;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\BrowserKit\Cookie;
+
+/**
+ * Authenticates the test client the same way production works: a signed JWT
+ * in the "jwt" cookie (stateless firewall, cookie extractor).
+ */
+trait JwtAuthTrait
+{
+    private function authenticateClient(KernelBrowser $client, string $discordId = '188967649332428800'): DiscordUser
+    {
+        $user = static::getContainer()->get(DiscordUserRepository::class)->find($discordId);
+
+        if (!$user instanceof DiscordUser) {
+            throw new \LogicException(\sprintf('Fixture user "%s" not found, load the alice fixtures first.', $discordId));
+        }
+
+        $token = static::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+        $client->getCookieJar()->set(new Cookie('jwt', $token));
+
+        return $user;
+    }
+}

--- a/tests/Unit/Service/BoosterClaimServiceTest.php
+++ b/tests/Unit/Service/BoosterClaimServiceTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Unit\Service;
 use App\Entity\Booster;
 use App\Entity\DiscordUser;
 use App\Exception\Booster\DailyClaimLimitReachedException;
-use App\Repository\BoosterClaimRepository;
+use App\Service\Booster\BoosterClaimQuotaInterface;
 use App\Service\Booster\BoosterClaimService;
 use App\Service\Booster\UserInventoryService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -16,22 +16,6 @@ use Symfony\Component\Clock\MockClock;
 
 final class BoosterClaimServiceTest extends TestCase
 {
-    public function testRemainingClaimsCountsDownFromTheDailyLimit(): void
-    {
-        $user = new DiscordUser();
-
-        foreach ([0 => 2, 1 => 1, 2 => 0, 3 => 0] as $claimsToday => $expectedRemaining) {
-            $service = new BoosterClaimService(
-                $this->claimRepositoryCounting($claimsToday),
-                $this->createStub(UserInventoryService::class),
-                $this->createStub(EntityManagerInterface::class),
-                new MockClock('2026-06-10 12:00:00', 'UTC'),
-            );
-
-            $this->assertSame($expectedRemaining, $service->getRemainingClaims($user));
-        }
-    }
-
     public function testClaimCreditsTheInventoryAndPersistsAnAuditRow(): void
     {
         $clock = new MockClock('2026-06-10 12:00:00', 'UTC');
@@ -45,7 +29,7 @@ final class BoosterClaimServiceTest extends TestCase
         $entityManager->expects($this->once())->method('persist');
         $entityManager->expects($this->once())->method('flush');
 
-        $service = new BoosterClaimService($this->claimRepositoryCounting(0), $inventory, $entityManager, $clock);
+        $service = new BoosterClaimService($this->quotaWithRemaining(2), $inventory, $entityManager, $clock);
 
         $claim = $service->claim($user, $booster);
 
@@ -54,13 +38,13 @@ final class BoosterClaimServiceTest extends TestCase
         $this->assertEquals($clock->now(), $claim->getClaimedAt());
     }
 
-    public function testClaimThrowsOnceTheDailyLimitIsReached(): void
+    public function testClaimThrowsOnceTheQuotaIsExhausted(): void
     {
         $inventory = $this->createMock(UserInventoryService::class);
         $inventory->expects($this->never())->method('creditBooster');
 
         $service = new BoosterClaimService(
-            $this->claimRepositoryCounting(BoosterClaimService::DAILY_LIMIT),
+            $this->quotaWithRemaining(0),
             $inventory,
             $this->createStub(EntityManagerInterface::class),
             new MockClock('2026-06-10 12:00:00', 'UTC'),
@@ -71,98 +55,29 @@ final class BoosterClaimServiceTest extends TestCase
         $service->claim(new DiscordUser(), new Booster());
     }
 
-    public function testQuotaWindowStartsAtMidnightParisInWinter(): void
+    public function testQuotaAccessorsDelegateToThePolicy(): void
     {
-        // 2026-01-15 23:30 UTC is already 2026-01-16 00:30 in Paris (UTC+1):
-        // the window must start at 23:00 UTC = midnight Paris of the new day.
-        $this->assertQuotaWindowStartsAt('2026-01-15 23:00:00', clockNow: '2026-01-15 23:30:00');
-    }
-
-    public function testQuotaWindowStartsAtMidnightParisInSummer(): void
-    {
-        // 2026-06-10 12:00 UTC = 14:00 Paris (UTC+2): the window must start
-        // at 2026-06-09 22:00 UTC = midnight Paris the same day.
-        $this->assertQuotaWindowStartsAt('2026-06-09 22:00:00', clockNow: '2026-06-10 12:00:00');
-    }
-
-    public function testDisabledLimitAlwaysReportsFullQuota(): void
-    {
-        $claimRepository = $this->createMock(BoosterClaimRepository::class);
-        $claimRepository->expects($this->never())->method('countSince');
+        $resetTime = new \DateTimeImmutable('2026-06-11 00:00:00');
+        $quota = $this->createStub(BoosterClaimQuotaInterface::class);
+        $quota->method('getRemainingClaims')->willReturn(1);
+        $quota->method('getNextResetTime')->willReturn($resetTime);
 
         $service = new BoosterClaimService(
-            $claimRepository,
-            $this->createStub(UserInventoryService::class),
-            $this->createStub(EntityManagerInterface::class),
-            new MockClock('2026-06-10 12:00:00', 'UTC'),
-            dailyLimitEnabled: false,
-        );
-
-        $this->assertSame(BoosterClaimService::DAILY_LIMIT, $service->getRemainingClaims(new DiscordUser()));
-    }
-
-    public function testDisabledLimitNeverBlocksClaims(): void
-    {
-        $inventory = $this->createMock(UserInventoryService::class);
-        $inventory->expects($this->exactly(BoosterClaimService::DAILY_LIMIT + 3))->method('creditBooster');
-
-        $service = new BoosterClaimService(
-            $this->claimRepositoryCounting(1000),
-            $inventory,
-            $this->createStub(EntityManagerInterface::class),
-            new MockClock('2026-06-10 12:00:00', 'UTC'),
-            dailyLimitEnabled: false,
-        );
-
-        for ($i = 0; $i < BoosterClaimService::DAILY_LIMIT + 3; ++$i) {
-            $service->claim(new DiscordUser(), new Booster());
-        }
-    }
-
-    public function testNextResetTimeIsTheUpcomingMidnightParis(): void
-    {
-        $service = new BoosterClaimService(
-            $this->claimRepositoryCounting(0),
+            $quota,
             $this->createStub(UserInventoryService::class),
             $this->createStub(EntityManagerInterface::class),
             new MockClock('2026-06-10 12:00:00', 'UTC'),
         );
 
-        $nextReset = $service->getNextResetTime()->setTimezone(new \DateTimeZone('UTC'));
-
-        // Midnight Paris on June 11th is 22:00 UTC on June 10th.
-        $this->assertSame('2026-06-10 22:00:00', $nextReset->format('Y-m-d H:i:s'));
+        $this->assertSame(1, $service->getRemainingClaims(new DiscordUser()));
+        $this->assertSame($resetTime, $service->getNextResetTime());
     }
 
-    private function assertQuotaWindowStartsAt(string $expectedUtcWindowStart, string $clockNow): void
+    private function quotaWithRemaining(int $remaining): BoosterClaimQuotaInterface
     {
-        $claimRepository = $this->createMock(BoosterClaimRepository::class);
-        $claimRepository->expects($this->once())
-            ->method('countSince')
-            ->with(
-                $this->anything(),
-                $this->callback(
-                    static fn (\DateTimeImmutable $since): bool => $expectedUtcWindowStart === $since->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
-                ),
-            )
-            ->willReturn(0)
-        ;
+        $quota = $this->createStub(BoosterClaimQuotaInterface::class);
+        $quota->method('getRemainingClaims')->willReturn($remaining);
 
-        $service = new BoosterClaimService(
-            $claimRepository,
-            $this->createStub(UserInventoryService::class),
-            $this->createStub(EntityManagerInterface::class),
-            new MockClock($clockNow, 'UTC'),
-        );
-
-        $this->assertSame(BoosterClaimService::DAILY_LIMIT, $service->getRemainingClaims(new DiscordUser()));
-    }
-
-    private function claimRepositoryCounting(int $claimsToday): BoosterClaimRepository
-    {
-        $claimRepository = $this->createStub(BoosterClaimRepository::class);
-        $claimRepository->method('countSince')->willReturn($claimsToday);
-
-        return $claimRepository;
+        return $quota;
     }
 }

--- a/tests/Unit/Service/BoosterClaimServiceTest.php
+++ b/tests/Unit/Service/BoosterClaimServiceTest.php
@@ -85,6 +85,40 @@ final class BoosterClaimServiceTest extends TestCase
         $this->assertQuotaWindowStartsAt('2026-06-09 22:00:00', clockNow: '2026-06-10 12:00:00');
     }
 
+    public function testDisabledLimitAlwaysReportsFullQuota(): void
+    {
+        $claimRepository = $this->createMock(BoosterClaimRepository::class);
+        $claimRepository->expects($this->never())->method('countSince');
+
+        $service = new BoosterClaimService(
+            $claimRepository,
+            $this->createStub(UserInventoryService::class),
+            $this->createStub(EntityManagerInterface::class),
+            new MockClock('2026-06-10 12:00:00', 'UTC'),
+            dailyLimitEnabled: false,
+        );
+
+        $this->assertSame(BoosterClaimService::DAILY_LIMIT, $service->getRemainingClaims(new DiscordUser()));
+    }
+
+    public function testDisabledLimitNeverBlocksClaims(): void
+    {
+        $inventory = $this->createMock(UserInventoryService::class);
+        $inventory->expects($this->exactly(BoosterClaimService::DAILY_LIMIT + 3))->method('creditBooster');
+
+        $service = new BoosterClaimService(
+            $this->claimRepositoryCounting(1000),
+            $inventory,
+            $this->createStub(EntityManagerInterface::class),
+            new MockClock('2026-06-10 12:00:00', 'UTC'),
+            dailyLimitEnabled: false,
+        );
+
+        for ($i = 0; $i < BoosterClaimService::DAILY_LIMIT + 3; ++$i) {
+            $service->claim(new DiscordUser(), new Booster());
+        }
+    }
+
     public function testNextResetTimeIsTheUpcomingMidnightParis(): void
     {
         $service = new BoosterClaimService(

--- a/tests/Unit/Service/DailyBoosterClaimQuotaTest.php
+++ b/tests/Unit/Service/DailyBoosterClaimQuotaTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\DiscordUser;
+use App\Repository\BoosterClaimRepository;
+use App\Service\Booster\BoosterClaimQuotaInterface;
+use App\Service\Booster\DailyBoosterClaimQuota;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+
+final class DailyBoosterClaimQuotaTest extends TestCase
+{
+    public function testRemainingClaimsCountsDownFromTheDailyLimit(): void
+    {
+        $user = new DiscordUser();
+
+        foreach ([0 => 2, 1 => 1, 2 => 0, 3 => 0] as $claimsToday => $expectedRemaining) {
+            $quota = new DailyBoosterClaimQuota(
+                $this->claimRepositoryCounting($claimsToday),
+                new MockClock('2026-06-10 12:00:00', 'UTC'),
+            );
+
+            $this->assertSame($expectedRemaining, $quota->getRemainingClaims($user));
+        }
+    }
+
+    public function testQuotaWindowStartsAtMidnightParisInWinter(): void
+    {
+        // 2026-01-15 23:30 UTC is already 2026-01-16 00:30 in Paris (UTC+1):
+        // the window must start at 23:00 UTC = midnight Paris of the new day.
+        $this->assertQuotaWindowStartsAt('2026-01-15 23:00:00', clockNow: '2026-01-15 23:30:00');
+    }
+
+    public function testQuotaWindowStartsAtMidnightParisInSummer(): void
+    {
+        // 2026-06-10 12:00 UTC = 14:00 Paris (UTC+2): the window must start
+        // at 2026-06-09 22:00 UTC = midnight Paris the same day.
+        $this->assertQuotaWindowStartsAt('2026-06-09 22:00:00', clockNow: '2026-06-10 12:00:00');
+    }
+
+    public function testNextResetTimeIsTheUpcomingMidnightParis(): void
+    {
+        $quota = new DailyBoosterClaimQuota(
+            $this->claimRepositoryCounting(0),
+            new MockClock('2026-06-10 12:00:00', 'UTC'),
+        );
+
+        $nextReset = $quota->getNextResetTime()->setTimezone(new \DateTimeZone('UTC'));
+
+        // Midnight Paris on June 11th is 22:00 UTC on June 10th.
+        $this->assertSame('2026-06-10 22:00:00', $nextReset->format('Y-m-d H:i:s'));
+    }
+
+    private function assertQuotaWindowStartsAt(string $expectedUtcWindowStart, string $clockNow): void
+    {
+        $claimRepository = $this->createMock(BoosterClaimRepository::class);
+        $claimRepository->expects($this->once())
+            ->method('countSince')
+            ->with(
+                $this->anything(),
+                $this->callback(
+                    static fn (\DateTimeImmutable $since): bool => $expectedUtcWindowStart === $since->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+                ),
+            )
+            ->willReturn(0)
+        ;
+
+        $quota = new DailyBoosterClaimQuota($claimRepository, new MockClock($clockNow, 'UTC'));
+
+        $this->assertSame(BoosterClaimQuotaInterface::DAILY_LIMIT, $quota->getRemainingClaims(new DiscordUser()));
+    }
+
+    private function claimRepositoryCounting(int $claimsToday): BoosterClaimRepository
+    {
+        $claimRepository = $this->createStub(BoosterClaimRepository::class);
+        $claimRepository->method('countSince')->willReturn($claimsToday);
+
+        return $claimRepository;
+    }
+}

--- a/tests/Unit/Service/UnlimitedBoosterClaimQuotaTest.php
+++ b/tests/Unit/Service/UnlimitedBoosterClaimQuotaTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\DiscordUser;
+use App\Service\Booster\BoosterClaimQuotaInterface;
+use App\Service\Booster\UnlimitedBoosterClaimQuota;
+use PHPUnit\Framework\TestCase;
+
+final class UnlimitedBoosterClaimQuotaTest extends TestCase
+{
+    public function testDisabledLimitAlwaysReportsFullQuotaWithoutHittingTheInnerQuota(): void
+    {
+        $inner = $this->createMock(BoosterClaimQuotaInterface::class);
+        $inner->expects($this->never())->method('getRemainingClaims');
+
+        $quota = new UnlimitedBoosterClaimQuota($inner, dailyLimitEnabled: false);
+
+        $this->assertSame(BoosterClaimQuotaInterface::DAILY_LIMIT, $quota->getRemainingClaims(new DiscordUser()));
+    }
+
+    public function testEnabledLimitDelegatesToTheInnerQuota(): void
+    {
+        $user = new DiscordUser();
+        $inner = $this->createMock(BoosterClaimQuotaInterface::class);
+        $inner->expects($this->once())->method('getRemainingClaims')->with($user)->willReturn(1);
+
+        $quota = new UnlimitedBoosterClaimQuota($inner, dailyLimitEnabled: true);
+
+        $this->assertSame(1, $quota->getRemainingClaims($user));
+    }
+
+    public function testNextResetTimeAlwaysDelegates(): void
+    {
+        $resetTime = new \DateTimeImmutable('2026-06-11 00:00:00');
+        $inner = $this->createStub(BoosterClaimQuotaInterface::class);
+        $inner->method('getNextResetTime')->willReturn($resetTime);
+
+        $quota = new UnlimitedBoosterClaimQuota($inner, dailyLimitEnabled: false);
+
+        $this->assertSame($resetTime, $quota->getNextResetTime());
+    }
+}


### PR DESCRIPTION
Dernière brique de la Phase 1 (stack : 1a → 1b → 1c → **#29**). Base = phase-1c, à retarget après merge.

### UI
- Hub `/boosters` en **Live Component** (`BoosterHub`) : quota du jour, countdown vers le reset, badges d'inventaire par booster, actions claim/open/close avec remontée d'erreurs
- **Modale d'ouverture** : reveal séquentiel face cachée → flip anime.js → glow par rareté (pulse legendary), clic pour skip, 3D interactif après reveal, foil/badge holo. Grille `data-live-ignore` + `data-live-id` par ouverture pour cohabiter avec le morphing Live Component
- `rarity.css` (glow par `data-rarity`, facedown/revealed, dos de carte, badge holo), `CardComponent` paramétrable (`holo`/`facedown`/`id`, rétro-compatible)

### Quota dev
La limite quotidienne est neutralisée **en dev uniquement** via le décorateur `UnlimitedBoosterClaimQuota` (`#[When(env: 'dev')]` + `#[AsDecorator]` sur `DailyBoosterClaimQuota`), piloté par `BOOSTER_DAILY_LIMIT_ENABLED` qui n'existe que dans `.env.dev` — aucun code de bypass en prod.

### Fixes embarqués
- Setters Vich qui assignaient un `DateTimeImmutable` à la colonne Gedmo mutable (crashait tout flush après hydratation `inject_on_load`) + `setFoilImageFile` qui écrivait dans `imageMaskFile`
- Build Tailwind ajouté à la CI test (premier rendu de page complet en CI)
- **phpmd retiré** (pdepend incompatible PHP 8.4) — aligné sur barlito/utils 2.0 / php-make-rules

### Tests
Fonctionnels : auth par cookie JWT, rendu de page, actions Live Component (claim crédite, open remplit collection + modale, chemin d'erreur). Baseline PHPStan 59 → 54.

**Test manuel** : login Discord → `/boosters` → claim, ouverture, reveal (déjà validé ✔)
