### PR TITLE
feat(phase 1d): opening engine hardening — no UI

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -14,3 +14,9 @@ JWT_COOKIE_DOMAIN=.local.barlito.fr
 REFRESH_TOKEN_URL='https://yc.local.barlito.fr/refresh_token'
 LOGOUT_URL='https://yc.local.barlito.fr/logout'
 ###< Project external URLS ###
+
+###> Booster claims ###
+# Limite quotidienne désactivée en dev pour tester les ouvertures en boucle.
+# Repasser à true pour tester le quota/countdown.
+BOOSTER_DAILY_LIMIT_ENABLED=false
+###< Booster claims ###

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,9 @@ jobs:
           make doctrine.migrate.ci
           make doctrine.load_fixtures.ci
 
+      - name: Build Tailwind CSS
+        run: make tailwind.build
+
       - name: Run phpunit
         run: make phpunit
 

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@
 ###> lexik/jwt-authentication-bundle ###
 /config/jwt/*.pem
 ###< lexik/jwt-authentication-bundle ###
+
+###> Claude Code (settings locaux et handoffs design uniquement) ###
+/.claude/settings.local.json
+/.claude/design_handoff_youl/
+###< Claude Code ###

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Youl TCG** is a Trading Card Game (TCG) application built with Symfony 7.2. Users authenticate via Discord OAuth2 and can view/collect trading cards organized into extensions. The application features advanced 3D interactive card rendering with JavaScript-based animations.
+**Youl TCG** is a Trading Card Game (TCG) application built with Symfony 7.4 LTS. Users authenticate via Discord OAuth2, claim free daily boosters, open them with an animated card reveal and collect trading cards organized into extensions. The application features advanced 3D interactive card rendering with JavaScript-based animations.
 
 ## Development Environment
 
 ### Stack & Tools
-- **Framework:** Symfony 7.2 (PHP 8.2+)
-- **Database:** PostgreSQL 13 (production), SQLite (dev)
-- **Web Server:** FrankenPHP (Caddy-based)
+- **Framework:** Symfony 7.4 LTS (PHP 8.4)
+- **Database:** PostgreSQL 18
+- **Web Server:** FrankenPHP (Caddy-based, non-root user `www`)
 - **Authentication:** JWT (cookie-based) + Discord OAuth2
-- **Admin Panel:** EasyAdminBundle 4.11
+- **Admin Panel:** EasyAdminBundle 4.x
+- **Frontend interactivity:** Stimulus + symfony/ux-live-component (AssetMapper, no build step)
 - **Task Runner:** Castor + Makefile (uses barlito/php-make-rules submodule)
 - **Container Orchestration:** Docker Swarm (stack name: `ytcg`)
-- **Reverse Proxy:** Traefik (external traefik_traefik_proxy network)
+- **Reverse Proxy:** Traefik (external traefik_traefik_proxy network, TLS terminated by Traefik)
 
 ### Common Commands
 
@@ -53,10 +54,8 @@ make cs-fix
 # PHP CodeSniffer (uses vendor/barlito/utils/config/phpcs.xml.dist)
 make cs-check
 
-# PHPMD (uses vendor/barlito/utils/config/phpmd.xml)
-make phpmd
-
-# Run all quality checks
+# Run all quality checks (composer validate, phpcs, cs-fixer, phpstan, rector)
+# Note: phpmd is disabled everywhere until pdepend supports PHP 8.4 syntax
 make quality
 ```
 
@@ -99,7 +98,8 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 **Core Entities:**
 - **Card**: Trading cards with multi-image support (main image, mask, foil)
-  - Fields: name, description, status (DRAFT/PUBLISHED), uniqueFlag
+  - Fields: name, description, status (DRAFT/PUBLISHED), rarity (CardRarityEnum: common/uncommon/rare/epic/legendary — white/green/blue/purple/orange glows), uniqueFlag
+  - No "type" field: visual customization (glow, borders, CSS aspects) will be an extension-level config overridable per card (future phase)
   - Uses VichUploaderBundle for file uploads
   - ManyToOne with Extension
 
@@ -108,8 +108,8 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
   - OneToMany with Card and Booster
 
 - **Booster**: Booster packs containing cards
-  - Fields: price, quantity, rarityRate[], holoRate[]
-  - ManyToOne with Extension
+  - Fields: rarityRates (JSON, one `{rarity: weight}` map per card slot — the slot count IS the card count), holoRate (0-100 % holo chance per drawn card), imageName
+  - ManyToOne with Extension; boosters are free (no currency in v2)
 
 **User System:**
 - **DiscordUser**: Main user entity (implements UserInterface)
@@ -117,8 +117,19 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
   - Discord OAuth2 integration for authentication
   - OneToMany with UserCard and UserBooster
 
-- **UserCard**: User card inventory (composite key: DiscordUser + Card)
-- **UserBooster**: User booster inventory (composite key: DiscordUser + Booster)
+- **UserCard**: User card inventory (composite key: DiscordUser + Card, quantity + holoQuantity)
+- **UserBooster**: User unopened booster inventory (composite key: DiscordUser + Booster)
+
+**Audit Entities (booster opening):**
+- **BoosterClaim**: one row per daily free claim; the daily quota (2/day, reset midnight Europe/Paris) is a COUNT since midnight — no mutable counter anywhere
+- **BoosterOpening** + **BoosterOpeningCard**: opening history with the RNG seed (reproducible draws); duplicates aggregated per card (composite PK)
+
+### Booster Opening Flow (`src/Service/Booster/`)
+
+1. **BoosterClaimService::claim()** — asks the quota policy (`BoosterClaimQuotaInterface` / `DailyBoosterClaimQuota`) for remaining claims, credits `UserBooster` via UserInventoryService, persists a `BoosterClaim`. In dev only, the `UnlimitedBoosterClaimQuota` decorator (`#[When(env: 'dev')]`) lifts the limit unless `BOOSTER_DAILY_LIMIT_ENABLED=true` is set in `.env.dev` — prod code carries no bypass
+2. **BoosterOpeningService::open()** — one transaction: pessimistic-locked inventory debit, seeded `CardDrawer::draw()` (per-slot weighted rarity roll, uniform pick in the tier, fallback to the nearest tier with cards, holo roll), duplicate aggregation, `UserCard` credit, audit persistence
+3. **RandomService** (`src/Service/Random/`) — seedable `Random\Randomizer` wrapper; the seed is stored on `BoosterOpening`
+4. UI: **not implemented yet** — the booster opening pages arrive with the phase 2 "Violet Arcade" design (`/boosters` is still coming_soon). The engine is fully tested at the service level.
 
 **Common Traits:**
 - `IdUuidTrait` (from barlito/utils): UUID primary keys
@@ -139,28 +150,25 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 **Frontend (`src/Controller/`):**
 - **BaseController**: Homepage with 3 random published cards (cached daily)
-  - Routes: `/` (homepage), `/extensions` (coming soon), `/boosters` (coming soon)
+  - Routes: `/` (homepage), `/extensions` (coming soon), `/boosters` (coming soon — phase 2 design)
   - Uses custom `CardRepository::findRandomCardId()` with RANDOM() DQL function
 
 **Admin (`src/Controller/Admin/`):**
 - **DashboardController**: EasyAdmin dashboard entry
-- **CardCrudController**: Card management with custom ImageField
+- **CardCrudController**: Card management with custom ImageField (rarity/type choice fields)
 - **ExtensionCrudController**: Extension management
+- **BoosterCrudController**: Booster management (rarityRates edited as JSON via CodeEditorField, validated by the ValidRarityRates constraint)
 - Access: Requires ROLE_ADMIN
 
 ### Frontend Architecture
 
 **3D Card Rendering System:**
-- **CSS**: `assets/styles/cards/base.css` (347 lines of advanced 3D CSS)
+- **CSS**: `assets/styles/cards/base.css` (advanced 3D CSS)
   - Hardware-accelerated transforms with perspective
   - Multi-layer effects: shine, glare, foil masks
   - Type-specific glows (water, fire, grass, etc.)
-
-- **JavaScript**: `assets/scripts/card/card.js`
-  - Real-time mouse-tracking 3D rotation
-  - Anime.js animations for smooth transitions
-  - Touch event support
-  - Key functions: `computePositions()`, `updateCard()`, `resetElement()`
+- **JavaScript (Stimulus controllers in `assets/controllers/`):**
+  - `card_controller.js`: real-time mouse-tracking 3D rotation (anime.js); attached via `data-controller="card"`, so dynamically rendered cards (Live Components) work too
 
 **Asset Pipeline:**
 - Uses Symfony AssetMapper (no Webpack/build step)
@@ -174,6 +182,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 - `cards`: Main card artwork → `/public/images/cards/`
 - `masks`: Foil/holo masks → `/public/images/masks/`
 - `foils`: Foil textures → `/public/images/foils/`
+- `boosters`: Booster images → `/public/images/boosters/`
 - `extensions`: Extension images → `/public/images/extensions/`
 
 **Upload Routes:**
@@ -221,8 +230,8 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 ### Modifying Card Display
 
-- **CSS changes**: Edit `assets/styles/cards/base.css`
-- **JavaScript interactions**: Edit `assets/scripts/card/card.js`
+- **CSS changes**: Edit `assets/styles/cards/base.css` (3D core)
+- **JavaScript interactions**: Edit `assets/controllers/card_controller.js`
 - **Template structure**: Edit `templates/components/CardComponent.html.twig`
 - **Card selection logic**: Modify `CardRepository::findRandomCardId()`
 
@@ -244,7 +253,7 @@ All JWT listeners must:
 ### Code Quality Standards
 
 - PSR-12 coding standard via PHP CS Fixer
-- PHPMD ruleset from `vendor/barlito/utils/config/phpmd.xml`
+- PHPStan level 8 (baseline in `phpstan-baseline.neon` — never add new entries)
 - Declare strict types: `declare(strict_types=1);`
 - Use typed properties and return types
 - Enum over constants for fixed value sets

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ backup_path=/srv/ytcg/backups
 # Config paths
 config_cs_fixer=vendor/barlito/utils/config/.php-cs-fixer.dist.php
 config_phpcs=vendor/barlito/utils/config/phpcs.xml.dist
-config_phpmd=vendor/barlito/utils/config/phpmd.xml
 
 # Include all make rules from submodule
 include make/entrypoint.mk
@@ -37,6 +36,12 @@ db.backup:
 	else \
 		echo "ℹ  DB container introuvable, backup skippé (1er deploy ?)"; \
 	fi
+
+# Tailwind est requis pour rendre base.html.twig (TailwindCssAssetCompiler lève
+# une exception si var/tailwind/tailwind.built.css est absent) — nécessaire en CI
+# avant les tests fonctionnels qui rendent des pages.
+tailwind.build:
+	docker exec -t $(app_container_id) bin/console tailwind:build --minify
 
 # Smoke test : curl GET / → fail si non-2xx. Sert de garde-fou post-deploy/update.
 smoke.test:

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,6 @@
         "dama/doctrine-test-bundle": "^8.6",
         "friendsofphp/php-cs-fixer": "^3.95",
         "hautelook/alice-bundle": "^2.16",
-        "phpmd/phpmd": "^2.15",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-doctrine": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47f1df85047522cb8354f09ab4378fc2",
+    "content-hash": "32369721db7a15db40d132e9626939b9",
     "packages": [
         {
             "name": "barlito/utils",
@@ -10316,69 +10316,6 @@
             "time": "2025-12-06T11:56:16+00:00"
         },
         {
-            "name": "pdepend/pdepend",
-            "version": "2.16.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "f942b208dc2a0868454d01b29f0c75bbcfc6ed58"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/f942b208dc2a0868454d01b29f0c75bbcfc6ed58",
-                "reference": "f942b208dc2a0868454d01b29f0c75bbcfc6ed58",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.7",
-                "symfony/config": "^2.3.0|^3|^4|^5|^6.0|^7.0",
-                "symfony/dependency-injection": "^2.3.0|^3|^4|^5|^6.0|^7.0",
-                "symfony/filesystem": "^2.3.0|^3|^4|^5|^6.0|^7.0",
-                "symfony/polyfill-mbstring": "^1.19"
-            },
-            "require-dev": {
-                "easy-doc/easy-doc": "0.0.0|^1.2.3",
-                "gregwar/rst": "^1.0",
-                "squizlabs/php_codesniffer": "^2.0.0"
-            },
-            "bin": [
-                "src/bin/pdepend"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PDepend\\": "src/main/php/PDepend"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Official version of pdepend to be handled with Composer",
-            "keywords": [
-                "PHP Depend",
-                "PHP_Depend",
-                "dev",
-                "pdepend"
-            ],
-            "support": {
-                "issues": "https://github.com/pdepend/pdepend/issues",
-                "source": "https://github.com/pdepend/pdepend/tree/2.16.2"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/pdepend/pdepend",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-12-17T18:09:59+00:00"
-        },
-        {
             "name": "phar-io/manifest",
             "version": "2.0.4",
             "source": {
@@ -10495,89 +10432,6 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
-        },
-        {
-            "name": "phpmd/phpmd",
-            "version": "2.15.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "74a1f56e33afad4128b886e334093e98e1b5e7c0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/74a1f56e33afad4128b886e334093e98e1b5e7c0",
-                "reference": "74a1f56e33afad4128b886e334093e98e1b5e7c0",
-                "shasum": ""
-            },
-            "require": {
-                "composer/xdebug-handler": "^1.0 || ^2.0 || ^3.0",
-                "ext-xml": "*",
-                "pdepend/pdepend": "^2.16.1",
-                "php": ">=5.3.9"
-            },
-            "require-dev": {
-                "easy-doc/easy-doc": "0.0.0 || ^1.3.2",
-                "ext-json": "*",
-                "ext-simplexml": "*",
-                "gregwar/rst": "^1.0",
-                "mikey179/vfsstream": "^1.6.8",
-                "squizlabs/php_codesniffer": "^2.9.2 || ^3.7.2"
-            },
-            "bin": [
-                "src/bin/phpmd"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "PHPMD\\": "src/main/php"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Manuel Pichler",
-                    "email": "github@manuel-pichler.de",
-                    "homepage": "https://github.com/manuelpichler",
-                    "role": "Project Founder"
-                },
-                {
-                    "name": "Marc Würth",
-                    "email": "ravage@bluewin.ch",
-                    "homepage": "https://github.com/ravage84",
-                    "role": "Project Maintainer"
-                },
-                {
-                    "name": "Other contributors",
-                    "homepage": "https://github.com/phpmd/phpmd/graphs/contributors",
-                    "role": "Contributors"
-                }
-            ],
-            "description": "PHPMD is a spin-off project of PHP Depend and aims to be a PHP equivalent of the well known Java tool PMD.",
-            "homepage": "https://phpmd.org/",
-            "keywords": [
-                "dev",
-                "mess detection",
-                "mess detector",
-                "pdepend",
-                "phpmd",
-                "pmd"
-            ],
-            "support": {
-                "irc": "irc://irc.freenode.org/phpmd",
-                "issues": "https://github.com/phpmd/phpmd/issues",
-                "source": "https://github.com/phpmd/phpmd/tree/2.15.0"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpmd/phpmd",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-12-11T08:22:20+00:00"
         },
         {
             "name": "phpstan/extension-installer",

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,6 +20,11 @@ services:
             - '../src/Entity/'
             - '../src/Kernel.php'
 
+    # Explicit alias: in dev the UnlimitedBoosterClaimQuota decorator also
+    # implements the interface, which breaks the automatic alias. Pointing at
+    # the decorated service id resolves to the decorator chain when present.
+    App\Service\Booster\BoosterClaimQuotaInterface: '@App\Service\Booster\DailyBoosterClaimQuota'
+
 when@test:
     services:
         _defaults:

--- a/fixtures/Booster.yaml
+++ b/fixtures/Booster.yaml
@@ -6,7 +6,7 @@ App\Entity\Booster:
         rarityRates:
             - { common: 100 }
             - { common: 100 }
-            - { common: 60, rare: 30, legendary: 10 }
+            - { common: 55, rare: 25, epic: 15, legendary: 5 }
     booster_bleach:
         extension: '@extension_bleach'
         imageName: 'default_card.png'

--- a/fixtures/Card.yaml
+++ b/fixtures/Card.yaml
@@ -36,7 +36,7 @@ App\Entity\Card:
         unique: true
         imageName: 'default_card.png'
         status: 2
-        rarity: 'rare'
+        rarity: 'epic'
     card_magic_king_julian:
         name: 'Magic King Julian'
         extension: '@extension_magic'

--- a/fixtures/UserBooster.yaml
+++ b/fixtures/UserBooster.yaml
@@ -1,0 +1,9 @@
+App\Entity\UserBooster:
+    user_booster_barlito_cyberpunk:
+        discordUser: '@discord_user_barlito'
+        booster: '@booster_cyberpunk'
+        quantity: 3
+    user_booster_barlito_bleach:
+        discordUser: '@discord_user_barlito'
+        booster: '@booster_bleach'
+        quantity: 1

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,20 +55,8 @@ parameters:
 			path: src/Doctrine/DBAL/FunctionNode/Random.php
 
 		-
-			message: '#^Property App\\Entity\\Booster\:\:\$updatedAt \(DateTime\|null\) does not accept DateTimeImmutable\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: src/Entity/Booster.php
-
-		-
 			message: '#^Method App\\Entity\\Card\:\:getExtension\(\) should return App\\Entity\\Extension but returns App\\Entity\\Extension\|null\.$#'
 			identifier: return.type
-			count: 1
-			path: src/Entity/Card.php
-
-		-
-			message: '#^Property App\\Entity\\Card\:\:\$imageFoilFile \(Symfony\\Component\\HttpFoundation\\File\\File\|null\) is never assigned Symfony\\Component\\HttpFoundation\\File\\File so it can be removed from the property type\.$#'
-			identifier: property.unusedType
 			count: 1
 			path: src/Entity/Card.php
 
@@ -76,12 +64,6 @@ parameters:
 			message: '#^Property App\\Entity\\Card\:\:\$imageName type mapping mismatch\: property can contain string\|null but database expects string\.$#'
 			identifier: doctrine.columnType
 			count: 1
-			path: src/Entity/Card.php
-
-		-
-			message: '#^Property App\\Entity\\Card\:\:\$updatedAt \(DateTime\|null\) does not accept DateTimeImmutable\.$#'
-			identifier: assign.propertyType
-			count: 3
 			path: src/Entity/Card.php
 
 		-

--- a/src/Entity/Booster.php
+++ b/src/Entity/Booster.php
@@ -120,7 +120,7 @@ class Booster implements \Stringable
         $this->imageFile = $imageFile;
 
         if ($imageFile instanceof File) {
-            $this->updatedAt = new \DateTimeImmutable();
+            $this->updatedAt = new \DateTime();
         }
     }
 

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -145,7 +145,7 @@ class Card
     {
         $this->imageFile = $imageFile;
 
-        $this->updatedAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTime();
     }
 
     public function getImageFile(): ?File
@@ -177,7 +177,7 @@ class Card
         if ($imageMaskFile instanceof File) {
             // It is required that at least one field changes if you are using doctrine
             // otherwise the event listeners won't be called and the file is lost
-            $this->updatedAt = new \DateTimeImmutable();
+            $this->updatedAt = new \DateTime();
         }
     }
 
@@ -205,12 +205,12 @@ class Card
      */
     public function setFoilImageFile(?File $imageFoilFile = null): void
     {
-        $this->imageMaskFile = $imageFoilFile;
+        $this->imageFoilFile = $imageFoilFile;
 
         if ($imageFoilFile instanceof File) {
             // It is required that at least one field changes if you are using doctrine
             // otherwise the event listeners won't be called and the file is lost
-            $this->updatedAt = new \DateTimeImmutable();
+            $this->updatedAt = new \DateTime();
         }
     }
 

