### PR TITLE
feat(phase 1c): tirage pondéré, claims quotidiens, ouverture transactionnelle

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,11 @@ jobs:
       - name: Generate JWT key pair
         run: castor generate-jwt-key-pair
 
+      - name: Prepare test database
+        run: |
+          make doctrine.migrate.ci
+          make doctrine.load_fixtures.ci
+
       - name: Run phpunit
         run: make phpunit
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "stof/doctrine-extensions-bundle": "^1.12",
         "symfony/asset-mapper": "7.4.*",
         "symfony/cache": "7.4.*",
+        "symfony/clock": "7.4.*",
         "symfony/console": "7.4.*",
         "symfony/dotenv": "7.4.*",
         "symfony/flex": "^2",

--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,7 @@
         }
     },
     "require-dev": {
+        "dama/doctrine-test-bundle": "^8.6",
         "friendsofphp/php-cs-fixer": "^3.95",
         "hautelook/alice-bundle": "^2.16",
         "phpmd/phpmd": "^2.15",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f8e25a4d360c7597b2af4d1d5c9f4bf",
+    "content-hash": "b0931a855baf526c338e086928f2a0d2",
     "packages": [
         {
             "name": "barlito/utils",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0931a855baf526c338e086928f2a0d2",
+    "content-hash": "47f1df85047522cb8354f09ab4378fc2",
     "packages": [
         {
             "name": "barlito/utils",
@@ -9544,6 +9544,75 @@
                 }
             ],
             "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "dama/doctrine-test-bundle",
+            "version": "v8.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dmaicher/doctrine-test-bundle.git",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dmaicher/doctrine-test-bundle/zipball/f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "reference": "f7e3487643e685432f7e27c50cac64e9f8c515a4",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.3 || ^4.0",
+                "doctrine/doctrine-bundle": "^2.11.0 || ^3.0",
+                "php": ">= 8.2",
+                "psr/cache": "^2.0 || ^3.0",
+                "symfony/cache": "^6.4 || ^7.3 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<11.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.0",
+                "friendsofphp/php-cs-fixer": "^3.27",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^11.5.41|| ^12.3.14",
+                "symfony/dotenv": "^6.4 || ^7.3 || ^8.0",
+                "symfony/process": "^6.4 || ^7.3 || ^8.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DAMA\\DoctrineTestBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David Maicher",
+                    "email": "mail@dmaicher.de"
+                }
+            ],
+            "description": "Symfony bundle to isolate doctrine database tests and improve test performance",
+            "keywords": [
+                "doctrine",
+                "isolation",
+                "performance",
+                "symfony",
+                "testing",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dmaicher/doctrine-test-bundle/issues",
+                "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v8.6.0"
+            },
+            "time": "2026-01-21T07:39:44+00:00"
         },
         {
             "name": "ergebnis/agent-detector",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -26,4 +26,5 @@ return [
     Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle::class => ['all' => true],
     Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
     Symfony\UX\LiveComponent\LiveComponentBundle::class => ['all' => true],
+    DAMA\DoctrineTestBundle\DAMADoctrineTestBundle::class => ['test' => true],
 ];

--- a/config/reference.php
+++ b/config/reference.php
@@ -1762,6 +1762,12 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     secret?: scalar|Param|null, // The secret used to compute fingerprints and checksums // Default: "%kernel.secret%"
  *     fetch_credentials?: "same-origin"|"include"|"omit"|Param, // The default fetch credentials mode for all Live Components ('same-origin', 'include', 'omit') // Default: "same-origin"
  * }
+ * @psalm-type DamaDoctrineTestConfig = array{
+ *     enable_static_connection?: mixed, // Default: true
+ *     enable_static_meta_data_cache?: bool|Param, // Default: true
+ *     enable_static_query_cache?: bool|Param, // Default: true
+ *     connection_keys?: list<mixed>,
+ * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,
  *     parameters?: ParametersConfig,
@@ -1850,6 +1856,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         lexik_jwt_authentication?: LexikJwtAuthenticationConfig,
  *         stimulus?: StimulusConfig,
  *         live_component?: LiveComponentConfig,
+ *         dama_doctrine_test?: DamaDoctrineTestConfig,
  *     },
  *     ...<string, ExtensionType|array{ // extra keys must follow the when@%env% pattern or match an extension alias
  *         imports?: ImportsConfig,

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -19,3 +19,13 @@ services:
             - '../src/DependencyInjection/'
             - '../src/Entity/'
             - '../src/Kernel.php'
+
+when@test:
+    services:
+        _defaults:
+            autowire: true
+            autoconfigure: true
+
+        # exposed for integration tests (would otherwise be inlined/removed)
+        App\Service\Booster\BoosterOpeningService:
+            public: true

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -40,5 +40,6 @@
     </source>
 
     <extensions>
+        <bootstrap class="DAMA\DoctrineTestBundle\PHPUnit\PHPUnitExtension" />
     </extensions>
 </phpunit>

--- a/src/Dto/DrawnCard.php
+++ b/src/Dto/DrawnCard.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Entity\Card;
+use App\Enum\Entity\CardRarityEnum;
+
+/**
+ * A single card drawn from a booster slot. The rarity is the effective one:
+ * it may differ from the slot's rolled rarity when the pool had no card of
+ * that tier and the drawer fell back to another one.
+ */
+final readonly class DrawnCard
+{
+    public function __construct(
+        public Card $card,
+        public CardRarityEnum $rarity,
+        public bool $holo,
+    ) {
+    }
+}

--- a/src/Exception/Booster/BoosterException.php
+++ b/src/Exception/Booster/BoosterException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Booster;
+
+abstract class BoosterException extends \RuntimeException
+{
+}

--- a/src/Exception/Booster/DailyClaimLimitReachedException.php
+++ b/src/Exception/Booster/DailyClaimLimitReachedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Booster;
+
+final class DailyClaimLimitReachedException extends BoosterException
+{
+}

--- a/src/Exception/Booster/NoBoosterInInventoryException.php
+++ b/src/Exception/Booster/NoBoosterInInventoryException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Booster;
+
+final class NoBoosterInInventoryException extends BoosterException
+{
+}

--- a/src/Exception/Booster/NoCardAvailableException.php
+++ b/src/Exception/Booster/NoCardAvailableException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Booster;
+
+final class NoCardAvailableException extends BoosterException
+{
+}

--- a/src/Repository/UserBoosterRepository.php
+++ b/src/Repository/UserBoosterRepository.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\Booster;
+use App\Entity\DiscordUser;
 use App\Entity\UserBooster;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -21,5 +24,23 @@ class UserBoosterRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, UserBooster::class);
