### PR TITLE
feat(design): Phase 2a — Violet Arcade design system + layout

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -2,6 +2,37 @@
 @tailwind components;
 @tailwind utilities;
 
-.active{
-    @apply font-bold underline underline-offset-auto decoration-gray-600
+@layer components {
+    /* Bouton primaire arcade : plein, biseauté, typo display condensée */
+    .btn-arcade {
+        @apply inline-block bg-primary px-6 py-3.5 font-display text-sm font-bold uppercase tracking-[.15em] text-white;
+        clip-path: polygon(8px 0, 100% 0, calc(100% - 8px) 100%, 0 100%);
+    }
+
+    .btn-arcade:hover {
+        @apply bg-magenta;
+    }
+
+    /* Bouton secondaire : transparent, hairline */
+    .btn-ghost {
+        @apply inline-block border border-white/20 px-6 py-3.5 font-display text-sm font-bold uppercase tracking-[.15em] text-white;
+    }
+
+    .btn-ghost:hover {
+        @apply border-primary text-primary;
+    }
+
+    /* Eyebrow de section : "01 / CONCEPT" */
+    .eyebrow {
+        @apply font-mono text-[11px] uppercase tracking-[.25em] text-magenta;
+    }
+
+    /* Petites étiquettes monospace (codes, méta) */
+    .chip-mono {
+        @apply font-mono text-[10px] uppercase tracking-[.15em];
+    }
+}
+
+.active {
+    @apply text-primary;
 }

--- a/assets/styles/theme.css
+++ b/assets/styles/theme.css
@@ -1,0 +1,96 @@
+/*
+ * Violet Arcade — design tokens & textures partagées.
+ *
+ * Fichier volontairement hors Tailwind : les variables et les sélecteurs
+ * d'attribut (ex. [data-rarity=…] dans cards/holo.css) ne doivent pas
+ * dépendre de la purge du compiler.
+ */
+
+:root {
+    --bg: #0b0712;
+    --surface: #160e22;
+    --primary: #a435f0;
+    --magenta: #ff3db0;
+    --gradient-brand: linear-gradient(90deg, #a435f0, #ff3db0);
+
+    --text: #f0e8f7;
+    --text-strong: #fff;
+    --text-muted: #b9a8cf;
+    --text-dim: #6a5a8a;
+
+    --hairline: #a435f033;
+    --live: #5be584;
+    --soon: #ffd24a;
+
+    /* Raretés — 5 tiers (mythic/secret du design remappés sur epic/legendary) */
+    --rarity-common: #9aa3b2;
+    --rarity-uncommon: #5be584;
+    --rarity-rare: #54a8ff;
+    --rarity-epic: #a435f0;
+    --rarity-legendary: #ff8a2b;
+}
+
+/* --- Textures ------------------------------------------------------------ */
+
+.scanlines {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+    pointer-events: none;
+    background: repeating-linear-gradient(0deg, transparent 0 2px, #00000030 2px 3px);
+    opacity: .4;
+}
+
+.glow-ambient {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(ellipse at center, #a435f033, transparent 60%);
+    filter: blur(60px);
+}
+
+.hazard-stripes {
+    background-image: repeating-linear-gradient(45deg, #000 0 12px, transparent 12px 24px);
+}
+
+/* --- Formes -------------------------------------------------------------- */
+
+/* Boutons à coins biseautés (pas de border-radius dans ce design) */
+.notched {
+    clip-path: polygon(8px 0, 100% 0, calc(100% - 8px) 100%, 0 100%);
+}
+
+.notched-lg {
+    clip-path: polygon(12px 0, 100% 0, calc(100% - 12px) 100%, 0 100%);
+}
+
+/* Coin bas-gauche coupé (grande tuile magazine) */
+.notched-corner {
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 16px 100%, 0 calc(100% - 16px));
+}
+
+/* Octogone (avatar) — deux coins opposés coupés */
+.notched-avatar {
+    clip-path: polygon(12px 0, 100% 0, 100% calc(100% - 12px), calc(100% - 12px) 100%, 0 100%, 0 12px);
+}
+
+.skew-brand {
+    transform: skewX(-6deg);
+}
+
+/* --- Animations ---------------------------------------------------------- */
+
+@keyframes floatY {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-14px); }
+}
+
+@keyframes marquee {
+    from { transform: translateX(0); }
+    to { transform: translateX(-100%); }
+}
+
+@keyframes holoSpark {
+    0%, 100% { opacity: .2; transform: scale(.6); }
+    50% { opacity: 1; transform: scale(1.4); }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,30 @@ module.exports = {
     "./templates/**/*.html.twig",
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        bg: '#0b0712',
+        surface: '#160e22',
+        primary: { DEFAULT: '#a435f0', on: '#000' },
+        magenta: '#ff3db0',
+        ink: { DEFAULT: '#f0e8f7', strong: '#fff', muted: '#b9a8cf', dim: '#6a5a8a' },
+        hairline: 'rgba(164, 53, 240, 0.2)',
+        live: '#5be584',
+        soon: '#ffd24a',
+        rarity: {
+          common: '#9aa3b2',
+          uncommon: '#5be584',
+          rare: '#54a8ff',
+          epic: '#a435f0',
+          legendary: '#ff8a2b',
+        },
+      },
+      fontFamily: {
+        display: ['"Space Grotesk"', 'sans-serif'],
+        sans: ['Inter', 'ui-sans-serif', 'sans-serif'],
+        mono: ['"JetBrains Mono"', 'monospace'],
+      },
+    },
   },
   plugins: [],
 }

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -21,7 +21,7 @@
         {% endblock %}
     {% endblock %}
 </head>