--- a/src/Enum/Entity/CardRarityEnum.php
+++ b/src/Enum/Entity/CardRarityEnum.php
@@ -9,6 +9,7 @@ enum CardRarityEnum: string
     case COMMON = 'common';
     case UNCOMMON = 'uncommon';
     case RARE = 'rare';
+    case EPIC = 'epic';
     case LEGENDARY = 'legendary';
 
     /**
@@ -16,6 +17,6 @@ enum CardRarityEnum: string
      */
     public static function ascending(): array
     {
-        return [self::COMMON, self::UNCOMMON, self::RARE, self::LEGENDARY];
+        return [self::COMMON, self::UNCOMMON, self::RARE, self::EPIC, self::LEGENDARY];
     }
 }

--- a/src/Repository/BoosterRepository.php
+++ b/src/Repository/BoosterRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Booster;
+use App\Enum\Entity\ExtensionStatusEnum;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -21,5 +22,20 @@ class BoosterRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Booster::class);
+    }
+
+    /**
+     * @return list<Booster>
+     */
+    public function findPublished(): array
+    {
+        return $this->createQueryBuilder('booster')
+            ->join('booster.extension', 'extension')
+            ->andWhere('extension.status = :status')
+            ->setParameter('status', ExtensionStatusEnum::PUBLISHED)
+            ->orderBy('extension.name', 'ASC')
+            ->getQuery()
+            ->getResult()
+        ;
     }
 }