+    }
+
+    /**
+     * Pessimistic write lock to guard the quantity against concurrent
+     * openings (double-click / parallel requests). Requires an active
+     * transaction.
+     */
+    public function findOneForUpdate(DiscordUser $discordUser, Booster $booster): ?UserBooster
+    {
+        return $this->createQueryBuilder('userBooster')
+            ->andWhere('userBooster.discordUser = :discordUser')
+            ->andWhere('userBooster.booster = :booster')
+            ->setParameter('discordUser', $discordUser)
+            ->setParameter('booster', $booster)
+            ->getQuery()
+            ->setLockMode(LockMode::PESSIMISTIC_WRITE)
+            ->getOneOrNullResult()
+        ;
     }
 }

--- a/src/Service/Booster/BoosterClaimService.php
+++ b/src/Service/Booster/BoosterClaimService.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Entity\Booster;
+use App\Entity\BoosterClaim;
+use App\Entity\DiscordUser;
+use App\Exception\Booster\DailyClaimLimitReachedException;
+use App\Repository\BoosterClaimRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Clock\ClockInterface;
+
+/**
+ * Daily free booster claims: every player can claim DAILY_LIMIT boosters per
+ * day, the quota resets at midnight Europe/Paris. Claimed boosters land in
+ * the UserBooster inventory and can be opened later.
+ */
+final readonly class BoosterClaimService
+{
+    public const int DAILY_LIMIT = 2;
+
+    private const string TIMEZONE = 'Europe/Paris';
+
+    public function __construct(
+        private BoosterClaimRepository $boosterClaimRepository,
+        private UserInventoryService $userInventoryService,
+        private EntityManagerInterface $entityManager,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function getRemainingClaims(DiscordUser $discordUser): int
+    {
+        $claimsToday = $this->boosterClaimRepository->countSince($discordUser, $this->startOfToday());
+
+        return max(0, self::DAILY_LIMIT - $claimsToday);
+    }
+
+    /**
+     * @throws DailyClaimLimitReachedException
+     */
+    public function claim(DiscordUser $discordUser, Booster $booster): BoosterClaim
+    {
+        if ($this->getRemainingClaims($discordUser) < 1) {
+            throw new DailyClaimLimitReachedException(\sprintf('Daily limit of %d boosters reached, come back tomorrow.', self::DAILY_LIMIT));
+        }
+
+        $this->userInventoryService->creditBooster($discordUser, $booster);
+
+        $claim = new BoosterClaim($discordUser, $booster, $this->clock->now());
+        $this->entityManager->persist($claim);
+        $this->entityManager->flush();
+
+        return $claim;
+    }
+
+    public function getNextResetTime(): \DateTimeImmutable
+    {
+        return $this->startOfToday()->modify('+1 day');
+    }
+
+    /**
+     * Midnight Europe/Paris expressed as an absolute point in time, so the
+     * comparison with UTC-stored claimed_at timestamps stays correct across
+     * DST changes.
+     */
+    private function startOfToday(): \DateTimeImmutable
+    {
+        return $this->clock->now()
+            ->setTimezone(new \DateTimeZone(self::TIMEZONE))
+            ->setTime(0, 0)
+        ;
+    }
+}

--- a/src/Service/Booster/BoosterOpeningService.php
+++ b/src/Service/Booster/BoosterOpeningService.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Dto\DrawnCard;
+use App\Entity\Booster;
+use App\Entity\BoosterOpening;
+use App\Entity\BoosterOpeningCard;
+use App\Entity\DiscordUser;
+use App\Exception\Booster\NoBoosterInInventoryException;
+use App\Exception\Booster\NoCardAvailableException;
+use App\Service\Random\RandomService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Clock\ClockInterface;
+
+/**
+ * Orchestrates a booster opening as one atomic transaction: debit the
+ * booster from the inventory, draw the cards, credit them to the collection
+ * and persist the audit trail with the RNG seed.
+ */
+final readonly class BoosterOpeningService
+{
+    public function __construct(
+        private CardDrawer $cardDrawer,
+        private UserInventoryService $userInventoryService,
+        private RandomService $randomService,
+        private EntityManagerInterface $entityManager,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /**
+     * @throws NoBoosterInInventoryException
+     * @throws NoCardAvailableException
+     */
+    public function open(DiscordUser $discordUser, Booster $booster): BoosterOpening
+    {
+        return $this->entityManager->wrapInTransaction(function () use ($discordUser, $booster): BoosterOpening {
+            $this->userInventoryService->debitBooster($discordUser, $booster);
+
+            $openedAt = $this->clock->now();
+            $seed = crc32(\sprintf('%s-%s-%s', $discordUser->getDiscordId(), $booster->getId(), $openedAt->format('Uu')));
+            $this->randomService->seed($seed);
+
+            $opening = new BoosterOpening($discordUser, $booster, $seed, $openedAt);
+
+            foreach ($this->aggregate($this->cardDrawer->draw($booster)) as $aggregated) {
+                $this->userInventoryService->addCard($discordUser, $aggregated['card']->card, $aggregated['quantity'], $aggregated['holoQuantity']);
+                $opening->addBoosterOpeningCard(new BoosterOpeningCard($opening, $aggregated['card']->card, $aggregated['quantity'], $aggregated['holoQuantity']));
+            }
+
+            $this->entityManager->persist($opening);
+            $this->entityManager->flush();
+
+            return $opening;
+        });
+    }
+
+    /**
+     * Aggregates duplicate cards: composite-keyed rows (BoosterOpeningCard,
+     * UserCard) must be persisted once per card with summed quantities.
+     *
+     * @param list<DrawnCard> $drawnCards
+     *
+     * @return array<string, array{card: DrawnCard, quantity: int, holoQuantity: int}>
+     */
+    private function aggregate(array $drawnCards): array
+    {
+        $aggregated = [];
+
+        foreach ($drawnCards as $drawnCard) {
+            $cardId = (string) $drawnCard->card->getId();
+
+            $aggregated[$cardId] ??= ['card' => $drawnCard, 'quantity' => 0, 'holoQuantity' => 0];
+            ++$aggregated[$cardId]['quantity'];
+            $aggregated[$cardId]['holoQuantity'] += $drawnCard->holo ? 1 : 0;
+        }
+
+        return $aggregated;
+    }
+}

--- a/src/Service/Booster/CardDrawer.php
+++ b/src/Service/Booster/CardDrawer.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Dto\DrawnCard;
+use App\Entity\Booster;
+use App\Entity\Card;
+use App\Entity\Extension;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Exception\Booster\NoCardAvailableException;
+use App\Repository\CardRepository;
+use App\Service\Random\RandomService;
+
+/**
+ * Weighted card draw. Each booster slot rolls a rarity from its weight map,
+ * then picks a card uniformly among the published cards of that rarity in
+ * the booster's extension.
+ */
+final readonly class CardDrawer
+{
+    public function __construct(
+        private CardRepository $cardRepository,
+        private RandomService $randomService,
+    ) {
+    }
+
+    /**
+     * @throws NoCardAvailableException when the extension has no published card
+     *
+     * @return list<DrawnCard>
+     */
+    public function draw(Booster $booster): array
+    {
+        $pool = $this->loadPool($booster->getExtension());
+
+        if ([] === $pool) {
+            throw new NoCardAvailableException(\sprintf('Extension "%s" has no published card to draw from.', $booster->getExtension()->getName()));
+        }
+
+        $drawnCards = [];
+
+        foreach ($booster->getRarityRates() as $weights) {
+            $rarity = $this->resolveAvailableRarity($pool, $this->drawRarity($weights));
+            $candidates = $pool[$rarity->value];
+            $card = $candidates[$this->randomService->getInt(0, \count($candidates) - 1)];
+            $holo = $this->randomService->getInt(1, 100) <= $booster->getHoloRate();
+
+            $drawnCards[] = new DrawnCard($card, $rarity, $holo);
+        }
+
+        return $drawnCards;
+    }
+
+    /**
+     * @return array<string, non-empty-list<Card>> published cards grouped by rarity value
+     */
+    private function loadPool(Extension $extension): array
+    {
+        $cards = $this->cardRepository->findBy([
+            'extension' => $extension,
+            'status' => CardStatusEnum::PUBLISHED,
+        ]);
+
+        $pool = [];
+
+        foreach ($cards as $card) {
+            $pool[$card->getRarity()->value][] = $card;
+        }
+
+        return $pool;
+    }
+
+    /**
+     * Cumulative weighted roll over a slot's rarity weight map.
+     *
+     * @param array<string, int> $weights
+     */
+    private function drawRarity(array $weights): CardRarityEnum
+    {
+        if ([] === $weights) {
+            throw new \InvalidArgumentException('A booster slot must define at least one rarity weight.');
+        }
+
+        $roll = $this->randomService->getInt(1, array_sum($weights));
+
+        foreach ($weights as $rarity => $weight) {
+            $roll -= $weight;
+
+            if ($roll <= 0) {
+                return CardRarityEnum::from((string) $rarity);
+            }
+        }
+
+        throw new \LogicException('Weighted roll exhausted the weight map without resolving a rarity.');
+    }
+
+    /**
+     * Falls back to the closest rarity that actually has cards in the pool:
+     * first toward common, then toward legendary.
+     *
+     * @param array<string, non-empty-list<Card>> $pool
+     */
+    private function resolveAvailableRarity(array $pool, CardRarityEnum $rolled): CardRarityEnum
+    {
+        $ascending = CardRarityEnum::ascending();
+        $rolledIndex = (int) array_search($rolled, $ascending, true);
+
+        for ($index = $rolledIndex; $index >= 0; --$index) {
+            if (isset($pool[$ascending[$index]->value])) {
+                return $ascending[$index];
+            }
+        }
+        $counter = \count($ascending);
+
+        for ($index = $rolledIndex + 1; $index < $counter; ++$index) {
+            if (isset($pool[$ascending[$index]->value])) {
+                return $ascending[$index];
+            }
+        }
+
+        throw new NoCardAvailableException('No rarity tier with available cards found in the pool.');
+    }
+}

--- a/src/Service/Booster/UserInventoryService.php
+++ b/src/Service/Booster/UserInventoryService.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Entity\Booster;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\UserBooster;
+use App\Entity\UserCard;
+use App\Exception\Booster\NoBoosterInInventoryException;
+use App\Repository\UserBoosterRepository;
+use App\Repository\UserCardRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Create-or-increment mutations on the user's booster and card inventories.
+ * Persists without flushing: callers own the transaction boundary.
+ */
+class UserInventoryService
+{
+    public function __construct(
+        private readonly UserBoosterRepository $userBoosterRepository,
+        private readonly UserCardRepository $userCardRepository,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public function creditBooster(DiscordUser $discordUser, Booster $booster, int $quantity = 1): UserBooster
+    {
+        $userBooster = $this->userBoosterRepository->findOneBy([
+            'discordUser' => $discordUser,
+            'booster' => $booster,
+        ]);
+
+        if (null === $userBooster) {
+            $userBooster = new UserBooster()
+                ->setDiscordUser($discordUser)
+                ->setBooster($booster)
+            ;
+            $this->entityManager->persist($userBooster);
+        }
+
+        return $userBooster->setQuantity($userBooster->getQuantity() + $quantity);
+    }
+
+    /**
+     * @throws NoBoosterInInventoryException
+     */
+    public function debitBooster(DiscordUser $discordUser, Booster $booster): UserBooster
+    {
+        $userBooster = $this->userBoosterRepository->findOneForUpdate($discordUser, $booster);
+
+        if (!$userBooster instanceof UserBooster || $userBooster->getQuantity() < 1) {
+            throw new NoBoosterInInventoryException('You do not own this booster.');
+        }
+
+        return $userBooster->setQuantity($userBooster->getQuantity() - 1);
+    }
+
+    public function addCard(DiscordUser $discordUser, Card $card, int $quantity, int $holoQuantity = 0): UserCard
+    {
+        $userCard = $this->userCardRepository->findOneBy([
+            'discordUser' => $discordUser,
+            'card' => $card,
+        ]);
+
+        if (null === $userCard) {
+            $userCard = new UserCard()
+                ->setDiscordUser($discordUser)
+                ->setCard($card)
+            ;
+            $this->entityManager->persist($userCard);
+        }
+
+        return $userCard
+            ->setQuantity($userCard->getQuantity() + $quantity)
+            ->setHoloQuantity($userCard->getHoloQuantity() + $holoQuantity)
+        ;
+    }
+}

--- a/src/Service/Random/RandomService.php
+++ b/src/Service/Random/RandomService.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Random;
+
+use Random\Engine\Mt19937;
+use Random\Randomizer;
+
+/**
+ * Seedable RNG wrapper. Seeding makes a draw fully reproducible (the seed is
+ * stored in BoosterOpening for auditing), without touching PHP's global
+ * mt_srand() state.
+ */
+final class RandomService
+{
+    private ?Randomizer $randomizer = null;
+
+    private ?int $seed = null;
+
+    public function seed(int $seed): void
+    {
+        $this->seed = $seed;
+        $this->randomizer = new Randomizer(new Mt19937($seed));
+    }
+
+    public function getSeed(): ?int
+    {
+        return $this->seed;
+    }
+
+    public function getInt(int $min, int $max): int
+    {
+        $this->randomizer ??= new Randomizer(new Mt19937());
+
+        return $this->randomizer->getInt($min, $max);
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,4 +1,7 @@
 {
+    "dama/doctrine-test-bundle": {
+        "version": "v8.6.0"
+    },
     "doctrine/deprecations": {
         "version": "1.1",
         "recipe": {

--- a/tests/Integration/Service/BoosterOpeningServiceTest.php
+++ b/tests/Integration/Service/BoosterOpeningServiceTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Service;
+
+use App\Entity\Booster;
+use App\Entity\BoosterOpening;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Entity\UserBooster;
+use App\Entity\UserCard;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use App\Exception\Booster\NoBoosterInInventoryException;
+use App\Exception\Booster\NoCardAvailableException;
+use App\Service\Booster\BoosterOpeningService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class BoosterOpeningServiceTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    private BoosterOpeningService $openingService;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->openingService = self::getContainer()->get(BoosterOpeningService::class);
+    }
+
+    public function testOpeningDebitsInventoryAndCreditsCards(): void
+    {
+        $scenario = $this->createScenario(boosterQuantity: 2);
+
+        $opening = $this->openingService->open($scenario['user'], $scenario['booster']);
+
+        $this->entityManager->clear();
+
+        $userBooster = $this->entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $scenario['user']]);
+        $this->assertNotNull($userBooster);
+        $this->assertSame(1, $userBooster->getQuantity());
+
+        $userCards = $this->entityManager->getRepository(UserCard::class)->findBy(['discordUser' => $scenario['user']]);
+        $this->assertSame(3, array_sum(array_map(static fn (UserCard $userCard): int => $userCard->getQuantity(), $userCards)));
+
+        $persistedOpening = $this->entityManager->getRepository(BoosterOpening::class)->find($opening->getId());
+        $this->assertNotNull($persistedOpening);
+        $this->assertNotSame(0, $persistedOpening->getSeed());
+        $this->assertSame(
+            3,
+            array_sum($persistedOpening->getBoosterOpeningCards()->map(static fn ($openingCard): int => $openingCard->getQuantity())->toArray()),
+        );
+    }
+
+    public function testSecondOpeningIncrementsExistingUserCards(): void
+    {
+        $scenario = $this->createScenario(boosterQuantity: 2, rarityRates: [['common' => 100]]);
+
+        $this->openingService->open($scenario['user'], $scenario['booster']);
+        $this->openingService->open($scenario['user'], $scenario['booster']);
+
+        $this->entityManager->clear();
+
+        $userCards = $this->entityManager->getRepository(UserCard::class)->findBy(['discordUser' => $scenario['user']]);
+        $this->assertCount(1, $userCards);
+        $this->assertSame(2, $userCards[0]->getQuantity());
+    }
+
+    public function testFullHoloRateCreditsHoloQuantities(): void
+    {
+        $scenario = $this->createScenario(boosterQuantity: 1, holoRate: 100, rarityRates: [['common' => 100], ['common' => 100]]);
+
+        $this->openingService->open($scenario['user'], $scenario['booster']);
+
+        $this->entityManager->clear();
+
+        $userCards = $this->entityManager->getRepository(UserCard::class)->findBy(['discordUser' => $scenario['user']]);
+        $this->assertCount(1, $userCards);
+        $this->assertSame(2, $userCards[0]->getQuantity());
+        $this->assertSame(2, $userCards[0]->getHoloQuantity());
+    }
+
+    public function testZeroHoloRateCreditsNoHolo(): void
+    {
+        $scenario = $this->createScenario(boosterQuantity: 1, holoRate: 0);
+
+        $this->openingService->open($scenario['user'], $scenario['booster']);
+
+        $this->entityManager->clear();
+
+        foreach ($this->entityManager->getRepository(UserCard::class)->findBy(['discordUser' => $scenario['user']]) as $userCard) {
+            $this->assertSame(0, $userCard->getHoloQuantity());
+        }
+    }
+
+    public function testOpeningWithoutInventoryThrowsAndChangesNothing(): void
+    {
+        $scenario = $this->createScenario(boosterQuantity: 0);
+
+        try {
+            $this->openingService->open($scenario['user'], $scenario['booster']);
+            $this->fail('Expected NoBoosterInInventoryException');
+        } catch (NoBoosterInInventoryException) {
+        }
+
+        $this->entityManager->clear();
+
+        $this->assertSame([], $this->entityManager->getRepository(UserCard::class)->findBy(['discordUser' => $scenario['user']]));
+        $this->assertSame([], $this->entityManager->getRepository(BoosterOpening::class)->findBy(['discordUser' => $scenario['user']]));
+    }
+
+    public function testOpeningRollsBackWhenExtensionHasNoPublishedCard(): void
+    {
+        $scenario = $this->createScenario(boosterQuantity: 1, withPublishedCards: false);
+
+        try {
+            $this->openingService->open($scenario['user'], $scenario['booster']);
+            $this->fail('Expected NoCardAvailableException');
+        } catch (NoCardAvailableException) {
+        }
+
+        $this->entityManager->clear();
+
+        $userBooster = $this->entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $scenario['user']]);
+        $this->assertNotNull($userBooster);
+        $this->assertSame(1, $userBooster->getQuantity(), 'The booster must not be consumed when the draw fails.');
+        $this->assertSame([], $this->entityManager->getRepository(BoosterOpening::class)->findBy(['discordUser' => $scenario['user']]));
+    }
+
+    /**
+     * @param list<array<string, int>>|null $rarityRates
+     *
+     * @return array{user: DiscordUser, booster: Booster}
+     */
+    private function createScenario(
+        int $boosterQuantity,
+        int $holoRate = 10,
+        ?array $rarityRates = null,
+        bool $withPublishedCards = true,
+    ): array {
+        $extension = new Extension()
+            ->setName('Opening test extension ' . uniqid())
+            ->setDescription('Test extension')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($extension);
+
+        if ($withPublishedCards) {
+            $cardDefinitions = [
+                ['Common test card', CardRarityEnum::COMMON],
+                ['Rare test card', CardRarityEnum::RARE],
+                ['Legendary test card', CardRarityEnum::LEGENDARY],
+            ];
+
+            foreach ($cardDefinitions as [$name, $rarity]) {
+                $card = new Card()
+                    ->setName($name)
+                    ->setDescription('Test card')
+                    ->setStatus(CardStatusEnum::PUBLISHED)
+                    ->setRarity($rarity)
+                    ->setExtension($extension)
+                ;
+                $card->setImageName('default_card.png');
+                $this->entityManager->persist($card);
+            }
+        }
+
+        $booster = new Booster()
+            ->setExtension($extension)
+            ->setHoloRate($holoRate)
+            ->setRarityRates($rarityRates ?? [['common' => 100], ['common' => 100], ['common' => 60, 'rare' => 30, 'legendary' => 10]])
+        ;
+        $booster->setImageName('default_card.png');
+        $this->entityManager->persist($booster);
+
+        $user = new DiscordUser()
+            ->setDiscordId('opening-test-' . uniqid())
+            ->setUsername('Opening tester')
+        ;
+        $this->entityManager->persist($user);
+
+        if ($boosterQuantity > 0) {
+            $userBooster = new UserBooster()
+                ->setDiscordUser($user)
+                ->setBooster($booster)
+                ->setQuantity($boosterQuantity)
+            ;
+            $this->entityManager->persist($userBooster);
+        }
+
+        $this->entityManager->flush();
+
+        return ['user' => $user, 'booster' => $booster];
+    }
+}

--- a/tests/Unit/Service/BoosterClaimServiceTest.php
+++ b/tests/Unit/Service/BoosterClaimServiceTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Booster;
+use App\Entity\DiscordUser;
+use App\Exception\Booster\DailyClaimLimitReachedException;
+use App\Repository\BoosterClaimRepository;
+use App\Service\Booster\BoosterClaimService;
+use App\Service\Booster\UserInventoryService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+
+final class BoosterClaimServiceTest extends TestCase
+{
+    public function testRemainingClaimsCountsDownFromTheDailyLimit(): void
+    {
+        $user = new DiscordUser();
+
+        foreach ([0 => 2, 1 => 1, 2 => 0, 3 => 0] as $claimsToday => $expectedRemaining) {
+            $service = new BoosterClaimService(
+                $this->claimRepositoryCounting($claimsToday),
+                $this->createStub(UserInventoryService::class),
+                $this->createStub(EntityManagerInterface::class),
+                new MockClock('2026-06-10 12:00:00', 'UTC'),
+            );
+
+            $this->assertSame($expectedRemaining, $service->getRemainingClaims($user));
+        }
+    }
+
+    public function testClaimCreditsTheInventoryAndPersistsAnAuditRow(): void
+    {
+        $clock = new MockClock('2026-06-10 12:00:00', 'UTC');
+        $user = new DiscordUser();
+        $booster = new Booster();
+
+        $inventory = $this->createMock(UserInventoryService::class);
+        $inventory->expects($this->once())->method('creditBooster')->with($user, $booster);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects($this->once())->method('persist');
+        $entityManager->expects($this->once())->method('flush');
+
+        $service = new BoosterClaimService($this->claimRepositoryCounting(0), $inventory, $entityManager, $clock);
+
+        $claim = $service->claim($user, $booster);
+
+        $this->assertSame($user, $claim->getDiscordUser());
+        $this->assertSame($booster, $claim->getBooster());
+        $this->assertEquals($clock->now(), $claim->getClaimedAt());
+    }
+
+    public function testClaimThrowsOnceTheDailyLimitIsReached(): void
+    {
+        $inventory = $this->createMock(UserInventoryService::class);
+        $inventory->expects($this->never())->method('creditBooster');
+
+        $service = new BoosterClaimService(
+            $this->claimRepositoryCounting(BoosterClaimService::DAILY_LIMIT),
+            $inventory,
+            $this->createStub(EntityManagerInterface::class),
+            new MockClock('2026-06-10 12:00:00', 'UTC'),
+        );
+
+        $this->expectException(DailyClaimLimitReachedException::class);
+
+        $service->claim(new DiscordUser(), new Booster());
+    }
+
+    public function testQuotaWindowStartsAtMidnightParisInWinter(): void
+    {
+        // 2026-01-15 23:30 UTC is already 2026-01-16 00:30 in Paris (UTC+1):
+        // the window must start at 23:00 UTC = midnight Paris of the new day.
+        $this->assertQuotaWindowStartsAt('2026-01-15 23:00:00', clockNow: '2026-01-15 23:30:00');
+    }
+
+    public function testQuotaWindowStartsAtMidnightParisInSummer(): void
+    {
+        // 2026-06-10 12:00 UTC = 14:00 Paris (UTC+2): the window must start
+        // at 2026-06-09 22:00 UTC = midnight Paris the same day.
+        $this->assertQuotaWindowStartsAt('2026-06-09 22:00:00', clockNow: '2026-06-10 12:00:00');
+    }
+
+    public function testNextResetTimeIsTheUpcomingMidnightParis(): void
+    {
+        $service = new BoosterClaimService(
+            $this->claimRepositoryCounting(0),
+            $this->createStub(UserInventoryService::class),
+            $this->createStub(EntityManagerInterface::class),
+            new MockClock('2026-06-10 12:00:00', 'UTC'),
+        );
+
+        $nextReset = $service->getNextResetTime()->setTimezone(new \DateTimeZone('UTC'));
+
+        // Midnight Paris on June 11th is 22:00 UTC on June 10th.
+        $this->assertSame('2026-06-10 22:00:00', $nextReset->format('Y-m-d H:i:s'));
+    }
+
+    private function assertQuotaWindowStartsAt(string $expectedUtcWindowStart, string $clockNow): void
+    {
+        $claimRepository = $this->createMock(BoosterClaimRepository::class);
+        $claimRepository->expects($this->once())
+            ->method('countSince')
+            ->with(
+                $this->anything(),
+                $this->callback(
+                    static fn (\DateTimeImmutable $since): bool => $expectedUtcWindowStart === $since->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+                ),
+            )
+            ->willReturn(0)
+        ;
+
+        $service = new BoosterClaimService(
+            $claimRepository,
+            $this->createStub(UserInventoryService::class),
+            $this->createStub(EntityManagerInterface::class),
+            new MockClock($clockNow, 'UTC'),
+        );
+
+        $this->assertSame(BoosterClaimService::DAILY_LIMIT, $service->getRemainingClaims(new DiscordUser()));
+    }
+
+    private function claimRepositoryCounting(int $claimsToday): BoosterClaimRepository
+    {
+        $claimRepository = $this->createStub(BoosterClaimRepository::class);
+        $claimRepository->method('countSince')->willReturn($claimsToday);
+
+        return $claimRepository;
+    }
+}

--- a/tests/Unit/Service/CardDrawerTest.php
+++ b/tests/Unit/Service/CardDrawerTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Booster;
+use App\Entity\Card;
+use App\Entity\Extension;
+use App\Enum\Entity\CardRarityEnum;
+use App\Exception\Booster\NoCardAvailableException;
+use App\Repository\CardRepository;
+use App\Service\Booster\CardDrawer;
+use App\Service\Random\RandomService;
+use PHPUnit\Framework\TestCase;
+
+final class CardDrawerTest extends TestCase
+{
+    public function testDrawsOneCardPerSlot(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Common card', CardRarityEnum::COMMON),
+            $this->card('Rare card', CardRarityEnum::RARE),
+        ]);
+
+        $drawnCards = $drawer->draw($this->booster([
+            ['common' => 100],
+            ['rare' => 100],
+            ['common' => 50, 'rare' => 50],
+        ]));
+
+        $this->assertCount(3, $drawnCards);
+        $this->assertSame('Common card', $drawnCards[0]->card->getName());
+        $this->assertSame(CardRarityEnum::COMMON, $drawnCards[0]->rarity);
+        $this->assertSame('Rare card', $drawnCards[1]->card->getName());
+        $this->assertSame(CardRarityEnum::RARE, $drawnCards[1]->rarity);
+    }
+
+    public function testWeightedDistributionOverManyDraws(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Common card', CardRarityEnum::COMMON),
+            $this->card('Rare card', CardRarityEnum::RARE),
+            $this->card('Legendary card', CardRarityEnum::LEGENDARY),
+        ]);
+        $booster = $this->booster([['common' => 60, 'rare' => 30, 'legendary' => 10]]);
+
+        $draws = 10_000;
+        $counts = [CardRarityEnum::COMMON->value => 0, CardRarityEnum::RARE->value => 0, CardRarityEnum::LEGENDARY->value => 0];
+
+        for ($i = 0; $i < $draws; ++$i) {
+            ++$counts[$drawer->draw($booster)[0]->rarity->value];
+        }
+
+        $this->assertEqualsWithDelta(0.60, $counts['common'] / $draws, 0.03);
+        $this->assertEqualsWithDelta(0.30, $counts['rare'] / $draws, 0.03);
+        $this->assertEqualsWithDelta(0.10, $counts['legendary'] / $draws, 0.03);
+    }
+
+    public function testFallsBackTowardCommonWhenRolledRarityHasNoCard(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Uncommon card', CardRarityEnum::UNCOMMON),
+        ]);
+
+        $drawnCards = $drawer->draw($this->booster([['legendary' => 100]]));
+
+        $this->assertSame(CardRarityEnum::UNCOMMON, $drawnCards[0]->rarity);
+        $this->assertSame('Uncommon card', $drawnCards[0]->card->getName());
+    }
+
+    public function testFallsBackTowardLegendaryWhenNothingBelowRolledRarity(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Legendary card', CardRarityEnum::LEGENDARY),
+        ]);
+
+        $drawnCards = $drawer->draw($this->booster([['common' => 100]]));
+
+        $this->assertSame(CardRarityEnum::LEGENDARY, $drawnCards[0]->rarity);
+    }
+
+    public function testDrawnRarityMatchesTheCardRarity(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Common card', CardRarityEnum::COMMON),
+            $this->card('Legendary card', CardRarityEnum::LEGENDARY),
+        ]);
+        $booster = $this->booster([['common' => 50, 'legendary' => 50]]);
+
+        for ($i = 0; $i < 100; ++$i) {
+            $drawnCard = $drawer->draw($booster)[0];
+
+            $this->assertSame($drawnCard->card->getRarity(), $drawnCard->rarity);
+        }
+    }
+
+    public function testZeroHoloRateNeverDrawsHolo(): void
+    {
+        $drawer = $this->createDrawer([$this->card('Common card', CardRarityEnum::COMMON)]);
+        $booster = $this->booster([['common' => 100]], holoRate: 0);
+
+        for ($i = 0; $i < 200; ++$i) {
+            $this->assertFalse($drawer->draw($booster)[0]->holo);
+        }
+    }
+
+    public function testFullHoloRateAlwaysDrawsHolo(): void
+    {
+        $drawer = $this->createDrawer([$this->card('Common card', CardRarityEnum::COMMON)]);
+        $booster = $this->booster([['common' => 100]], holoRate: 100);
+
+        for ($i = 0; $i < 200; ++$i) {
+            $this->assertTrue($drawer->draw($booster)[0]->holo);
+        }
+    }
+
+    public function testThrowsWhenExtensionHasNoPublishedCard(): void
+    {
+        $drawer = $this->createDrawer([]);
+
+        $this->expectException(NoCardAvailableException::class);
+
+        $drawer->draw($this->booster([['common' => 100]]));
+    }
+
+    public function testSameSeedReproducesTheSameDraw(): void
+    {
+        $cards = [
+            $this->card('Common A', CardRarityEnum::COMMON),
+            $this->card('Common B', CardRarityEnum::COMMON),
+            $this->card('Rare card', CardRarityEnum::RARE),
+        ];
+        $booster = $this->booster([['common' => 70, 'rare' => 30], ['common' => 70, 'rare' => 30]]);
+
+        $names = static fn (array $drawnCards): array => array_map(
+            static fn ($drawnCard): string => $drawnCard->card->getName() . ($drawnCard->holo ? '*' : ''),
+            $drawnCards,
+        );
+
+        $firstRandom = new RandomService();
+        $firstRandom->seed(20260610);
+        $firstDraw = $names(new CardDrawer($this->repositoryWith($cards), $firstRandom)->draw($booster));
+
+        $secondRandom = new RandomService();
+        $secondRandom->seed(20260610);
+        $secondDraw = $names(new CardDrawer($this->repositoryWith($cards), $secondRandom)->draw($booster));
+
+        $this->assertSame($firstDraw, $secondDraw);
+    }
+
+    /**
+     * @param list<Card> $publishedCards
+     */
+    private function createDrawer(array $publishedCards): CardDrawer
+    {
+        $randomService = new RandomService();
+        $randomService->seed(424242);
+
+        return new CardDrawer($this->repositoryWith($publishedCards), $randomService);
+    }
+
+    /**
+     * @param list<Card> $publishedCards
+     */
+    private function repositoryWith(array $publishedCards): CardRepository
+    {
+        $cardRepository = $this->createStub(CardRepository::class);
+        $cardRepository->method('findBy')->willReturn($publishedCards);
+
+        return $cardRepository;
+    }
+
+    private function card(string $name, CardRarityEnum $rarity): Card
+    {
+        return new Card()
+            ->setName($name)
+            ->setRarity($rarity)
+            ->setExtension($this->extension())
+        ;
+    }
+
+    /**
+     * @param list<array<string, int>> $rarityRates
+     */
+    private function booster(array $rarityRates, int $holoRate = 10): Booster
+    {
+        return new Booster()
+            ->setExtension($this->extension())
+            ->setRarityRates($rarityRates)
+            ->setHoloRate($holoRate)
+        ;
+    }
+
+    private function extension(): Extension
+    {
+        return $this->extensionInstance ??= new Extension()->setName('Test extension');
+    }
+
+    private ?Extension $extensionInstance = null;
+}