-<body class="min-h-screen bg-bg font-sans text-ink antialiased">
+<body class="flex min-h-screen flex-col bg-bg font-sans text-ink antialiased">
 <div class="scanlines" aria-hidden="true"></div>
 {% block header %}
     {{ include('parts/_header.html.twig') }}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -2,11 +2,16 @@
 <html lang="fr">
 <head>
     <meta charset="UTF-8">
-    <title>{% block title %}YTCG{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}YOUL TCG{% endblock %}</title>
     <link rel="icon"
           href="{{ asset('images/ytcg_logo.png') }}">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;700&display=swap">
     {% block stylesheets %}
         <link rel="stylesheet" href="{{ asset('styles/app.css') }}">
+        <link rel="stylesheet" href="{{ asset('styles/theme.css') }}">
         <link rel="stylesheet" href="{{ asset('styles/cards/base.css') }}">
     {% endblock %}
 
@@ -16,11 +21,15 @@
         {% endblock %}
     {% endblock %}
 </head>
-<body class="min-h-screen bg-gray-700">
+<body class="min-h-screen bg-bg font-sans text-ink antialiased">
+<div class="scanlines" aria-hidden="true"></div>
 {% block header %}
     {{ include('parts/_header.html.twig') }}
 {% endblock %}
 {% block body %}
+{% endblock %}
+{% block footer %}
+    {{ include('parts/_footer.html.twig') }}
 {% endblock %}
 </body>
 </html>

--- a/templates/pages/coming_soon.html.twig
+++ b/templates/pages/coming_soon.html.twig
@@ -1,15 +1,21 @@
 {% extends 'base.html.twig' %}
 
 {% block title %}
-    YTCG - Coming Soon TM
+    YOUL TCG — Coming soon
 {% endblock %}
 
 {% block body %}
-    <main class="my-10">
-        <div class="container mx-auto">
-            <div class="relative h-[80vh] overflow-hidden rounded-3xl">
-                <img src="{{ asset('images/coming_soon.png') }}" class="absolute block w-full -translate-x-1/2 -translate-y-[26rem] top-1/2 left-1/2 mx-auto" alt="YTCG Coming soon">
-            </div>
+    <main class="relative px-6 py-24 lg:px-14">
+        <div class="glow-ambient" aria-hidden="true"></div>
+        <div class="relative mx-auto max-w-3xl border border-dashed border-hairline px-8 py-20 text-center">
+            <p class="eyebrow">En construction</p>
+            <h1 class="mt-6 font-display text-7xl font-bold uppercase leading-[.9] tracking-[-0.05em] text-ink-strong md:text-8xl">
+                Soon<span class="text-primary">.</span>
+            </h1>
+            <p class="mt-8 text-ink-muted">
+                Cette page arrive avec une prochaine mise à jour. Reviens vite.
+            </p>
+            <a href="{{ path('homepage') }}" class="btn-arcade mt-10">Retour à l'accueil ▸</a>
         </div>
     </main>
 {% endblock %}

