### PR TITLE
feat(phase 1b): rareté/type des cartes, refonte Booster, retrait YoulCoin, entités d'audit

### DIFF
--- a/.env
+++ b/.env
@@ -24,10 +24,6 @@
 DATABASE_URL="postgresql://postgres:root@ytcg_db:5432/ytcg?serverVersion=16&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 
-###> Projects admin URLs ###
-YC_ADMIN_URL='https://yc.barlito.fr/admin'
-###< Projects admin URLs ###
-
 ###> Project external URLS ###
 REFRESH_TOKEN_URL='https://yc.barlito.fr/refresh_token'
 LOGOUT_URL='https://yc.barlito.fr/logout'

--- a/.env.dev
+++ b/.env.dev
@@ -3,10 +3,6 @@ APP_ENV=dev
 APP_SECRET=super_secret
 ###< symfony/framework-bundle ###
 
-###> Projects admin URLs ###
-YC_ADMIN_URL='https://yc.local.barlito.fr/admin'
-###< Projects admin URLs ###
-
 ###> lexik/jwt-authentication-bundle ###
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem

--- a/config/packages/vich_uploader.yaml
+++ b/config/packages/vich_uploader.yaml
@@ -10,6 +10,10 @@ vich_uploader:
             upload_destination: '%kernel.project_dir%/public/images/cards'
             namer: Vich\UploaderBundle\Naming\SmartUniqueNamer
             inject_on_load: true
+        boosters:
+            uri_prefix: /images/boosters
+            upload_destination: '%kernel.project_dir%/public/images/boosters'
+            namer: Vich\UploaderBundle\Naming\SmartUniqueNamer
         extensions:
             uri_prefix: /images/extensions
             upload_destination: '%kernel.project_dir%/public/images/extensions'

--- a/config/parameters/admin_project_urls.yaml
+++ b/config/parameters/admin_project_urls.yaml
@@ -1,3 +1,0 @@
-parameters:
-    app.admin_urls:
-        youl_coin: '%env(YC_ADMIN_URL)%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -3,9 +3,6 @@
 
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
-imports:
-    - { resource: 'parameters/*' }
-
 parameters:
 
 services:

--- a/fixtures/Booster.yaml
+++ b/fixtures/Booster.yaml
@@ -1,0 +1,23 @@
+App\Entity\Booster:
+    booster_cyberpunk:
+        extension: '@extension_cyberpunk'
+        imageName: 'default_card.png'
+        holoRate: 10
+        rarityRates:
+            - { common: 100 }
+            - { common: 100 }
+            - { common: 60, rare: 30, legendary: 10 }
+    booster_bleach:
+        extension: '@extension_bleach'
+        imageName: 'default_card.png'
+        holoRate: 100
+        rarityRates:
+            - { common: 70, rare: 30 }
+            - { rare: 100 }
+    booster_magic:
+        extension: '@extension_magic'
+        imageName: 'default_card.png'
+        holoRate: 0
+        rarityRates:
+            - { common: 100 }
+            - { common: 50, uncommon: 30, rare: 15, legendary: 5 }

--- a/fixtures/Card.yaml
+++ b/fixtures/Card.yaml
@@ -6,18 +6,24 @@ App\Entity\Card:
         unique: true
         imageName: 'default_card.png'
         status: 2
+        rarity: 'legendary'
+        type: 'lightning'
     card_rogue:
         name: 'Cyberpunk Rogue'
         extension: '@extension_cyberpunk'
         description: 'Rogue is the queen of the Afterlife. She is a key figure in the game Cyberpunk 2077.'
         unique: false
         imageName: 'default_card.png'
+        rarity: 'rare'
+        type: 'darkness'
     card_ichigo:
         name: 'Bleach Ichigo Kurosaki'
         extension: '@extension_bleach'
         description: 'Ichigo Kurosaki is the main character of the Bleach series. He is a teenager with the ability to see ghosts who gains the powers of a Soul Reaper after a fateful encounter with another Soul Reaper, Rukia Kuchiki.'
         unique: false
         imageName: 'default_card.png'
+        rarity: 'rare'
+        type: 'fighting'
     card_cp_barlito:
         name: 'Cyberpunk Barlito'
         extension: '@extension_cyberpunk'
@@ -25,6 +31,8 @@ App\Entity\Card:
         unique: false
         imageName: 'default_card.png'
         status: 2
+        rarity: 'common'
+        type: 'fire'
     card_cp_farf:
         name: 'Cyberpunk Farf'
         extension: '@extension_cyberpunk'
@@ -32,6 +40,8 @@ App\Entity\Card:
         unique: true
         imageName: 'default_card.png'
         status: 2