--- a/tests/Unit/Service/RandomServiceTest.php
+++ b/tests/Unit/Service/RandomServiceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Service\Random\RandomService;
+use PHPUnit\Framework\TestCase;
+
+final class RandomServiceTest extends TestCase
+{
+    public function testSameSeedProducesSameSequence(): void
+    {
+        $first = new RandomService();
+        $first->seed(42);
+        $second = new RandomService();
+        $second->seed(42);
+
+        $firstSequence = $this->drawSequence($first);
+
+        $this->assertSame($firstSequence, $this->drawSequence($second));
+    }
+
+    public function testDifferentSeedsProduceDifferentSequences(): void
+    {
+        $first = new RandomService();
+        $first->seed(42);
+        $second = new RandomService();
+        $second->seed(43);
+
+        $this->assertNotSame($this->drawSequence($first), $this->drawSequence($second));
+    }
+
+    public function testReseedingRestartsTheSequence(): void
+    {
+        $random = new RandomService();
+        $random->seed(42);
+        $sequence = $this->drawSequence($random);
+
+        $random->seed(42);
+
+        $this->assertSame($sequence, $this->drawSequence($random));
+    }
+
+    public function testGetSeedExposesTheLastSeed(): void
+    {
+        $random = new RandomService();
+
+        $this->assertNull($random->getSeed());
+
+        $random->seed(1337);
+
+        $this->assertSame(1337, $random->getSeed());
+    }
+
+    public function testWorksUnseeded(): void
+    {
+        $value = new RandomService()->getInt(1, 10);
+
+        $this->assertGreaterThanOrEqual(1, $value);
+        $this->assertLessThanOrEqual(10, $value);
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function drawSequence(RandomService $random): array
+    {
+        return array_map(static fn (): int => $random->getInt(1, 1_000_000), range(1, 20));
+    }
+}


### PR DESCRIPTION
Troisième brique de la Phase 1 (stack : 1a → 1b → **1c** → #29). Base = phase-1b, à retarget après merge.

**Services (`src/Service/`) :**
- `RandomService` seedable (`Random\Randomizer` + Mt19937, pas d'état global) — seed stocké dans l'audit, tout tirage est rejouable
- `CardDrawer` : rareté au poids par slot → carte uniforme dans le tier → fallback vers le tier le plus proche si vide → roll holo
- `UserInventoryService` (create-or-increment UserBooster/UserCard, débit avec lock pessimiste anti double-clic)
- `BoosterClaimService` : 2 claims gratuits/jour, reset minuit Europe/Paris (calcul DST-safe, `symfony/clock`)
- `BoosterOpeningService::open()` : une transaction = débit inventaire, tirage seedé, agrégation doublons, crédit collection, audit — tout échec rollback (le booster n'est jamais consommé sur un tirage raté)

**CI/test** : la DB de test n'était jamais migrée ni peuplée en CI — steps ajoutés + isolation `dama/doctrine-test-bundle`.

**Tests** : unitaires (reproductibilité seed, distribution 10k tirages, fallback, holo 0/100, frontières DST hiver/été) + intégration sur vraie DB (débit/crédit, incréments, rollbacks).