### PR TITLE
feat(dev): page de démo des effets de cartes (/dev/card-effects)

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -3,3 +3,8 @@ controllers:
         path: ../src/Controller/
         namespace: App\Controller
     type: attribute
+
+when@dev:
+    dev_card_effects:
+        path: /dev/card-effects
+        controller: App\Controller\Dev\CardEffectsDemoController

--- a/src/Controller/Dev/CardEffectsDemoController.php
+++ b/src/Controller/Dev/CardEffectsDemoController.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Dev;
+
+use App\Entity\Card;
+use App\Enum\Entity\CardStatusEnum;
+use App\Repository\CardRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\Attribute\When;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Dev-only showcase of card visual effects: the same card rendered with
+ * different glow colors (--card-glow inherited from a wrapper), 3D tilt and
+ * glare on hover. Previews the future extension-level visual config
+ * (default glow/borders per extension, overridable per card).
+ *
+ * The service only exists in the dev container (#[When]) and the route is
+ * declared in config/routes.yaml under when@dev (a #[Route] attribute would
+ * be picked up by the route scanner in every environment).
+ */
+#[When(env: 'dev')]
+class CardEffectsDemoController extends AbstractController
+{
+    /**
+     * Demo glow palette. The first ten mirror the legacy .card.<type> colors
+     * still present in assets/styles/cards/base.css; the last entries show
+     * that any color works (the future config will be a free value).
+     */
+    private const array GLOW_PALETTE = [
+        'azur (ex water)' => 'hsl(192, 97%, 60%)',
+        'braise (ex fire)' => 'hsl(9, 81%, 59%)',
+        'sève (ex grass)' => 'hsl(96, 81%, 65%)',
+        'volt (ex lightning)' => 'hsl(54, 87%, 63%)',
+        'nébule (ex psychic)' => 'hsl(281, 62%, 58%)',
+        'terre (ex fighting)' => 'rgb(145, 90, 39)',
+        'abysse (ex darkness)' => 'hsl(189, 77%, 27%)',
+        'chrome (ex metal)' => 'hsl(184, 20%, 70%)',
+        'or (ex dragon)' => 'hsl(51, 60%, 35%)',
+        'rose (ex fairy)' => 'hsl(323, 100%, 89%)',
+        'violet arcade' => '#a435f0',
+        'magenta arcade' => '#ff3db0',
+    ];
+
+    public function __invoke(CardRepository $cardRepository): Response
+    {
+        $referenceCard = $cardRepository->findOneBy(['status' => CardStatusEnum::PUBLISHED])
+            ?? throw $this->createNotFoundException('No published card found, load the fixtures first.');
+
+        $demos = [];
+
+        foreach (self::GLOW_PALETTE as $label => $glow) {
+            $demos[] = [
+                'card' => $this->variant($referenceCard, $label, $glow),
+                'label' => $label,
+                'glow' => $glow,
+            ];
+        }
+
+        return $this->render('dev/card_effects.html.twig', [
+            'demos' => $demos,
+        ]);
+    }
+
+    /**
+     * Transient clone, never persisted: same artwork, demo label.
+     */
+    private function variant(Card $referenceCard, string $label, string $glow): Card
+    {
+        $variant = clone $referenceCard;
+        $variant->setName(ucfirst($label));
+        $variant->setDescription(\sprintf('--card-glow: %s', $glow));
+
+        return $variant;
+    }
+}

--- a/templates/dev/card_effects.html.twig
+++ b/templates/dev/card_effects.html.twig
@@ -1,0 +1,57 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    DEV — Effets de cartes
+{% endblock %}
+
+{% block body %}
+    <style>
+        /* Force le glow "active" en permanence (sans survol) pour comparer les couleurs.
+           Copie du box-shadow de `.card.active .card__rotator` dans cards/base.css. */
+        .force-glow .card .card__rotator {
+            box-shadow:
+                0 0 3px -1px white,
+                0 0 3px 1px var(--card-edge),
+                0 0 12px 2px var(--card-glow),
+                0px 10px 20px -5px black,
+                0 0 40px -30px var(--card-glow),
+                0 0 50px -20px var(--card-glow);
+        }
+    </style>
+
+    <main class="container mx-auto py-10 px-4">
+        <div class="mb-8">
+            <p class="text-sm font-mono uppercase tracking-widest text-purple-400">dev only · /dev/card-effects</p>
+            <h1 class="text-4xl font-bold text-white mt-1">Effets de cartes — palette de glows</h1>
+            <p class="text-gray-300 mt-2 max-w-3xl">
+                Le glow d'une carte = la variable CSS <code class="text-purple-300">--card-glow</code>, héritée ici
+                d'un simple wrapper (<code class="text-purple-300">style="--card-glow: …"</code>) — n'importe quelle
+                couleur fonctionne. C'est le mécanisme que la future <strong>config visuelle par extension</strong>
+                (override par carte) pilotera. Le glow est forcé en permanence ; <strong>survole une carte</strong>
+                pour le 3D interactif + glare.
+            </p>
+        </div>
+
+        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            {% for demo in demos %}
+                <div class="force-glow" style="--card-glow: {{ demo.glow }};">
+                    {{ include('components/CardComponent.html.twig', { card: demo.card }) }}
+                    <div class="mt-2 flex items-center gap-2 px-1">
+                        <span class="inline-block w-4 h-4 rounded-full border border-white/30" style="background: {{ demo.glow }};"></span>
+                        <code class="text-sm text-gray-200">{{ demo.label }}</code>
+                        <span class="text-xs text-gray-400 font-mono">{{ demo.glow }}</span>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+
+        <div class="mt-12 bg-slate-800/60 border border-slate-700 rounded-xl p-6 max-w-3xl">
+            <h2 class="text-xl font-bold text-white mb-3">Notes</h2>
+            <ul class="text-gray-300 space-y-2 list-disc list-inside">
+                <li><strong>Plus de champ <code>Card.type</code></strong> : la custom visuelle (glow, borders, aspects CSS) sera une config au niveau Extension, overridable par carte (phase future). Les classes <code>.card.water</code>… de base.css sont un legacy à nettoyer à ce moment-là.</li>
+                <li><strong>Calques holo/foil</strong> : <code>.card__shine</code> est vide — le rendu façon poke-holo arrive avec la phase 2 (cf. RAPPORT-CARTES-HOLO).</li>
+                <li><strong>Glow par rareté</strong> (<code>data-rarity</code> posé, sans CSS) — arrive avec l'UI d'ouverture phase 2.</li>
+            </ul>
+        </div>
+    </main>
+{% endblock %}


### PR DESCRIPTION
Page **dev only** `/dev/card-effects` : la même carte rendue une fois par valeur de `CardTypeEnum` (+ une sans type), glow "active" forcé pour comparer les couleurs, 3D interactif au survol. Légende = nom du type + couleur exacte.

Objectifs :
- support visuel pour **renommer les types** hérités du CSS Pokémon (water/fire/… n'ont pas de sens pour YOUL) — on choisit les nouveaux noms en regardant les halos ;
- vitrine des effets existants, avec un encart qui liste ce qui arrive en phase 2 (calques holo, glow par rareté, masques foil).

Technique : service `#[When(env: 'dev')]` **et** route déclarée en `when@dev` dans `routes.yaml` — piège vérifié : un attribut `#[Route]` serait scanné dans tous les envs même quand le service n'existe pas (route présente en prod → 500). Route absente en test/prod, page 200 en dev.

Basée sur la stack (1d) — se re-targetera sur master au fil des merges.