+        rarity: 'rare'
+        type: 'water'
     card_magic_king_julian:
         name: 'Magic King Julian'
         extension: '@extension_magic'
@@ -39,3 +49,5 @@ App\Entity\Card:
         unique: true
         imageName: 'default_card.png'
         status: 2
+        rarity: 'legendary'
+        type: 'psychic'

--- a/migrations/Version20260610152319.php
+++ b/migrations/Version20260610152319.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260610152319 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add card.rarity and card.type; absorb DBAL 4 schema drift (uuid comments, varchar lengths)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('COMMENT ON COLUMN booster.id IS \'\'');
+        $this->addSql('COMMENT ON COLUMN booster.extension_id IS \'\'');
+        $this->addSql('ALTER TABLE card ADD rarity VARCHAR(255) DEFAULT \'common\' NOT NULL');
+        $this->addSql('ALTER TABLE card ADD type VARCHAR(255) DEFAULT NULL');
+        $this->addSql('COMMENT ON COLUMN card.id IS \'\'');
+        $this->addSql('COMMENT ON COLUMN card.extension_id IS \'\'');
+        $this->addSql('COMMENT ON COLUMN extension.id IS \'\'');
+        $this->addSql('ALTER TABLE user_booster ALTER discord_user_id TYPE VARCHAR');
+        $this->addSql('COMMENT ON COLUMN user_booster.booster_id IS \'\'');
+        $this->addSql('ALTER TABLE user_card ALTER discord_user_id TYPE VARCHAR');
+        $this->addSql('COMMENT ON COLUMN user_card.card_id IS \'\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('COMMENT ON COLUMN booster.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN booster.extension_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('ALTER TABLE card DROP rarity');
+        $this->addSql('ALTER TABLE card DROP type');
+        $this->addSql('COMMENT ON COLUMN card.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN card.extension_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN extension.id IS \'(DC2Type:uuid)\'');
+        $this->addSql('ALTER TABLE user_booster ALTER discord_user_id TYPE VARCHAR(255)');
+        $this->addSql('COMMENT ON COLUMN user_booster.booster_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('ALTER TABLE user_card ALTER discord_user_id TYPE VARCHAR(255)');
+        $this->addSql('COMMENT ON COLUMN user_card.card_id IS \'(DC2Type:uuid)\'');
+    }
+}

--- a/migrations/Version20260610152808.php
+++ b/migrations/Version20260610152808.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260610152808 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Booster rework: per-slot rarity_rates and holo_rate replace price/quantity (YoulCoin removal)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE booster ADD rarity_rates JSON DEFAULT \'[]\' NOT NULL');
+        $this->addSql('ALTER TABLE booster ADD holo_rate INT DEFAULT 10 NOT NULL');
+        $this->addSql('ALTER TABLE booster DROP price');
+        $this->addSql('ALTER TABLE booster DROP quantity');
+        $this->addSql('ALTER TABLE booster ALTER image_name DROP NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE booster ADD price INT NOT NULL');
+        $this->addSql('ALTER TABLE booster ADD quantity INT NOT NULL');
+        $this->addSql('ALTER TABLE booster DROP rarity_rates');
+        $this->addSql('ALTER TABLE booster DROP holo_rate');
+        $this->addSql('ALTER TABLE booster ALTER image_name SET NOT NULL');
+    }
+}