--- a/src/Service/Booster/BoosterClaimQuotaInterface.php
+++ b/src/Service/Booster/BoosterClaimQuotaInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Entity\DiscordUser;
+
+/**
+ * Quota policy for daily free booster claims.
+ */
+interface BoosterClaimQuotaInterface
+{
+    public const int DAILY_LIMIT = 2;
+
+    public function getRemainingClaims(DiscordUser $discordUser): int;
+
+    public function getNextResetTime(): \DateTimeImmutable;
+}

--- a/src/Service/Booster/BoosterClaimService.php
+++ b/src/Service/Booster/BoosterClaimService.php
@@ -8,23 +8,18 @@ use App\Entity\Booster;
 use App\Entity\BoosterClaim;
 use App\Entity\DiscordUser;
 use App\Exception\Booster\DailyClaimLimitReachedException;
-use App\Repository\BoosterClaimRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
 
 /**
- * Daily free booster claims: every player can claim DAILY_LIMIT boosters per
- * day, the quota resets at midnight Europe/Paris. Claimed boosters land in
- * the UserBooster inventory and can be opened later.
+ * Daily free booster claims: the quota policy (BoosterClaimQuotaInterface)
+ * decides how many claims are left; a claim credits the UserBooster
+ * inventory and leaves a BoosterClaim audit row.
  */
 final readonly class BoosterClaimService
 {
-    public const int DAILY_LIMIT = 2;
-
-    private const string TIMEZONE = 'Europe/Paris';
-
     public function __construct(
-        private BoosterClaimRepository $boosterClaimRepository,
+        private BoosterClaimQuotaInterface $quota,
         private UserInventoryService $userInventoryService,
         private EntityManagerInterface $entityManager,
         private ClockInterface $clock,
@@ -33,9 +28,12 @@ final readonly class BoosterClaimService
 
     public function getRemainingClaims(DiscordUser $discordUser): int
     {
-        $claimsToday = $this->boosterClaimRepository->countSince($discordUser, $this->startOfToday());
+        return $this->quota->getRemainingClaims($discordUser);
+    }
 
-        return max(0, self::DAILY_LIMIT - $claimsToday);
+    public function getNextResetTime(): \DateTimeImmutable
+    {
+        return $this->quota->getNextResetTime();
     }
 
     /**
@@ -43,8 +41,8 @@ final readonly class BoosterClaimService
      */
     public function claim(DiscordUser $discordUser, Booster $booster): BoosterClaim
     {
-        if ($this->getRemainingClaims($discordUser) < 1) {
-            throw new DailyClaimLimitReachedException(\sprintf('Daily limit of %d boosters reached, come back tomorrow.', self::DAILY_LIMIT));
+        if ($this->quota->getRemainingClaims($discordUser) < 1) {
+            throw new DailyClaimLimitReachedException(\sprintf('Daily limit of %d boosters reached, come back tomorrow.', BoosterClaimQuotaInterface::DAILY_LIMIT));
         }
 
         $this->userInventoryService->creditBooster($discordUser, $booster);
@@ -54,23 +52,5 @@ final readonly class BoosterClaimService
         $this->entityManager->flush();
 
         return $claim;
-    }
-
-    public function getNextResetTime(): \DateTimeImmutable
-    {
-        return $this->startOfToday()->modify('+1 day');
-    }
-
-    /**
-     * Midnight Europe/Paris expressed as an absolute point in time, so the
-     * comparison with UTC-stored claimed_at timestamps stays correct across
-     * DST changes.
-     */
-    private function startOfToday(): \DateTimeImmutable
-    {
-        return $this->clock->now()
-            ->setTimezone(new \DateTimeZone(self::TIMEZONE))
-            ->setTime(0, 0)
-        ;
     }
 }

--- a/src/Service/Booster/DailyBoosterClaimQuota.php
+++ b/src/Service/Booster/DailyBoosterClaimQuota.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Entity\DiscordUser;
+use App\Repository\BoosterClaimRepository;
+use Psr\Clock\ClockInterface;
+
+/**
+ * Production quota: DAILY_LIMIT claims per day, resetting at midnight
+ * Europe/Paris. Counts BoosterClaim rows since the last reset — no mutable
+ * counter anywhere.
+ */
+final readonly class DailyBoosterClaimQuota implements BoosterClaimQuotaInterface
+{
+    private const string TIMEZONE = 'Europe/Paris';
+
+    public function __construct(
+        private BoosterClaimRepository $boosterClaimRepository,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    public function getRemainingClaims(DiscordUser $discordUser): int
+    {
+        $claimsToday = $this->boosterClaimRepository->countSince($discordUser, $this->startOfToday());
+
+        return max(0, self::DAILY_LIMIT - $claimsToday);
+    }
+
+    public function getNextResetTime(): \DateTimeImmutable
+    {
+        return $this->startOfToday()->modify('+1 day');
+    }
+
+    /**
+     * Midnight Europe/Paris expressed as an absolute point in time, so the
+     * comparison with UTC-stored claimed_at timestamps stays correct across
+     * DST changes.
+     */
+    private function startOfToday(): \DateTimeImmutable
+    {
+        return $this->clock->now()
+            ->setTimezone(new \DateTimeZone(self::TIMEZONE))
+            ->setTime(0, 0)
+        ;
+    }
+}

--- a/src/Service/Booster/UnlimitedBoosterClaimQuota.php
+++ b/src/Service/Booster/UnlimitedBoosterClaimQuota.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Entity\DiscordUser;
+use Symfony\Component\DependencyInjection\Attribute\AsDecorator;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\DependencyInjection\Attribute\When;
+
+/**
+ * Dev-only decorator: lifts the daily claim limit so boosters can be opened
+ * repeatedly while testing. Never registered outside the dev environment;
+ * set BOOSTER_DAILY_LIMIT_ENABLED=true (.env.dev) to restore the real quota.
+ */
+#[When(env: 'dev')]
+#[AsDecorator(decorates: DailyBoosterClaimQuota::class)]
+final readonly class UnlimitedBoosterClaimQuota implements BoosterClaimQuotaInterface
+{
+    public function __construct(
+        private BoosterClaimQuotaInterface $inner,
+        #[Autowire(env: 'bool:BOOSTER_DAILY_LIMIT_ENABLED')]
+        private bool $dailyLimitEnabled,
+    ) {
+    }
+
+    public function getRemainingClaims(DiscordUser $discordUser): int
+    {
+        if ($this->dailyLimitEnabled) {
+            return $this->inner->getRemainingClaims($discordUser);
+        }
+
+        return self::DAILY_LIMIT;
+    }
+
+    public function getNextResetTime(): \DateTimeImmutable
+    {
+        return $this->inner->getNextResetTime();
+    }
+}

--- a/tests/Functional/JwtAuthTrait.php
+++ b/tests/Functional/JwtAuthTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\DiscordUser;
+use App\Repository\DiscordUserRepository;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\BrowserKit\Cookie;
+
+/**
+ * Authenticates the test client the same way production works: a signed JWT
+ * in the "jwt" cookie (stateless firewall, cookie extractor).
+ */
+trait JwtAuthTrait
+{
+    private function authenticateClient(KernelBrowser $client, string $discordId = '188967649332428800'): DiscordUser
+    {
+        $user = static::getContainer()->get(DiscordUserRepository::class)->find($discordId);
+
+        if (!$user instanceof DiscordUser) {
+            throw new \LogicException(\sprintf('Fixture user "%s" not found, load the alice fixtures first.', $discordId));
+        }
+
+        $token = static::getContainer()->get(JWTTokenManagerInterface::class)->create($user);
+        $client->getCookieJar()->set(new Cookie('jwt', $token));
+
+        return $user;
+    }
+}

--- a/tests/Unit/Service/BoosterClaimServiceTest.php
+++ b/tests/Unit/Service/BoosterClaimServiceTest.php
@@ -7,7 +7,7 @@ namespace App\Tests\Unit\Service;
 use App\Entity\Booster;
 use App\Entity\DiscordUser;
 use App\Exception\Booster\DailyClaimLimitReachedException;
-use App\Repository\BoosterClaimRepository;
+use App\Service\Booster\BoosterClaimQuotaInterface;
 use App\Service\Booster\BoosterClaimService;
 use App\Service\Booster\UserInventoryService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -16,22 +16,6 @@ use Symfony\Component\Clock\MockClock;
 
 final class BoosterClaimServiceTest extends TestCase
 {
-    public function testRemainingClaimsCountsDownFromTheDailyLimit(): void
-    {
-        $user = new DiscordUser();
-
-        foreach ([0 => 2, 1 => 1, 2 => 0, 3 => 0] as $claimsToday => $expectedRemaining) {
-            $service = new BoosterClaimService(
-                $this->claimRepositoryCounting($claimsToday),
-                $this->createStub(UserInventoryService::class),
-                $this->createStub(EntityManagerInterface::class),
-                new MockClock('2026-06-10 12:00:00', 'UTC'),
-            );
-
-            $this->assertSame($expectedRemaining, $service->getRemainingClaims($user));
-        }
-    }
-
     public function testClaimCreditsTheInventoryAndPersistsAnAuditRow(): void
     {
         $clock = new MockClock('2026-06-10 12:00:00', 'UTC');
@@ -45,7 +29,7 @@ final class BoosterClaimServiceTest extends TestCase
         $entityManager->expects($this->once())->method('persist');
         $entityManager->expects($this->once())->method('flush');
 
-        $service = new BoosterClaimService($this->claimRepositoryCounting(0), $inventory, $entityManager, $clock);
+        $service = new BoosterClaimService($this->quotaWithRemaining(2), $inventory, $entityManager, $clock);
 
         $claim = $service->claim($user, $booster);
 
@@ -54,13 +38,13 @@ final class BoosterClaimServiceTest extends TestCase
         $this->assertEquals($clock->now(), $claim->getClaimedAt());
     }
 
-    public function testClaimThrowsOnceTheDailyLimitIsReached(): void
+    public function testClaimThrowsOnceTheQuotaIsExhausted(): void
     {
         $inventory = $this->createMock(UserInventoryService::class);
         $inventory->expects($this->never())->method('creditBooster');
 
         $service = new BoosterClaimService(
-            $this->claimRepositoryCounting(BoosterClaimService::DAILY_LIMIT),
+            $this->quotaWithRemaining(0),
             $inventory,
             $this->createStub(EntityManagerInterface::class),
             new MockClock('2026-06-10 12:00:00', 'UTC'),
@@ -71,64 +55,29 @@ final class BoosterClaimServiceTest extends TestCase
         $service->claim(new DiscordUser(), new Booster());
     }
 
-    public function testQuotaWindowStartsAtMidnightParisInWinter(): void
+    public function testQuotaAccessorsDelegateToThePolicy(): void
     {
-        // 2026-01-15 23:30 UTC is already 2026-01-16 00:30 in Paris (UTC+1):
-        // the window must start at 23:00 UTC = midnight Paris of the new day.
-        $this->assertQuotaWindowStartsAt('2026-01-15 23:00:00', clockNow: '2026-01-15 23:30:00');
-    }
+        $resetTime = new \DateTimeImmutable('2026-06-11 00:00:00');
+        $quota = $this->createStub(BoosterClaimQuotaInterface::class);
+        $quota->method('getRemainingClaims')->willReturn(1);
+        $quota->method('getNextResetTime')->willReturn($resetTime);
 
-    public function testQuotaWindowStartsAtMidnightParisInSummer(): void
-    {
-        // 2026-06-10 12:00 UTC = 14:00 Paris (UTC+2): the window must start
-        // at 2026-06-09 22:00 UTC = midnight Paris the same day.
-        $this->assertQuotaWindowStartsAt('2026-06-09 22:00:00', clockNow: '2026-06-10 12:00:00');
-    }
-
-    public function testNextResetTimeIsTheUpcomingMidnightParis(): void
-    {
         $service = new BoosterClaimService(
-            $this->claimRepositoryCounting(0),
+            $quota,
             $this->createStub(UserInventoryService::class),
             $this->createStub(EntityManagerInterface::class),
             new MockClock('2026-06-10 12:00:00', 'UTC'),
         );
 
-        $nextReset = $service->getNextResetTime()->setTimezone(new \DateTimeZone('UTC'));
-
-        // Midnight Paris on June 11th is 22:00 UTC on June 10th.
-        $this->assertSame('2026-06-10 22:00:00', $nextReset->format('Y-m-d H:i:s'));
+        $this->assertSame(1, $service->getRemainingClaims(new DiscordUser()));
+        $this->assertSame($resetTime, $service->getNextResetTime());
     }
 
-    private function assertQuotaWindowStartsAt(string $expectedUtcWindowStart, string $clockNow): void
+    private function quotaWithRemaining(int $remaining): BoosterClaimQuotaInterface
     {
-        $claimRepository = $this->createMock(BoosterClaimRepository::class);
-        $claimRepository->expects($this->once())
-            ->method('countSince')
-            ->with(
-                $this->anything(),
-                $this->callback(
-                    static fn (\DateTimeImmutable $since): bool => $expectedUtcWindowStart === $since->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
-                ),
-            )
-            ->willReturn(0)
-        ;
+        $quota = $this->createStub(BoosterClaimQuotaInterface::class);
+        $quota->method('getRemainingClaims')->willReturn($remaining);
 
-        $service = new BoosterClaimService(
-            $claimRepository,
-            $this->createStub(UserInventoryService::class),
-            $this->createStub(EntityManagerInterface::class),
-            new MockClock($clockNow, 'UTC'),
-        );
-
-        $this->assertSame(BoosterClaimService::DAILY_LIMIT, $service->getRemainingClaims(new DiscordUser()));
-    }
-
-    private function claimRepositoryCounting(int $claimsToday): BoosterClaimRepository
-    {
-        $claimRepository = $this->createStub(BoosterClaimRepository::class);
-        $claimRepository->method('countSince')->willReturn($claimsToday);
-
-        return $claimRepository;
+        return $quota;
     }
 }

--- a/tests/Unit/Service/DailyBoosterClaimQuotaTest.php
+++ b/tests/Unit/Service/DailyBoosterClaimQuotaTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\DiscordUser;
+use App\Repository\BoosterClaimRepository;
+use App\Service\Booster\BoosterClaimQuotaInterface;
+use App\Service\Booster\DailyBoosterClaimQuota;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Clock\MockClock;
+
+final class DailyBoosterClaimQuotaTest extends TestCase
+{
+    public function testRemainingClaimsCountsDownFromTheDailyLimit(): void
+    {
+        $user = new DiscordUser();
+
+        foreach ([0 => 2, 1 => 1, 2 => 0, 3 => 0] as $claimsToday => $expectedRemaining) {
+            $quota = new DailyBoosterClaimQuota(
+                $this->claimRepositoryCounting($claimsToday),
+                new MockClock('2026-06-10 12:00:00', 'UTC'),
+            );
+
+            $this->assertSame($expectedRemaining, $quota->getRemainingClaims($user));
+        }
+    }
+
+    public function testQuotaWindowStartsAtMidnightParisInWinter(): void
+    {
+        // 2026-01-15 23:30 UTC is already 2026-01-16 00:30 in Paris (UTC+1):
+        // the window must start at 23:00 UTC = midnight Paris of the new day.
+        $this->assertQuotaWindowStartsAt('2026-01-15 23:00:00', clockNow: '2026-01-15 23:30:00');
+    }
+
+    public function testQuotaWindowStartsAtMidnightParisInSummer(): void
+    {
+        // 2026-06-10 12:00 UTC = 14:00 Paris (UTC+2): the window must start
+        // at 2026-06-09 22:00 UTC = midnight Paris the same day.
+        $this->assertQuotaWindowStartsAt('2026-06-09 22:00:00', clockNow: '2026-06-10 12:00:00');
+    }
+
+    public function testNextResetTimeIsTheUpcomingMidnightParis(): void
+    {
+        $quota = new DailyBoosterClaimQuota(
+            $this->claimRepositoryCounting(0),
+            new MockClock('2026-06-10 12:00:00', 'UTC'),
+        );
+
+        $nextReset = $quota->getNextResetTime()->setTimezone(new \DateTimeZone('UTC'));
+
+        // Midnight Paris on June 11th is 22:00 UTC on June 10th.
+        $this->assertSame('2026-06-10 22:00:00', $nextReset->format('Y-m-d H:i:s'));
+    }
+
+    private function assertQuotaWindowStartsAt(string $expectedUtcWindowStart, string $clockNow): void
+    {
+        $claimRepository = $this->createMock(BoosterClaimRepository::class);
+        $claimRepository->expects($this->once())
+            ->method('countSince')
+            ->with(
+                $this->anything(),
+                $this->callback(
+                    static fn (\DateTimeImmutable $since): bool => $expectedUtcWindowStart === $since->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d H:i:s'),
+                ),
+            )
+            ->willReturn(0)
+        ;
+
+        $quota = new DailyBoosterClaimQuota($claimRepository, new MockClock($clockNow, 'UTC'));
+
+        $this->assertSame(BoosterClaimQuotaInterface::DAILY_LIMIT, $quota->getRemainingClaims(new DiscordUser()));
+    }
+
+    private function claimRepositoryCounting(int $claimsToday): BoosterClaimRepository
+    {
+        $claimRepository = $this->createStub(BoosterClaimRepository::class);
+        $claimRepository->method('countSince')->willReturn($claimsToday);
+
+        return $claimRepository;
+    }
+}

--- a/tests/Unit/Service/UnlimitedBoosterClaimQuotaTest.php
+++ b/tests/Unit/Service/UnlimitedBoosterClaimQuotaTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\DiscordUser;
+use App\Service\Booster\BoosterClaimQuotaInterface;
+use App\Service\Booster\UnlimitedBoosterClaimQuota;
+use PHPUnit\Framework\TestCase;
+
+final class UnlimitedBoosterClaimQuotaTest extends TestCase
+{
+    public function testDisabledLimitAlwaysReportsFullQuotaWithoutHittingTheInnerQuota(): void
+    {
+        $inner = $this->createMock(BoosterClaimQuotaInterface::class);
+        $inner->expects($this->never())->method('getRemainingClaims');
+
+        $quota = new UnlimitedBoosterClaimQuota($inner, dailyLimitEnabled: false);
+
+        $this->assertSame(BoosterClaimQuotaInterface::DAILY_LIMIT, $quota->getRemainingClaims(new DiscordUser()));
+    }
+
+    public function testEnabledLimitDelegatesToTheInnerQuota(): void
+    {
+        $user = new DiscordUser();
+        $inner = $this->createMock(BoosterClaimQuotaInterface::class);
+        $inner->expects($this->once())->method('getRemainingClaims')->with($user)->willReturn(1);
+
+        $quota = new UnlimitedBoosterClaimQuota($inner, dailyLimitEnabled: true);
+
+        $this->assertSame(1, $quota->getRemainingClaims($user));
+    }
+
+    public function testNextResetTimeAlwaysDelegates(): void
+    {
+        $resetTime = new \DateTimeImmutable('2026-06-11 00:00:00');
+        $inner = $this->createStub(BoosterClaimQuotaInterface::class);
+        $inner->method('getNextResetTime')->willReturn($resetTime);
+
+        $quota = new UnlimitedBoosterClaimQuota($inner, dailyLimitEnabled: false);
+
+        $this->assertSame($resetTime, $quota->getNextResetTime());
+    }
+}


### PR DESCRIPTION
Dernière brique **moteur** de la Phase 1 (stack : 1a → 1b → 1c → **1d**). Remplace la #29 : l'UI d'ouverture arrivera directement sous le design « Violet Arcade » en phase 2 (handoff dans `.claude/`, non versionné).

### Contenu (que du code, des tests et des fixes)
- **fix(entity)** : les setters Vich assignaient un `DateTimeImmutable` à la colonne Gedmo mutable → **tout flush après hydratation d'une Card plantait** (`inject_on_load`) ; + `setFoilImageFile` qui écrivait dans `imageMaskFile`
- **feat(card)** : tier **epic** → 5 raretés `common/uncommon/rare/epic/legendary` (blanc/vert/bleu/violet/orange — les couleurs CSS arrivent avec la UI). Zéro migration (varchar)
- **refactor(claim)** : politique de quota derrière `BoosterClaimQuotaInterface` ; en dev uniquement, le décorateur `UnlimitedBoosterClaimQuota` (`#[When(env: 'dev')]` + `#[AsDecorator]`) lève la limite via `BOOSTER_DAILY_LIMIT_ENABLED` (var présente seulement dans `.env.dev`) — aucun bypass en prod
- **feat(booster)** : `BoosterRepository::findPublished()`, fixtures `UserBooster` (inventaire dev pré-rempli), trait `JwtAuthTrait` (auth par cookie JWT pour les futurs tests fonctionnels)
- **chore** : retrait phpmd (pdepend incompatible PHP 8.4), cible `make tailwind.build` + step CI, `.claude/` local gitignoré, baseline PHPStan 59 → 54

### Tests
31 au total : unitaires quota (fenêtre minuit Paris + DST, décorateur, claim) en plus des suites 1c (tirage, intégration ouverture).

La branche `feat/phase-1-booster-opening` (ex-#29) est conservée comme **référence** pour la phase 2 : hub Live Component fonctionnel, animation de reveal (flip séquentiel + glow par rareté), modale anti-morphing — à recycler sous le nouveau design.