--- a/templates/parts/_footer.html.twig
+++ b/templates/parts/_footer.html.twig
@@ -1,4 +1,5 @@
-<footer class="flex items-center justify-between border-t border-hairline px-6 py-8 font-mono text-[11px] tracking-[.1em] text-ink-dim lg:px-14">
+{# mt-auto : le body est en flex column, le footer reste collé en bas des pages courtes #}
+<footer class="mt-auto flex items-center justify-between border-t border-hairline px-6 py-8 font-mono text-[11px] tracking-[.1em] text-ink-dim lg:px-14">
     <div class="flex items-center gap-3">
         <img src="{{ asset('images/ytcg_logo.png') }}" alt="" class="h-8 w-8 object-contain">
         <span>YOUL · YOULS TRADING CARD GAME · {{ 'now'|date('Y') }}</span>

--- a/templates/parts/_footer.html.twig
+++ b/templates/parts/_footer.html.twig
@@ -1,0 +1,7 @@
+<footer class="flex items-center justify-between border-t border-hairline px-6 py-8 font-mono text-[11px] tracking-[.1em] text-ink-dim lg:px-14">
+    <div class="flex items-center gap-3">
+        <img src="{{ asset('images/ytcg_logo.png') }}" alt="" class="h-8 w-8 object-contain">
+        <span>YOUL · YOULS TRADING CARD GAME · {{ 'now'|date('Y') }}</span>
+    </div>
+    <span>fan-made · non-officiel</span>
+</footer>

--- a/templates/parts/_header.html.twig
+++ b/templates/parts/_header.html.twig
@@ -1,22 +1,47 @@
-<header class="w-full opacity-90 bg-gradient-to-b from-gray-900 to-transparent text-white">
-    <div class="p-2 mx-4">
-        <div class="flex justify-between">
-            <div class="flex items-center">
-                <img src="{{ asset('images/ytcg_logo.png') }}" alt="Logo" class="h-16 mr-4">
-                <h1 class="text-2xl font-bold">Youl TCG</h1>
-            </div>
-            <div class="flex space-x-4 items-center text-xl text-white">
-                {{ _self.nav_link('homepage', 'Home') }}
-                {{ _self.nav_link('extensions', 'Cards') }}
-                {{ _self.nav_link('boosters', 'Boosters') }}
-            </div>
-            <div class="flex space-x-4 items-center text-xl text-white font-extrabold">
-{#                <a href="#" class>{{ app.user.username }}</a>#}
-            </div>
+<header class="border-b border-hairline">
+    <div class="flex items-center justify-between px-6 py-5 lg:px-14">
+        <a href="{{ path('homepage') }}" class="flex items-center gap-3.5">
+            <img src="{{ asset('images/ytcg_logo.png') }}" alt="Logo YOUL"
+                 class="h-12 w-12 object-contain [filter:drop-shadow(0_0_14px_#a435f0aa)]">
+            <span class="flex flex-col gap-1 leading-none">
+                <span class="skew-brand font-display text-[26px] font-bold tracking-[-0.04em] text-ink-strong">YOUL</span>
+                <span class="font-mono text-[9px] tracking-[.28em] text-primary">TRADING CARD GAME</span>
+            </span>
+        </a>
+
+        <nav class="hidden items-center gap-7 font-display text-sm font-semibold uppercase tracking-[.1em] md:flex">
+            {{ _self.nav_link('homepage', 'Accueil') }}
+            {{ _self.nav_link('extensions', 'Univers') }}
+            {{ _self.nav_link('boosters', 'Boosters') }}
+            {{ _self.nav_soon('Échanges') }}
+            {{ _self.nav_soon('Duels') }}
+        </nav>
+
+        <div class="flex items-center gap-4">
+            {% if is_granted('ROLE_ADMIN') %}
+                <a href="{{ path('admin') }}" class="chip-mono text-ink-dim hover:text-primary">Admin</a>
+            {% endif %}
+            {% if app.user %}
+                <span class="flex items-center gap-2.5 border border-hairline bg-surface py-1 pl-1 pr-3.5">
+                    <span class="flex h-7 w-7 items-center justify-center bg-gradient-to-br from-primary to-magenta font-display text-sm font-bold text-black">
+                        {{ app.user.username|first|upper }}
+                    </span>
+                    <span class="font-mono text-xs text-ink">{{ app.user.username }}</span>
+                </span>
+                <a href="{{ path('app_logout') }}" class="chip-mono text-ink-dim hover:text-magenta">Quitter</a>
+            {% endif %}
         </div>
     </div>
 </header>
 
 {% macro nav_link(route, label) %}
-    <a href="{{ path(route) }}" class="{{ app.request.get('_route') == route ? 'active' : '' }}">{{ label }}</a>
+    <a href="{{ path(route) }}"
+       class="text-ink-muted hover:text-ink-strong {{ app.request.get('_route') == route ? 'active' : '' }}">{{ label }}</a>
+{% endmacro %}
+
+{% macro nav_soon(label) %}
+    <span class="flex items-center gap-1.5 text-ink-dim" aria-disabled="true">
+        {{ label }}
+        <span class="font-mono text-[9px] tracking-[.15em] text-soon">SOON</span>
+    </span>
 {% endmacro %}

--- a/tests/Functional/LayoutTest.php
+++ b/tests/Functional/LayoutTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class LayoutTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private const string DISCORD_ID_JUJU = '195659530363731968';
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function pageProvider(): iterable
+    {
+        yield 'homepage' => ['/'];
+        yield 'extensions' => ['/extensions'];
+        yield 'boosters' => ['/boosters'];
+    }
+
+    #[DataProvider('pageProvider')]
+    public function testPageRespondsWithSharedLayout(string $uri): void
+    {
+        $client = self::createClient();
+        $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', $uri);
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('YOUL', $crawler->filter('header')->text());
+        $this->assertStringContainsString('TRADING CARD GAME', $crawler->filter('header')->text());
+        $this->assertStringContainsString('fan-made · non-officiel', $crawler->filter('footer')->text());
+    }
+
+    #[DataProvider('pageProvider')]
+    public function testAnonymousIsRedirected(string $uri): void
+    {
+        $client = self::createClient();
+
+        $client->request('GET', $uri);
+
+        self::assertResponseRedirects();
+    }
+
+    public function testHeaderShowsUserChipAndSoonEntries(): void
+    {
+        $client = self::createClient();
+        $user = $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        $header = $crawler->filter('header')->text();
+        $this->assertStringContainsString($user->getUsername(), $header);
+        $this->assertStringContainsString('SOON', $header);
+        $this->assertStringContainsString('Échanges', $header);
+        $this->assertStringContainsString('Duels', $header);
+        $this->assertCount(1, $crawler->filter('header a[href="/logout"]'));
+    }
+
+    public function testAdminLinkOnlyVisibleForAdmin(): void
+    {
+        $client = self::createClient();
+        $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', '/');
+        $this->assertCount(1, $crawler->filter('header a[href="/admin"]'));
+
+        $this->authenticateClient($client, self::DISCORD_ID_JUJU);
+
+        $crawler = $client->request('GET', '/');
+        $this->assertCount(0, $crawler->filter('header a[href="/admin"]'));
+    }
+}


### PR DESCRIPTION
## Phase 2a — Design system « Violet Arcade » + layout partagé

Première PR de la stack Phase 2 (design Violet Arcade). Pose les fondations visuelles sans toucher aux pages métier (la homepage reste l'ancienne, refaite en 2b).

### Contenu
- **`assets/styles/theme.css`** (nouveau, hors Tailwind pour échapper à la purge) : tokens couleurs (`--bg #0b0712`, `--primary #a435f0`, `--magenta #ff3db0`, hairline, live/soon), palette des 5 raretés (common/uncommon/rare/epic/legendary → gris/vert/bleu/violet/orange), textures (scanlines, glow ambiant, hazard stripes), clip-paths biseautés (`.notched*`), keyframes `floatY`/`marquee`/`holoSpark`
- **Tailwind** : palette + `font-display/sans/mono` (Space Grotesk, Inter, JetBrains Mono via Google Fonts CDN)
- **`app.css`** : composants `.btn-arcade`, `.btn-ghost`, `.eyebrow`, `.chip-mono`
- **`base.html.twig`** : fond noir-violet, overlay scanlines, fonts, bloc footer
- **Header** refondu : wordmark YOUL (skew −6°), nav uppercase (Accueil/Univers/Boosters + entrées désactivées Échanges/Duels « SOON »), chip user, liens Admin (ROLE_ADMIN) et Quitter
- **Footer** (nouveau partial) + **coming_soon** restylée

### Tests
`tests/Functional/LayoutTest.php` : pages 200 authentifié (layout partagé), redirect anonyme, chip user + entrées SOON, visibilité du lien admin selon le rôle.

`make quality` ✅ · `make phpunit` ✅ (39 tests)

### Stack Phase 2
2a (cette PR) → 2b homepage → 2c collection → 2d holo