--- a/migrations/Version20260610153422.php
+++ b/migrations/Version20260610153422.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20260610153422 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Booster claim/opening audit tables and user_card.holo_quantity';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE booster_claim (claimed_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, id UUID NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, discord_user_id VARCHAR NOT NULL, booster_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX IDX_376FE897E3F3F7CE ON booster_claim (discord_user_id)');
+        $this->addSql('CREATE INDEX IDX_376FE897F85E4930 ON booster_claim (booster_id)');
+        $this->addSql('CREATE TABLE booster_opening (opened_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, seed BIGINT NOT NULL, id UUID NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, discord_user_id VARCHAR NOT NULL, booster_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX IDX_254A7FE4E3F3F7CE ON booster_opening (discord_user_id)');
+        $this->addSql('CREATE INDEX IDX_254A7FE4F85E4930 ON booster_opening (booster_id)');
+        $this->addSql('CREATE TABLE booster_opening_card (quantity INT NOT NULL, holo_quantity INT DEFAULT 0 NOT NULL, booster_opening_id UUID NOT NULL, card_id UUID NOT NULL, PRIMARY KEY (booster_opening_id, card_id))');
+        $this->addSql('CREATE INDEX IDX_30C7E1ECF60470DE ON booster_opening_card (booster_opening_id)');
+        $this->addSql('CREATE INDEX IDX_30C7E1EC4ACC9A20 ON booster_opening_card (card_id)');
+        $this->addSql('ALTER TABLE booster_claim ADD CONSTRAINT FK_376FE897E3F3F7CE FOREIGN KEY (discord_user_id) REFERENCES discord_user (discord_id) NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE booster_claim ADD CONSTRAINT FK_376FE897F85E4930 FOREIGN KEY (booster_id) REFERENCES booster (id) NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE booster_opening ADD CONSTRAINT FK_254A7FE4E3F3F7CE FOREIGN KEY (discord_user_id) REFERENCES discord_user (discord_id) NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE booster_opening ADD CONSTRAINT FK_254A7FE4F85E4930 FOREIGN KEY (booster_id) REFERENCES booster (id) NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE booster_opening_card ADD CONSTRAINT FK_30C7E1ECF60470DE FOREIGN KEY (booster_opening_id) REFERENCES booster_opening (id) NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE booster_opening_card ADD CONSTRAINT FK_30C7E1EC4ACC9A20 FOREIGN KEY (card_id) REFERENCES card (id) NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE user_card ADD holo_quantity INT DEFAULT 0 NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE booster_claim DROP CONSTRAINT FK_376FE897E3F3F7CE');
+        $this->addSql('ALTER TABLE booster_claim DROP CONSTRAINT FK_376FE897F85E4930');
+        $this->addSql('ALTER TABLE booster_opening DROP CONSTRAINT FK_254A7FE4E3F3F7CE');
+        $this->addSql('ALTER TABLE booster_opening DROP CONSTRAINT FK_254A7FE4F85E4930');
+        $this->addSql('ALTER TABLE booster_opening_card DROP CONSTRAINT FK_30C7E1ECF60470DE');
+        $this->addSql('ALTER TABLE booster_opening_card DROP CONSTRAINT FK_30C7E1EC4ACC9A20');
+        $this->addSql('DROP TABLE booster_claim');
+        $this->addSql('DROP TABLE booster_opening');
+        $this->addSql('DROP TABLE booster_opening_card');
+        $this->addSql('ALTER TABLE user_card DROP holo_quantity');
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,12 +31,6 @@ parameters:
 			path: src/Controller/Admin/CardCrudController.php
 
 		-
-			message: '#^Method App\\Controller\\Admin\\DashboardController\:\:__construct\(\) has parameter \$adminUrls with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Controller/Admin/DashboardController.php
-
-		-
 			message: '#^Class App\\Controller\\Admin\\ExtensionCrudController extends generic class EasyCorp\\Bundle\\EasyAdminBundle\\Controller\\AbstractCrudController but does not specify its types\: TEntity$#'
 			identifier: missingType.generics
 			count: 1
@@ -59,48 +53,6 @@ parameters:
 			identifier: phpDoc.parseError
 			count: 1
 			path: src/Doctrine/DBAL/FunctionNode/Random.php
-
-		-
-			message: '#^Method App\\Entity\\Booster\:\:getHoloRate\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Entity/Booster.php
-
-		-
-			message: '#^Method App\\Entity\\Booster\:\:getRarityRate\(\) return type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Entity/Booster.php
-
-		-
-			message: '#^Method App\\Entity\\Booster\:\:setHoloRate\(\) has parameter \$holoRate with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Entity/Booster.php
-
-		-
-			message: '#^Method App\\Entity\\Booster\:\:setRarityRate\(\) has parameter \$rarityRate with no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Entity/Booster.php
-
-		-
-			message: '#^Property App\\Entity\\Booster\:\:\$holoRate type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Entity/Booster.php
-
-		-
-			message: '#^Property App\\Entity\\Booster\:\:\$imageName \(string\) does not accept string\|null\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Entity/Booster.php
-
-		-
-			message: '#^Property App\\Entity\\Booster\:\:\$rarityRate type has no value type specified in iterable type array\.$#'
-			identifier: missingType.iterableValue
-			count: 1
-			path: src/Entity/Booster.php
 
 		-
 			message: '#^Property App\\Entity\\Booster\:\:\$updatedAt \(DateTime\|null\) does not accept DateTimeImmutable\.$#'

--- a/src/Controller/Admin/BoosterCrudController.php
+++ b/src/Controller/Admin/BoosterCrudController.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Admin\Field\ImageField as VichImageField;
+use App\Entity\Booster;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\CodeEditorField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ImageField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
+use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
+
+/**
+ * @extends AbstractCrudController<Booster>
+ *
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
+ */
+class BoosterCrudController extends AbstractCrudController
+{
+    public function __construct(private readonly UploaderHelper $uploaderHelper, private readonly AssetMapperInterface $assetMapper)
+    {
+    }
+
+    public static function getEntityFqcn(): string
+    {
+        return Booster::class;
+    }
+
+    #[\Override]
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->renderContentMaximized()
+        ;
+    }
+
+    #[\Override]
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters
+            ->add('extension')
+        ;
+    }
+
+    #[\Override]
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions->add(Crud::PAGE_INDEX, Action::DETAIL);
+    }
+
+    /**
+     * @SuppressWarnings("PHPMD.UnusedFormalParameter")
+     */
+    #[\Override]
+    public function configureFields(string $pageName): iterable
+    {
+        $imageCss = $this->assetMapper->getAsset('styles/admin/image.css')
+            ?? throw new \LogicException('Asset "styles/admin/image.css" not found in the asset map.');
+
+        yield ImageField::new('imageName')
+            ->hideOnForm()
+            ->addCssFiles($imageCss->publicPath)
+            ->formatValue(function ($value, $entity): ?string {
+                if (!$entity instanceof Booster) {
+                    throw new UnexpectedTypeException($entity, Booster::class);
+                }
+
+                return $this->uploaderHelper->asset($entity, 'imageFile');
+            })
+        ;
+        yield Field::new('id')->onlyOnDetail();
+        yield AssociationField::new('extension');
+        yield IntegerField::new('cardCount')
+            ->setLabel('Cards')
+            ->hideOnForm()
+        ;
+        yield IntegerField::new('holoRate')
+            ->setHelp('Chance (0-100 %) for each drawn card to be holo')
+        ;
+        yield CodeEditorField::new('rarityRatesJson')
+            ->setLabel('Rarity rates')
+            ->setLanguage('js')
+            ->onlyOnForms()
+            ->setHelp('One weight map per card slot. Example: [{"common": 100}, {"common": 100}, {"common": 60, "rare": 30, "legendary": 10}]')
+        ;
+        yield Field::new('rarityRates')->onlyOnDetail();
+        yield VichImageField::new('imageFile')->onlyOnForms();
+    }
+}

--- a/src/Controller/Admin/CardCrudController.php
+++ b/src/Controller/Admin/CardCrudController.php
@@ -6,7 +6,9 @@ namespace App\Controller\Admin;
 
 use App\Admin\Field\ImageField as VichImageField;
 use App\Entity\Card;
+use App\Enum\Entity\CardRarityEnum;
 use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\CardTypeEnum;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
@@ -48,6 +50,7 @@ class CardCrudController extends AbstractCrudController
     {
         return $filters
             ->add('extension')
+            ->add('rarity')
         ;
     }
 
@@ -79,6 +82,12 @@ class CardCrudController extends AbstractCrudController
         yield Field::new('description');
         yield ChoiceField::new('status')
             ->setChoices(CardStatusEnum::cases())
+        ;
+        yield ChoiceField::new('rarity')
+            ->setChoices(CardRarityEnum::cases())
+        ;
+        yield ChoiceField::new('type')
+            ->setChoices(CardTypeEnum::cases())
         ;
         yield BooleanField::new('unique')
             ->setLabel('Unique Flag')

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Controller\Admin;
 
+use App\Entity\Booster;
 use App\Entity\Card;
 use App\Entity\Extension;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
 use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
@@ -18,8 +18,6 @@ class DashboardController extends AbstractDashboardController
 {
     public function __construct(
         private readonly AdminUrlGenerator $adminUrlGenerator,
-        #[Autowire(param: 'app.admin_urls')]
-        private readonly array $adminUrls,
     ) {
     }
 
@@ -48,8 +46,6 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::section('Card Settings');
         yield MenuItem::linkToCrud('Cards', 'fas fa-wallet', Card::class);
         yield MenuItem::linkToCrud('Extensions', 'fa fa-chart-bar', Extension::class);
-
-        yield MenuItem::section('Extra');
-        yield MenuItem::linkToUrl('YoulCoin - Admin', 'fa-brands fa-wizards-of-the-coast', $this->adminUrls['youl_coin'] ?? '#');
+        yield MenuItem::linkToCrud('Boosters', 'fa fa-box-open', Booster::class);
     }
 }

--- a/src/Entity/Booster.php
+++ b/src/Entity/Booster.php
@@ -5,58 +5,105 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use App\Repository\BoosterRepository;
+use App\Validator\ValidRarityRates;
 use Barlito\Utils\Traits\IdUuidTrait;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
+#[Vich\Uploadable]
 #[ORM\Entity(repositoryClass: BoosterRepository::class)]
-class Booster
+class Booster implements \Stringable
 {
     use IdUuidTrait;
     use TimestampableEntity;
 
-    #[ORM\Column]
-    private int $price;
+    /**
+     * One weight map per card slot, keys are CardRarityEnum values.
+     * Example for a 3-card booster: [{common: 100}, {common: 100}, {common: 60, rare: 30, legendary: 10}].
+     *
+     * @var list<array<string, int>>
+     */
+    #[ValidRarityRates]
+    #[ORM\Column(type: Types::JSON, options: ['default' => '[]'])]
+    private array $rarityRates = [];
 
-    #[ORM\Column]
-    private int $quantity;
+    /**
+     * Chance (0-100 %) for each drawn card to be holo.
+     */
+    #[Assert\Range(min: 0, max: 100)]
+    #[ORM\Column(options: ['default' => 10])]
+    private int $holoRate = 10;
 
-    #[Vich\UploadableField(mapping: 'cards', fileNameProperty: 'imageName')]
-    private File $imageFile;
+    #[Vich\UploadableField(mapping: 'boosters', fileNameProperty: 'imageName')]
+    private ?File $imageFile = null;
 
-    #[ORM\Column(type: 'string', length: 255)]
-    private string $imageName;
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $imageName = null;
 
     #[ORM\ManyToOne(inversedBy: 'boosters')]
     #[ORM\JoinColumn(nullable: false)]
     private Extension $extension;
 
-    private array $rarityRate = [];
-
-    private array $holoRate = [];
-
-    public function getPrice(): int
+    public function __toString(): string
     {
-        return $this->price;
+        return isset($this->extension) ? $this->extension->getName() . ' Booster' : 'Booster';
     }
 
-    public function setPrice(int $price): static
+    /**
+     * @return list<array<string, int>>
+     */
+    public function getRarityRates(): array
     {
-        $this->price = $price;
+        return $this->rarityRates;
+    }
+
+    /**
+     * @param list<array<string, int>> $rarityRates
+     */
+    public function setRarityRates(array $rarityRates): static
+    {
+        $this->rarityRates = $rarityRates;
 
         return $this;
     }
 
-    public function getQuantity(): int
+    public function getCardCount(): int
     {
-        return $this->quantity;
+        return \count($this->rarityRates);
     }
 
-    public function setQuantity(int $quantity): static
+    public function getRarityRatesJson(): string
     {
-        $this->quantity = $quantity;
+        return json_encode($this->rarityRates, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Invalid JSON resolves to an empty slot list so the ValidRarityRates
+     * constraint reports the error through form validation.
+     */
+    public function setRarityRatesJson(string $json): void
+    {
+        try {
+            $decoded = json_decode($json, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $decoded = null;
+        }
+
+        $this->rarityRates = \is_array($decoded) ? array_values($decoded) : [];
+    }
+
+    public function getHoloRate(): int
+    {
+        return $this->holoRate;
+    }
+
+    public function setHoloRate(int $holoRate): static
+    {
+        $this->holoRate = $holoRate;
 
         return $this;
     }
@@ -68,11 +115,13 @@ class Booster
      * must be able to accept an instance of 'File' as the bundle will inject one here
      * during Doctrine hydration.
      */
-    public function setImageFile(File $imageFile): void
+    public function setImageFile(?File $imageFile = null): void
     {
         $this->imageFile = $imageFile;
 
-        $this->updatedAt = new \DateTimeImmutable();
+        if ($imageFile instanceof File) {
+            $this->updatedAt = new \DateTimeImmutable();
+        }
     }
 
     public function getImageFile(): ?File
@@ -98,30 +147,6 @@ class Booster
     public function setExtension(Extension $extension): static
     {
         $this->extension = $extension;
-
-        return $this;
-    }
-
-    public function getRarityRate(): array
-    {
-        return $this->rarityRate;
-    }
-
-    public function setRarityRate(array $rarityRate): static
-    {
-        $this->rarityRate = $rarityRate;
-
-        return $this;
-    }
-
-    public function getHoloRate(): array
-    {
-        return $this->holoRate;
-    }
-
-    public function setHoloRate(array $holoRate): static
-    {
-        $this->holoRate = $holoRate;
 
         return $this;
     }

--- a/src/Entity/BoosterClaim.php
+++ b/src/Entity/BoosterClaim.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\BoosterClaimRepository;
+use Barlito\Utils\Traits\IdUuidTrait;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Timestampable\Traits\TimestampableEntity;
+
+/**
+ * Audit log of daily free booster claims. The daily quota is enforced by
+ * counting claims since the last midnight (Europe/Paris), so there is no
+ * mutable counter to reset.
+ */
+#[ORM\Entity(repositoryClass: BoosterClaimRepository::class)]
+class BoosterClaim
+{
+    use IdUuidTrait;
+    use TimestampableEntity;
+
+    public function __construct(
+        #[ORM\ManyToOne]
+        #[ORM\JoinColumn(referencedColumnName: 'discord_id', nullable: false)]
+        private DiscordUser $discordUser,
+        #[ORM\ManyToOne]
+        #[ORM\JoinColumn(nullable: false)]
+        private Booster $booster,
+        #[ORM\Column]
+        private \DateTimeImmutable $claimedAt,
+    ) {
+    }
+
+    public function getDiscordUser(): DiscordUser
+    {
+        return $this->discordUser;
+    }
+
+    public function getBooster(): Booster
+    {
+        return $this->booster;
+    }
+
+    public function getClaimedAt(): \DateTimeImmutable
+    {
+        return $this->claimedAt;
+    }
+}

--- a/src/Entity/BoosterOpening.php
+++ b/src/Entity/BoosterOpening.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\BoosterOpeningRepository;
+use Barlito\Utils\Traits\IdUuidTrait;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Timestampable\Traits\TimestampableEntity;
+
+/**
+ * Audit log of a booster opening: who opened what, when, with which RNG seed
+ * (the seed makes any draw reproducible) and which cards came out.
+ */
+#[ORM\Entity(repositoryClass: BoosterOpeningRepository::class)]
+class BoosterOpening
+{
+    use IdUuidTrait;
+    use TimestampableEntity;
+
+    /**
+     * @var Collection<int, BoosterOpeningCard>
+     */
+    #[ORM\OneToMany(targetEntity: BoosterOpeningCard::class, mappedBy: 'boosterOpening', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection $boosterOpeningCards;
+
+    public function __construct(#[ORM\ManyToOne]
+        #[ORM\JoinColumn(referencedColumnName: 'discord_id', nullable: false)]
+        private DiscordUser $discordUser, #[ORM\ManyToOne]
+        #[ORM\JoinColumn(nullable: false)]
+        private Booster $booster, #[ORM\Column(type: Types::BIGINT)]
+        private int $seed, #[ORM\Column]
+        private \DateTimeImmutable $openedAt)
+    {
+        $this->boosterOpeningCards = new ArrayCollection();
+    }
+
+    public function getDiscordUser(): DiscordUser
+    {
+        return $this->discordUser;
+    }
+
+    public function getBooster(): Booster
+    {
+        return $this->booster;
+    }
+
+    public function getOpenedAt(): \DateTimeImmutable
+    {
+        return $this->openedAt;
+    }
+
+    public function getSeed(): int
+    {
+        return $this->seed;
+    }
+
+    /**
+     * @return Collection<int, BoosterOpeningCard>
+     */
+    public function getBoosterOpeningCards(): Collection
+    {
+        return $this->boosterOpeningCards;
+    }
+
+    public function addBoosterOpeningCard(BoosterOpeningCard $boosterOpeningCard): static
+    {
+        if (!$this->boosterOpeningCards->contains($boosterOpeningCard)) {
+            $this->boosterOpeningCards->add($boosterOpeningCard);
+        }
+
+        return $this;
+    }
+}

--- a/src/Entity/BoosterOpeningCard.php
+++ b/src/Entity/BoosterOpeningCard.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\BoosterOpeningCardRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * One distinct card drawn in a booster opening. Duplicates are aggregated:
+ * a single row per card with quantity / holoQuantity counters (composite PK).
+ */
+#[ORM\Entity(repositoryClass: BoosterOpeningCardRepository::class)]
+class BoosterOpeningCard
+{
+    public function __construct(
+        #[ORM\Id]
+        #[ORM\ManyToOne(inversedBy: 'boosterOpeningCards')]
+        #[ORM\JoinColumn(nullable: false)]
+        private BoosterOpening $boosterOpening,
+        #[ORM\Id]
+        #[ORM\ManyToOne]
+        #[ORM\JoinColumn(nullable: false)]
+        private Card $card,
+        #[ORM\Column]
+        private int $quantity,
+        #[ORM\Column(options: ['default' => 0])]
+        private int $holoQuantity = 0,
+    ) {
+    }
+
+    public function getBoosterOpening(): BoosterOpening
+    {
+        return $this->boosterOpening;
+    }
+
+    public function getCard(): Card
+    {
+        return $this->card;
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function getHoloQuantity(): int
+    {
+        return $this->holoQuantity;
+    }
+}

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Enum\Entity\CardRarityEnum;
 use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\CardTypeEnum;
 use App\Repository\CardRepository;
 use Barlito\Utils\Traits\IdUuidTrait;
 use Doctrine\ORM\Mapping as ORM;
@@ -31,6 +33,12 @@ class Card
 
     #[ORM\Column(options: ['default' => CardStatusEnum::DRAFT])]
     private CardStatusEnum $status = CardStatusEnum::DRAFT;
+
+    #[ORM\Column(options: ['default' => CardRarityEnum::COMMON])]
+    private CardRarityEnum $rarity = CardRarityEnum::COMMON;
+
+    #[ORM\Column(nullable: true)]
+    private ?CardTypeEnum $type = null;
 
     #[ORM\Column]
     private bool $uniqueFlag = false;
@@ -90,6 +98,30 @@ class Card
     public function setStatus(CardStatusEnum $status): Card
     {
         $this->status = $status;
+
+        return $this;
+    }
+
+    public function getRarity(): CardRarityEnum
+    {
+        return $this->rarity;
+    }
+
+    public function setRarity(CardRarityEnum $rarity): static
+    {
+        $this->rarity = $rarity;
+
+        return $this;
+    }
+
+    public function getType(): ?CardTypeEnum
+    {
+        return $this->type;
+    }
+
+    public function setType(?CardTypeEnum $type): static
+    {
+        $this->type = $type;
 
         return $this;
     }

--- a/src/Entity/UserCard.php
+++ b/src/Entity/UserCard.php
@@ -26,6 +26,9 @@ class UserCard
     #[ORM\Column]
     private int $quantity = 0;
 
+    #[ORM\Column(options: ['default' => 0])]
+    private int $holoQuantity = 0;
+
     public function getDiscordUser(): DiscordUser
     {
         return $this->discordUser;
@@ -58,6 +61,18 @@ class UserCard
     public function setQuantity(int $quantity): static
     {
         $this->quantity = $quantity;
+
+        return $this;
+    }
+
+    public function getHoloQuantity(): int
+    {
+        return $this->holoQuantity;
+    }
+
+    public function setHoloQuantity(int $holoQuantity): static
+    {
+        $this->holoQuantity = $holoQuantity;
 
         return $this;
     }

--- a/src/Enum/Entity/CardRarityEnum.php
+++ b/src/Enum/Entity/CardRarityEnum.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum\Entity;
+
+enum CardRarityEnum: string
+{
+    case COMMON = 'common';
+    case UNCOMMON = 'uncommon';
+    case RARE = 'rare';
+    case LEGENDARY = 'legendary';
+
+    /**
+     * @return list<self> rarities ordered from least to most rare
+     */
+    public static function ascending(): array
+    {
+        return [self::COMMON, self::UNCOMMON, self::RARE, self::LEGENDARY];
+    }
+}

--- a/src/Enum/Entity/CardTypeEnum.php
+++ b/src/Enum/Entity/CardTypeEnum.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum\Entity;
+
+/**
+ * Values must match the card type CSS classes in assets/styles/cards/base.css.
+ */
+enum CardTypeEnum: string
+{
+    case WATER = 'water';
+    case FIRE = 'fire';
+    case GRASS = 'grass';
+    case LIGHTNING = 'lightning';
+    case PSYCHIC = 'psychic';
+    case FIGHTING = 'fighting';
+    case DARKNESS = 'darkness';
+    case METAL = 'metal';
+    case DRAGON = 'dragon';
+    case FAIRY = 'fairy';
+}

--- a/src/Repository/BoosterClaimRepository.php
+++ b/src/Repository/BoosterClaimRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\BoosterClaim;
+use App\Entity\DiscordUser;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BoosterClaim>
+ */
+class BoosterClaimRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BoosterClaim::class);
+    }
+
+    public function countSince(DiscordUser $discordUser, \DateTimeImmutable $since): int
+    {
+        return (int) $this->createQueryBuilder('claim')
+            ->select('COUNT(claim.id)')
+            ->andWhere('claim.discordUser = :discordUser')
+            ->andWhere('claim.claimedAt >= :since')
+            ->setParameter('discordUser', $discordUser)
+            ->setParameter('since', $since)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+    }
+}

--- a/src/Repository/BoosterOpeningCardRepository.php
+++ b/src/Repository/BoosterOpeningCardRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\BoosterOpeningCard;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BoosterOpeningCard>
+ */
+class BoosterOpeningCardRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BoosterOpeningCard::class);
+    }
+}

--- a/src/Repository/BoosterOpeningRepository.php
+++ b/src/Repository/BoosterOpeningRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\BoosterOpening;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<BoosterOpening>
+ */
+class BoosterOpeningRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, BoosterOpening::class);
+    }
+}

--- a/src/Validator/ValidRarityRates.php
+++ b/src/Validator/ValidRarityRates.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY)]
+final class ValidRarityRates extends Constraint
+{
+    public string $emptyMessage = 'A booster needs at least one slot (one weight map per card).';
+    public string $invalidSlotMessage = 'Slot #{{ slot }} must be a non-empty map of rarity => weight.';
+    public string $invalidRarityMessage = 'Slot #{{ slot }} uses unknown rarity "{{ rarity }}". Valid rarities: {{ rarities }}.';
+    public string $invalidWeightMessage = 'Slot #{{ slot }}, rarity "{{ rarity }}": weight must be a positive integer.';
+}

--- a/src/Validator/ValidRarityRatesValidator.php
+++ b/src/Validator/ValidRarityRatesValidator.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validator;
+
+use App\Enum\Entity\CardRarityEnum;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class ValidRarityRatesValidator extends ConstraintValidator
+{
+    public function validate(mixed $value, Constraint $constraint): void
+    {
+        if (!$constraint instanceof ValidRarityRates) {
+            throw new UnexpectedTypeException($constraint, ValidRarityRates::class);
+        }
+
+        if (!\is_array($value)) {
+            throw new UnexpectedValueException($value, 'array');
+        }
+
+        if ([] === $value) {
+            $this->context->buildViolation($constraint->emptyMessage)->addViolation();
+
+            return;
+        }
+
+        foreach (array_values($value) as $index => $slot) {
+            $this->validateSlot($constraint, $index + 1, $slot);
+        }
+    }
+
+    private function validateSlot(ValidRarityRates $constraint, int $slotNumber, mixed $slot): void
+    {
+        if (!\is_array($slot) || [] === $slot) {
+            $this->context->buildViolation($constraint->invalidSlotMessage)
+                ->setParameter('{{ slot }}', (string) $slotNumber)
+                ->addViolation()
+            ;
+
+            return;
+        }
+
+        foreach ($slot as $rarity => $weight) {
+            if (null === CardRarityEnum::tryFrom((string) $rarity)) {
+                $this->context->buildViolation($constraint->invalidRarityMessage)
+                    ->setParameter('{{ slot }}', (string) $slotNumber)
+                    ->setParameter('{{ rarity }}', (string) $rarity)
+                    ->setParameter('{{ rarities }}', implode(', ', array_column(CardRarityEnum::cases(), 'value')))
+                    ->addViolation()
+                ;
+            }
+
+            if (!\is_int($weight) || $weight < 1) {
+                $this->context->buildViolation($constraint->invalidWeightMessage)
+                    ->setParameter('{{ slot }}', (string) $slotNumber)
+                    ->setParameter('{{ rarity }}', (string) $rarity)
+                    ->addViolation()
+                ;
+            }
+        }
+    }
+}

--- a/templates/components/CardComponent.html.twig
+++ b/templates/components/CardComponent.html.twig
@@ -1,5 +1,5 @@
 <div class="bg-gray-500 rounded-lg shadow-lg p-4">
-    <div id="{{ card.id }}" class="card interactive" data-controller="card">
+    <div id="{{ card.id }}" class="card interactive{{ card.type ? ' ' ~ card.type.value }}" data-rarity="{{ card.rarity.value }}" data-controller="card">
         <div class="card__translater">
             <div class="card__rotator">
                 <div class="card__front">


### PR DESCRIPTION
Deuxième brique de la Phase 1 (stack : 1a → **1b** → 1c → #29). Base = phase-1a, à retarget sur master après son merge.

**Domaine :**
- `Card.rarity` (common/uncommon/rare/legendary) + `Card.type` (10 types = classes CSS de glow), exposés dans l'admin et les fixtures
- `Booster.rarityRates` **persisté** : une map JSON `{rareté: poids}` **par slot** (le nombre de slots = nombre de cartes, remplace `quantity`) + `holoRate` (%) — validés par la contrainte `ValidRarityRates`
- Entités d'audit : `BoosterClaim`, `BoosterOpening` (seed RNG), `BoosterOpeningCard` (PK composite, doublons agrégés) + `UserCard.holoQuantity`
- Relations vers DiscordUser unidirectionnelles (entité auth intouchée)

**Retrait YoulCoin** : `Booster.price`, lien admin, `config/parameters/`, `YC_ADMIN_URL` — boosters gratuits en v2.

**Fixes au passage** : `#[Vich\Uploadable]` manquant sur Booster (upload cassé), mapping Vich `boosters` dédié, `BoosterCrudController` (CodeEditorField JSON) + menu. Baseline PHPStan 67 → 59.

**Test manuel** : `/admin` → CRUD Boosters (JSON invalide rejeté), rarity/type sur les cartes.