### PR TITLE
feat(homepage): Phase 2b — homepage Violet Arcade (VioletHome)

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,10 +1,2 @@
 import './stimulus_bootstrap.js';
 import './styles/app.css';
-import { initFlowbite } from 'flowbite';
-
-document.addEventListener('turbo:render', () => {
-    initFlowbite();
-});
-document.addEventListener('turbo:frame-render', () => {
-    initFlowbite();
-});

--- a/assets/styles/theme.css
+++ b/assets/styles/theme.css
@@ -85,9 +85,10 @@
     50% { transform: translateY(-14px); }
 }
 
+/* La piste contient deux copies du contenu : -50% boucle sans couture */
 @keyframes marquee {
     from { transform: translateX(0); }
-    to { transform: translateX(-100%); }
+    to { transform: translateX(-50%); }
 }
 
 @keyframes holoSpark {

--- a/importmap.php
+++ b/importmap.php
@@ -18,19 +18,6 @@ return [
         'path' => './assets/app.js',
         'entrypoint' => true,
     ],
-    'flowbite' => [
-        'version' => '3.1.2',
-    ],
-    '@popperjs/core' => [
-        'version' => '2.11.8',
-    ],
-    'flowbite-datepicker' => [
-        'version' => '1.3.2',
-    ],
-    'flowbite/dist/flowbite.min.css' => [
-        'version' => '3.1.2',
-        'type' => 'css',
-    ],
     '@hotwired/stimulus' => [
         'version' => '3.2.2',
     ],

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -38,19 +38,13 @@ class BaseController extends AbstractController
             $cards = $cardRepository->findBy(['id' => $cardsIds]);
         }
 
-        $packsOpenedCount = $cache->get('home_packs_opened', function (ItemInterface $item) use ($boosterOpeningRepository): int {
-            $item->expiresAfter(300);
-
-            return $boosterOpeningRepository->countAll();
-        });
-
         $extensions = $extensionRepository->findPublishedWithPublishedCardCount();
 
         return $this->render('pages/homepage.html.twig', [
             'cards' => $cards,
             'extensions' => $extensions,
             'cardsTotal' => array_sum(array_column($extensions, 'cardCount')),
-            'packsOpenedCount' => $packsOpenedCount,
+            'packsOpenedCount' => $boosterOpeningRepository->countAll(),
         ]);
     }
 

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -36,9 +36,12 @@ class BaseController extends AbstractController
             return $boosterOpeningRepository->countAll();
         });
 
+        $extensions = $extensionRepository->findPublishedWithPublishedCardCount();
+
         return $this->render('pages/homepage.html.twig', [
             'cards' => $cards,
-            'extensions' => $extensionRepository->findPublishedWithPublishedCardCount(),
+            'extensions' => $extensions,
+            'cardsTotal' => array_sum(array_column($extensions, 'cardCount')),
             'packsOpenedCount' => $packsOpenedCount,
         ]);
     }

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -22,13 +22,21 @@ class BaseController extends AbstractController
         BoosterOpeningRepository $boosterOpeningRepository,
         CacheInterface $cache,
     ): Response {
-        $cardsIds = $cache->get('daycards', function (ItemInterface $item) use ($cardRepository): array {
+        $pickDayCards = function (ItemInterface $item) use ($cardRepository): array {
             $item->expiresAt(new \DateTime('tomorrow'));
 
             return $cardRepository->findRandomCardId(3);
-        });
+        };
 
+        $cardsIds = $cache->get('daycards', $pickDayCards);
         $cards = $cardRepository->findBy(['id' => $cardsIds]);
+
+        // Stale cache (a cached card got unpublished or deleted): redraw.
+        if (\count($cards) !== \count($cardsIds)) {
+            $cache->delete('daycards');
+            $cardsIds = $cache->get('daycards', $pickDayCards);
+            $cards = $cardRepository->findBy(['id' => $cardsIds]);
+        }
 
         $packsOpenedCount = $cache->get('home_packs_opened', function (ItemInterface $item) use ($boosterOpeningRepository): int {
             $item->expiresAfter(300);

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Repository\BoosterOpeningRepository;
 use App\Repository\CardRepository;
+use App\Repository\ExtensionRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -14,8 +16,12 @@ use Symfony\Contracts\Cache\ItemInterface;
 class BaseController extends AbstractController
 {
     #[Route('/', name: 'homepage')]
-    public function homepage(CardRepository $cardRepository, CacheInterface $cache): Response
-    {
+    public function homepage(
+        CardRepository $cardRepository,
+        ExtensionRepository $extensionRepository,
+        BoosterOpeningRepository $boosterOpeningRepository,
+        CacheInterface $cache,
+    ): Response {
         $cardsIds = $cache->get('daycards', function (ItemInterface $item) use ($cardRepository): array {
             $item->expiresAt(new \DateTime('tomorrow'));
 
@@ -24,8 +30,16 @@ class BaseController extends AbstractController
 
         $cards = $cardRepository->findBy(['id' => $cardsIds]);
 
+        $packsOpenedCount = $cache->get('home_packs_opened', function (ItemInterface $item) use ($boosterOpeningRepository): int {
+            $item->expiresAfter(300);
+
+            return $boosterOpeningRepository->countAll();
+        });
+
         return $this->render('pages/homepage.html.twig', [
             'cards' => $cards,
+            'extensions' => $extensionRepository->findPublishedWithPublishedCardCount(),
+            'packsOpenedCount' => $packsOpenedCount,
         ]);
     }
 

--- a/src/Repository/BoosterOpeningRepository.php
+++ b/src/Repository/BoosterOpeningRepository.php
@@ -17,4 +17,9 @@ class BoosterOpeningRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, BoosterOpening::class);
     }
+
+    public function countAll(): int
+    {
+        return $this->count([]);
+    }
 }

--- a/src/Repository/ExtensionRepository.php
+++ b/src/Repository/ExtensionRepository.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Extension;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -16,5 +19,29 @@ class ExtensionRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Extension::class);
+    }
+
+    /**
+     * @return list<array{extension: Extension, cardCount: int}>
+     */
+    public function findPublishedWithPublishedCardCount(): array
+    {
+        /** @var list<array{0: Extension, cardCount: string|int}> $rows */
+        $rows = $this->createQueryBuilder('e')
+            ->select('e', 'COUNT(c.id) AS cardCount')
+            ->leftJoin('e.cards', 'c', 'WITH', 'c.status = :cardStatus')
+            ->andWhere('e.status = :status')
+            ->setParameter('cardStatus', CardStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
+            ->setParameter('status', ExtensionStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
+            ->groupBy('e.id')
+            ->orderBy('e.createdAt', 'ASC')
+            ->getQuery()
+            ->getResult()
+        ;
+
+        return array_map(
+            static fn (array $row): array => ['extension' => $row[0], 'cardCount' => (int) $row['cardCount']],
+            $rows,
+        );
     }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    "./vendor/tales-from-a-dev/flowbite-bundle/templates/**/*.html.twig",
     "./assets/**/*.js",
     "./templates/**/*.html.twig",
   ],

--- a/templates/components/CardComponent.html.twig
+++ b/templates/components/CardComponent.html.twig
@@ -1,18 +1,11 @@
-<div class="bg-gray-500 rounded-lg shadow-lg p-4">
-    <div id="{{ card.id }}" class="card interactive" data-rarity="{{ card.rarity.value }}" data-controller="card">
-        <div class="card__translater">
-            <div class="card__rotator">
-                <div class="card__front">
-                    <img src="{{ vich_uploader_asset(card) }}" alt="{{ card.name }}" onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
-                    <div class="card__shine"></div>
-                    <div class="card__glare"></div>
-                </div>
+<div id="{{ card.id }}" class="card interactive" data-rarity="{{ card.rarity.value }}" data-controller="card">
+    <div class="card__translater">
+        <div class="card__rotator">
+            <div class="card__front">
+                <img src="{{ vich_uploader_asset(card) }}" alt="{{ card.name }}" onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
+                <div class="card__shine"></div>
+                <div class="card__glare"></div>
             </div>
         </div>
-    </div>
-
-    <div class="mt-4">
-        <h3 class="text-xl font-bold">{{ card.name }}</h3>
-        <p class="text-sm">{{ card.description }}</p>
     </div>
 </div>

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -1,82 +1,218 @@
 {% extends 'base.html.twig' %}
 
 {% block title %}
-    YTCG - Le multivers des Youls
+    YOUL TCG — Le multivers des Youls
 {% endblock %}
 
 {% block body %}
-    <main class="pt-10">
-        <div id="default-carousel" class="container mx-auto relative w-full" data-carousel="static">
-            <!-- Carousel wrapper -->
-            <div class="relative h-[70vh] overflow-hidden rounded-3xl">
-                <!-- Item 1 -->
-                <div class="hidden duration-400 ease-linear" data-carousel-item>
-                    <img src="{{ asset('images/ytcg_background.png') }}"
-                         class="absolute block w-full -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2" alt="...">
-                    <div class="absolute z-10 inset-0 flex flex-col items-center justify-center text-center bg-black bg-opacity-30 backdrop-blur-sm">
-                        <h1 class="text-6xl font-bold text-purple-800" style="text-shadow: 2px 2px 5px black;">
-                            Le multivers des Youls</h1>
-                        <p class="text-2xl text-white">The best place to play YTCG online</p>
+    <main>
+        {# ------------------------------------------------------------ Hero #}
+        <section class="relative overflow-hidden px-6 pb-12 pt-16 lg:px-14 lg:pt-20">
+            <div class="glow-ambient" aria-hidden="true"></div>
+            <div class="relative mx-auto grid max-w-7xl items-center gap-14 lg:grid-cols-[1.1fr_1fr]">
+                <div>
+                    <span class="inline-block bg-primary px-2.5 py-1 font-mono text-[11px] font-bold tracking-[.15em] text-black">★ PRESS START</span>
+                    <h1 class="mt-6 font-display text-7xl font-bold uppercase leading-[.85] tracking-[-0.06em] text-ink-strong md:text-8xl xl:text-[124px]">
+                        Ouvre.<br>
+                        <span class="text-primary">Collec-</span><br>
+                        tionne.<br>
+                        <span class="bg-gradient-to-r from-primary to-magenta bg-clip-text text-transparent">Frime.</span>
+                    </h1>
+                    <p class="mt-7 max-w-md text-[17px] leading-normal text-ink-muted">
+                        Le TCG fan-made où tous tes univers préférés s'affrontent.
+                        Ouvre tes packs quotidiens, chasse les légendaires et complète ta collection.
+                    </p>
+                    <div class="mt-8 flex flex-wrap gap-3">
+                        <a href="{{ path('boosters') }}" class="btn-arcade">Ouvrir un pack ▸</a>
+                        <a href="#univers" class="btn-ghost">Voir les univers</a>
                     </div>
                 </div>
-                <!-- Item 2 -->
-{#                <div class="hidden duration-400 ease-linear" data-carousel-item>#}
-{#                    <img src="https://dummyimage.com/16:9x1080/"#}
-{#                         class="absolute block w-full -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2" alt="...">#}
-{#                </div>#}
-{#                <!-- Item 3 -->#}
-{#                <div class="hidden duration-400 ease-linear" data-carousel-item>#}
-{#                    <img src="https://dummyimage.com/16:9x1080/"#}
-{#                         class="absolute block w-full -translate-x-1/2 -translate-y-1/2 top-1/2 left-1/2" alt="...">#}
-{#                </div>#}
-            </div>
-            <!-- Slider indicators -->
-{#            <div class="absolute z-30 flex -translate-x-1/2 bottom-5 left-1/2 space-x-3 rtl:space-x-reverse">#}
-{#                <button type="button" class="w-3 h-3 rounded-full" aria-current="true" aria-label="Slide 1"#}
-{#                        data-carousel-slide-to="0"></button>#}
-{#                <button type="button" class="w-3 h-3 rounded-full" aria-current="false" aria-label="Slide 2"#}
-{#                        data-carousel-slide-to="1"></button>#}
-{#                <button type="button" class="w-3 h-3 rounded-full" aria-current="false" aria-label="Slide 3"#}
-{#                        data-carousel-slide-to="2"></button>#}
-{#            </div>#}
-            <!-- Slider controls -->
-{#            <button type="button"#}
-{#                    class="absolute top-0 start-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none"#}
-{#                    data-carousel-prev>#}
-{#                        <span class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-white/30 dark:bg-gray-800/30 group-hover:bg-white/50 dark:group-hover:bg-gray-800/60 group-focus:ring-4 group-focus:ring-white dark:group-focus:ring-gray-800/70 group-focus:outline-none">#}
-{#                            <svg class="w-4 h-4 text-white dark:text-gray-800 rtl:rotate-180" aria-hidden="true"#}
-{#                                 xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">#}
-{#                                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"#}
-{#                                      stroke-width="2" d="M5 1 1 5l4 4"></path>#}
-{#                            </svg>#}
-{#                            <span class="sr-only">Previous</span>#}
-{#                        </span>#}
-{#            </button>#}
-{#            <button type="button"#}
-{#                    class="absolute top-0 end-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none"#}
-{#                    data-carousel-next>#}
-{#                        <span class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-white/30 dark:bg-gray-800/30 group-hover:bg-white/50 dark:group-hover:bg-gray-800/60 group-focus:ring-4 group-focus:ring-white dark:group-focus:ring-gray-800/70 group-focus:outline-none">#}
-{#                            <svg class="w-4 h-4 text-white dark:text-gray-800 rtl:rotate-180" aria-hidden="true"#}
-{#                                 xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 6 10">#}
-{#                                <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round"#}
-{#                                      stroke-width="2" d="m1 9 4-4-4-4"></path>#}
-{#                            </svg>#}
-{#                            <span class="sr-only">Next</span>#}
-{#                        </span>#}
-{#            </button>#}
-        </div>
-    </main>
-
-    {% if cards is not empty %}
-        <div class="mt-10 bg-slate-800">
-            <div class="container mx-auto py-5">
-                <h2 class="text-3xl font-bold text-white py-2">Cartes du jour</h2>
-                <div class="grid grid-cols-3 gap-4 mt-4">
+                <div class="relative hidden h-[540px] lg:block" aria-hidden="false">
+                    <img src="{{ asset('images/ytcg_logo.png') }}" alt=""
+                         class="absolute left-1/2 top-1/2 h-80 w-80 -translate-x-1/2 -translate-y-1/2 opacity-25 blur-sm saturate-150"
+                         aria-hidden="true">
+                    {% set heroSpots = [
+                        {left: '-2.5rem', top: '2.5rem', rotation: '-8deg', delay: '0s', z: 1},
+                        {left: '6.5rem', top: '-0.5rem', rotation: '6deg', delay: '.4s', z: 2},
+                        {left: '15.5rem', top: '5rem', rotation: '-2deg', delay: '.8s', z: 1},
+                    ] %}
                     {% for card in cards %}
-                        {{ include('components/CardComponent.html.twig') }}
+                        {% set spot = heroSpots[loop.index0 % heroSpots|length] %}
+                        <div class="absolute w-56"
+                             style="left: {{ spot.left }}; top: {{ spot.top }}; z-index: {{ spot.z }};">
+                            <div style="animation: floatY 5s ease-in-out {{ spot.delay }} infinite;">
+                                <div style="transform: rotate({{ spot.rotation }});">
+                                    {{ include('components/CardComponent.html.twig') }}
+                                </div>
+                            </div>
+                        </div>
                     {% endfor %}
                 </div>
             </div>
-        </div>
-    {% endif %}
+        </section>
+
+        {# ---------------------------------------------------------- Ticker #}
+        {% set tickerItems = [
+            "✦ %s packs ouverts"|format(packsOpenedCount|number_format(0, ',', ' ')),
+            '✦ %d univers'|format(extensions|length),
+            '✦ 2 packs / jour',
+            '✦ 5 paliers de rareté',
+        ] %}
+        <section class="overflow-hidden border-y-2 border-black bg-primary py-6 text-black" data-testid="ticker">
+            <div class="flex w-max" style="animation: marquee 30s linear infinite;">
+                {% for copy in range(0, 1) %}
+                    <div class="flex shrink-0 items-center" {{ copy == 1 ? 'aria-hidden="true"' }}>
+                        {% for item in tickerItems %}
+                            <span class="whitespace-nowrap px-6 font-display text-2xl font-bold uppercase tracking-[-0.02em]">{{ item }}</span>
+                        {% endfor %}
+                    </div>
+                {% endfor %}
+            </div>
+        </section>
+
+        {# --------------------------------------------------------- Concept #}
+        <section class="px-6 py-24 lg:px-14">
+            <div class="mx-auto max-w-7xl">
+                <p class="eyebrow">01 / Concept</p>
+                <h2 class="mt-4 max-w-4xl font-display text-6xl font-bold uppercase leading-[.9] tracking-[-0.04em] text-ink-strong md:text-7xl">
+                    Tous tes univers.<br>
+                    <span class="text-primary">Un seul deck.</span>
+                </h2>
+                <p class="mt-7 max-w-xl text-[17px] leading-relaxed text-ink-muted">
+                    Chaque univers est une extension avec ses propres cartes, ses raretés et ses
+                    légendaires. Connecte-toi avec Discord, réclame tes packs gratuits du jour et
+                    fais grimper ta complétion.
+                </p>
+            </div>
+        </section>
+
+        {# --------------------------------------------------------- Univers #}
+        <section id="univers" class="px-6 pb-24 lg:px-14">
+            <div class="mx-auto max-w-7xl">
+                <div class="flex items-end justify-between">
+                    <h2 class="font-display text-5xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-6xl">
+                        Les <span class="text-primary">univers</span>.
+                    </h2>
+                    <span class="font-mono text-xs text-ink-dim">{{ '%02d'|format(extensions|length) }} LIVE / 01 SOON</span>
+                </div>
+
+                <div class="mt-10 grid gap-4 md:grid-cols-[2fr_1fr_1fr] md:grid-rows-[320px_280px]">
+                    {% for item in extensions %}
+                        {% set extension = item.extension %}
+                        <article class="relative min-h-[240px] overflow-hidden bg-surface {{ loop.first ? 'notched-corner md:row-span-2' : '' }}">
+                            {% if extension.imageName %}
+                                <img src="{{ vich_uploader_asset(extension) }}" alt="{{ extension.name }}"
+                                     class="absolute inset-0 h-full w-full object-cover">
+                            {% else %}
+                                <div class="absolute inset-0 bg-gradient-to-br from-[#2a0f44] via-[#7a1f9c] to-magenta" aria-hidden="true"></div>
+                            {% endif %}
+                            <div class="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black/90" aria-hidden="true"></div>
+
+                            <div class="absolute left-4 right-4 top-4 flex items-center justify-between">
+                                <span class="chip-mono bg-black/80 px-2 py-0.5 font-bold text-live">● LIVE</span>
+                                <span class="chip-mono text-white">EX-{{ '%03d'|format(loop.index) }}</span>
+                            </div>
+
+                            <div class="absolute bottom-4 left-4 right-4">
+                                <h3 class="font-display font-bold uppercase leading-[.95] tracking-[-0.03em] text-white {{ loop.first ? 'text-4xl' : 'text-[22px]' }}">
+                                    {{ extension.name }}
+                                </h3>
+                                <p class="mt-1.5 text-white/80 {{ loop.first ? 'text-sm' : 'text-[11px]' }}">
+                                    {{ extension.description|slice(0, 90) }}{{ extension.description|length > 90 ? '…' }}
+                                </p>
+                                <div class="chip-mono mt-3 flex justify-between border-t border-white/20 pt-2.5 text-white/90">
+                                    <span>{{ item.cardCount }} cartes</span>
+                                    <span>{{ extension.createdAt|date('m/Y') }}</span>
+                                </div>
+                            </div>
+                        </article>
+                    {% endfor %}
+
+                    {# Tuile teaser : absorbe la 4e case du layout magazine #}
+                    <article class="relative min-h-[240px] overflow-hidden border border-dashed border-hairline bg-surface/50 opacity-60 md:col-span-2">
+                        <div class="absolute left-4 right-4 top-4 flex items-center justify-between">
+                            <span class="chip-mono bg-black/80 px-2 py-0.5 font-bold text-soon">▸ SOON</span>
+                            <span class="chip-mono text-white">EX-{{ '%03d'|format(extensions|length + 1) }}</span>
+                        </div>
+                        <div class="absolute bottom-4 left-4 right-4">
+                            <h3 class="font-display text-[22px] font-bold uppercase leading-[.95] tracking-[-0.03em] text-white">
+                                Prochain univers
+                            </h3>
+                            <p class="mt-1.5 text-[11px] text-white/80">Annonce bientôt. Reste connecté.</p>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        {# --------------------------------------------------------- Raretés #}
+        <section id="raretes" class="border-t-2 border-hairline px-6 py-20 lg:px-14">
+            <div class="mx-auto max-w-7xl">
+                <p class="eyebrow">02 / Raretés</p>
+                <h2 class="mb-10 mt-4 font-display text-5xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-6xl">
+                    5 paliers.
+                </h2>
+
+                {# Poids purement indicatifs (copy marketing) : les vrais taux sont définis par booster #}
+                {% set rarities = [
+                    {label: 'Common', chip: 'C', weight: 60, color: 'var(--rarity-common)'},
+                    {label: 'Uncommon', chip: 'U', weight: 25, color: 'var(--rarity-uncommon)'},
+                    {label: 'Rare', chip: 'R', weight: 10, color: 'var(--rarity-rare)'},
+                    {label: 'Epic', chip: 'E', weight: 4, color: 'var(--rarity-epic)'},
+                    {label: 'Legendary', chip: 'L', weight: 1, color: 'var(--rarity-legendary)'},
+                ] %}
+                <div class="flex flex-col items-stretch md:flex-row">
+                    {% for rarity in rarities %}
+                        <div class="px-5 py-8 {{ not loop.last ? 'md:border-r md:border-white/10' }}"
+                             style="flex: {{ rarity.weight + 5 }} 1 0%; border-top: 3px solid {{ rarity.color }}; background: linear-gradient(180deg, color-mix(in srgb, {{ rarity.color }} 9%, transparent), transparent);">
+                            <p class="chip-mono font-bold !tracking-[.2em]" style="color: {{ rarity.color }};">{{ rarity.chip }} · {{ rarity.label|upper }}</p>
+                            <p class="mt-4 font-display text-5xl font-bold tracking-[-0.04em] text-ink-strong">
+                                {{ rarity.weight }}<span class="text-2xl" style="color: {{ rarity.color }};">%</span>
+                            </p>
+                            <p class="chip-mono mt-2 text-ink-dim">drop rate</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+
+        {# --------------------------------------------------------- Roadmap #}
+        <section id="roadmap" class="px-6 py-20 lg:px-14">
+            <div class="mx-auto max-w-7xl">
+                <p class="eyebrow">03 / Roadmap</p>
+                <h2 class="mb-12 mt-4 font-display text-5xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-6xl">
+                    La suite.
+                </h2>
+
+                {% set roadmap = [
+                    {quarter: 'Q3 26', state: 'NOW', title: 'Ouverture de packs', color: 'var(--primary)'},
+                    {quarter: 'Q4 26', state: 'BUILDING', title: 'Échanges P2P', color: 'var(--magenta)'},
+                    {quarter: 'Q1 27', state: 'PLANNED', title: 'Mode Duel', color: 'var(--soon)'},
+                    {quarter: '2027', state: 'VISION', title: 'Saisons ranked', color: 'var(--text-dim)'},
+                ] %}
+                <div class="grid md:grid-cols-4">
+                    {% for step in roadmap %}
+                        <div class="p-6 {{ not loop.last ? 'md:border-r md:border-hairline' }}"
+                             style="border-top: 4px solid {{ step.color }};">
+                            <p class="chip-mono font-bold !tracking-[.2em]" style="color: {{ step.color }};">{{ step.quarter }} · {{ step.state }}</p>
+                            <p class="mt-3 font-display text-2xl font-bold uppercase tracking-[-0.02em] text-ink-strong">{{ step.title }}</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+
+        {# ------------------------------------------------------------- CTA #}
+        <section class="relative overflow-hidden bg-primary px-6 py-28 text-center text-black lg:px-14">
+            <div class="hazard-stripes absolute inset-0 opacity-15" aria-hidden="true"></div>
+            <div class="relative">
+                <h2 class="font-display text-7xl font-bold uppercase leading-[.9] tracking-[-0.05em] md:text-8xl">Press start.</h2>
+                <p class="mt-4 text-[17px] text-black/80">2 packs gratos par jour. Pas de CB. Juste Discord.</p>
+                <a href="{{ path('boosters') }}"
+                   class="notched-lg mt-8 inline-block bg-black px-9 py-4 font-display text-base font-bold uppercase tracking-[.15em] text-primary">
+                    Ouvrir un pack ▸
+                </a>
+            </div>
+        </section>
+    </main>
 {% endblock %}

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -55,15 +55,21 @@
         {% set tickerItems = [
             "✦ %s packs ouverts"|format(packsOpenedCount|number_format(0, ',', ' ')),
             '✦ %d univers'|format(extensions|length),
+            '✦ %d cartes à collectionner'|format(cardsTotal),
             '✦ 2 packs / jour',
             '✦ 5 paliers de rareté',
         ] %}
+        {# La boucle marquee = 2 copies de la piste, translateX(-50%). Chaque
+           copie répète les items 3× pour rester plus large que le viewport :
+           sans ça, du vide apparaît pendant le défilement. #}
         <section class="overflow-hidden border-y-2 border-black bg-primary py-6 text-black" data-testid="ticker">
-            <div class="flex w-max" style="animation: marquee 30s linear infinite;">
+            <div class="flex w-max" style="animation: marquee 60s linear infinite;">
                 {% for copy in range(0, 1) %}
                     <div class="flex shrink-0 items-center" {{ copy == 1 ? 'aria-hidden="true"' }}>
-                        {% for item in tickerItems %}
-                            <span class="whitespace-nowrap px-6 font-display text-2xl font-bold uppercase tracking-[-0.02em]">{{ item }}</span>
+                        {% for repeat in range(0, 2) %}
+                            {% for item in tickerItems %}
+                                <span class="whitespace-nowrap px-6 font-display text-2xl font-bold uppercase tracking-[-0.02em]">{{ item }}</span>
+                            {% endfor %}
                         {% endfor %}
                     </div>
                 {% endfor %}

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -9,11 +9,12 @@
         {# ------------------------------------------------------------ Hero #}
         <section class="relative overflow-hidden px-6 pb-12 pt-16 lg:px-14 lg:pt-20">
             <div class="glow-ambient" aria-hidden="true"></div>
-            <div class="relative mx-auto grid max-w-7xl items-center gap-14 lg:grid-cols-[1.1fr_1fr]">
+            <div class="relative mx-auto grid max-w-7xl items-center gap-14 lg:grid-cols-[1.1fr_1fr] 2xl:max-w-[88rem]">
                 <div>
                     <span class="inline-block bg-primary px-2.5 py-1 font-mono text-[11px] font-bold tracking-[.15em] text-black">★ PRESS START</span>
-                    {# Taille fluide : « Collectionne. » doit tenir entier sur sa ligne #}
-                    <h1 class="mt-6 font-display text-[clamp(2.75rem,5.2vw,5.25rem)] font-bold uppercase leading-[.9] tracking-[-0.04em] text-ink-strong">
+                    {# Taille fluide : « Collectionne. » doit tenir entier sur sa ligne
+                       (le conteneur s'élargit en 2xl pour laisser le titre grossir) #}
+                    <h1 class="mt-6 font-display text-[clamp(2.75rem,4.8vw,6rem)] font-bold uppercase leading-[.9] tracking-[-0.05em] text-ink-strong">
                         Ouvre.<br>
                         <span class="text-primary">Collectionne.</span><br>
                         <span class="bg-gradient-to-r from-primary to-magenta bg-clip-text text-transparent">Frime.</span>
@@ -27,14 +28,14 @@
                         <a href="#univers" class="btn-ghost">Voir les univers</a>
                     </div>
                 </div>
-                <div class="relative hidden h-[560px] lg:block" aria-hidden="false">
+                <div class="relative hidden h-[640px] lg:block" aria-hidden="false">
                     {# Logo net au-dessus des cartes (plus de watermark flou) #}
                     <img src="{{ asset('images/ytcg_logo.png') }}" alt="Logo YOUL"
-                         class="absolute left-1/2 top-0 h-40 w-auto -translate-x-1/2 [filter:drop-shadow(0_0_30px_#a435f088)]">
+                         class="absolute left-1/2 top-0 h-64 w-auto -translate-x-1/2 [filter:drop-shadow(0_0_40px_#a435f0aa)]">
                     {% set heroSpots = [
-                        {left: '-2.5rem', top: '12rem', rotation: '-8deg', delay: '0s', z: 1},
-                        {left: '6.5rem', top: '9rem', rotation: '6deg', delay: '.4s', z: 2},
-                        {left: '15.5rem', top: '14.5rem', rotation: '-2deg', delay: '.8s', z: 1},
+                        {left: '-2.5rem', top: '17rem', rotation: '-8deg', delay: '0s', z: 1},
+                        {left: '6.5rem', top: '14rem', rotation: '6deg', delay: '.4s', z: 2},
+                        {left: '15.5rem', top: '19rem', rotation: '-2deg', delay: '.8s', z: 1},
                     ] %}
                     {% for card in cards %}
                         {% set spot = heroSpots[loop.index0 % heroSpots|length] %}

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -12,10 +12,10 @@
             <div class="relative mx-auto grid max-w-7xl items-center gap-14 lg:grid-cols-[1.1fr_1fr]">
                 <div>
                     <span class="inline-block bg-primary px-2.5 py-1 font-mono text-[11px] font-bold tracking-[.15em] text-black">★ PRESS START</span>
-                    <h1 class="mt-6 font-display text-7xl font-bold uppercase leading-[.85] tracking-[-0.06em] text-ink-strong md:text-8xl xl:text-[124px]">
+                    {# Taille fluide : « Collectionne. » doit tenir entier sur sa ligne #}
+                    <h1 class="mt-6 font-display text-[clamp(2.75rem,5.2vw,5.25rem)] font-bold uppercase leading-[.9] tracking-[-0.04em] text-ink-strong">
                         Ouvre.<br>
-                        <span class="text-primary">Collec-</span><br>
-                        tionne.<br>
+                        <span class="text-primary">Collectionne.</span><br>
                         <span class="bg-gradient-to-r from-primary to-magenta bg-clip-text text-transparent">Frime.</span>
                     </h1>
                     <p class="mt-7 max-w-md text-[17px] leading-normal text-ink-muted">
@@ -27,14 +27,14 @@
                         <a href="#univers" class="btn-ghost">Voir les univers</a>
                     </div>
                 </div>
-                <div class="relative hidden h-[540px] lg:block" aria-hidden="false">
-                    <img src="{{ asset('images/ytcg_logo.png') }}" alt=""
-                         class="absolute left-1/2 top-1/2 h-80 w-80 -translate-x-1/2 -translate-y-1/2 opacity-25 blur-sm saturate-150"
-                         aria-hidden="true">
+                <div class="relative hidden h-[560px] lg:block" aria-hidden="false">
+                    {# Logo net au-dessus des cartes (plus de watermark flou) #}
+                    <img src="{{ asset('images/ytcg_logo.png') }}" alt="Logo YOUL"
+                         class="absolute left-1/2 top-0 h-40 w-auto -translate-x-1/2 [filter:drop-shadow(0_0_30px_#a435f088)]">
                     {% set heroSpots = [
-                        {left: '-2.5rem', top: '2.5rem', rotation: '-8deg', delay: '0s', z: 1},
-                        {left: '6.5rem', top: '-0.5rem', rotation: '6deg', delay: '.4s', z: 2},
-                        {left: '15.5rem', top: '5rem', rotation: '-2deg', delay: '.8s', z: 1},
+                        {left: '-2.5rem', top: '12rem', rotation: '-8deg', delay: '0s', z: 1},
+                        {left: '6.5rem', top: '9rem', rotation: '6deg', delay: '.4s', z: 2},
+                        {left: '15.5rem', top: '14.5rem', rotation: '-2deg', delay: '.8s', z: 1},
                     ] %}
                     {% for card in cards %}
                         {% set spot = heroSpots[loop.index0 % heroSpots|length] %}

--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -13,6 +13,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Uid\Uuid;
 
 final class HomepageTest extends WebTestCase
 {
@@ -91,15 +92,37 @@ final class HomepageTest extends WebTestCase
         $this->authenticateClient($this->client);
 
         // Prime the cache as if no published card existed when it was built.
-        $pool = self::getContainer()->get('cache.app');
-        \assert($pool instanceof CacheItemPoolInterface);
-        $item = $pool->getItem('daycards');
-        $item->set([]);
-        $pool->save($item);
+        $this->primeDayCardsCache([]);
 
         $this->client->request('GET', '/');
 
         self::assertResponseIsSuccessful();
+    }
+
+    public function testStaleDayCardsCacheIsRedrawn(): void
+    {
+        $this->authenticateClient($this->client);
+
+        // Ids that no longer exist (e.g. fixtures reloaded since the cache
+        // was built): the homepage must drop the cache and redraw.
+        $this->primeDayCardsCache([(string) Uuid::v4(), (string) Uuid::v4(), (string) Uuid::v4()]);
+
+        $crawler = $this->client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(3, $crawler->filter('.card'));
+    }
+
+    /**
+     * @param list<string> $cardIds
+     */
+    private function primeDayCardsCache(array $cardIds): void
+    {
+        $pool = self::getContainer()->get('cache.app');
+        \assert($pool instanceof CacheItemPoolInterface);
+        $item = $pool->getItem('daycards');
+        $item->set($cardIds);
+        $pool->save($item);
     }
 
     private function createOpenings(DiscordUser $user, int $count): void

--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -29,8 +29,8 @@ final class HomepageTest extends WebTestCase
         $this->client = self::createClient();
         $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
 
-        // The homepage caches the day cards and the ticker counters: without
-        // this, values leak from one test (or one local run) to the next.
+        // The homepage caches the day cards: without this, ids leak from one
+        // test (or one local run) to the next.
         self::getContainer()->get('cache.app')->clear();
     }
 

--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Booster;
+use App\Entity\BoosterOpening;
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Enum\Entity\ExtensionStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class HomepageTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private KernelBrowser $client;
+
+    private EntityManagerInterface $entityManager;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+
+        // The homepage caches the day cards and the ticker counters: without
+        // this, values leak from one test (or one local run) to the next.
+        self::getContainer()->get('cache.app')->clear();
+    }
+
+    public function testHomepageShowsAllSections(): void
+    {
+        $this->authenticateClient($this->client);
+
+        $crawler = $this->client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(1, $crawler->filter('#univers'));
+        $this->assertCount(1, $crawler->filter('#raretes'));
+        $this->assertCount(1, $crawler->filter('#roadmap'));
+        $this->assertCount(1, $crawler->filter('[data-testid="ticker"]'));
+
+        // The design uppercases through CSS: the DOM keeps the source case.
+        $body = $crawler->filter('main')->text();
+        $this->assertStringContainsString('PRESS START', $body);
+        $this->assertStringContainsString('5 paliers.', $body);
+        $this->assertStringContainsString('Prochain univers', $body);
+    }
+
+    public function testTickerShowsRealCounters(): void
+    {
+        $user = $this->authenticateClient($this->client);
+        $this->createOpenings($user, 2);
+
+        $crawler = $this->client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        $ticker = $crawler->filter('[data-testid="ticker"]')->text();
+        $this->assertStringContainsString('2 packs ouverts', $ticker);
+        $this->assertStringContainsString('univers', $ticker);
+        $this->assertStringContainsString('2 packs / jour', $ticker);
+    }
+
+    public function testUniverseGridOnlyShowsPublishedExtensions(): void
+    {
+        $this->authenticateClient($this->client);
+
+        $draftExtension = new Extension()
+            ->setName('Draft universe ' . uniqid())
+            ->setDescription('Should stay hidden')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+        ;
+        $this->entityManager->persist($draftExtension);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        $grid = $crawler->filter('#univers')->text();
+        $this->assertStringContainsString('Cyberpunk 2077', $grid);
+        $this->assertStringNotContainsString($draftExtension->getName(), $grid);
+    }
+
+    public function testHomepageSurvivesEmptyDayCards(): void
+    {
+        $this->authenticateClient($this->client);
+
+        // Prime the cache as if no published card existed when it was built.
+        $pool = self::getContainer()->get('cache.app');
+        \assert($pool instanceof CacheItemPoolInterface);
+        $item = $pool->getItem('daycards');
+        $item->set([]);
+        $pool->save($item);
+
+        $this->client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    private function createOpenings(DiscordUser $user, int $count): void
+    {
+        $extension = new Extension()
+            ->setName('Homepage test extension ' . uniqid())
+            ->setDescription('Test extension')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+        ;
+        $this->entityManager->persist($extension);
+
+        $booster = new Booster()
+            ->setExtension($extension)
+            ->setHoloRate(0)
+            ->setRarityRates([['common' => 100]])
+        ;
+        $booster->setImageName('default_card.png');
+        $this->entityManager->persist($booster);
+
+        for ($i = 0; $i < $count; ++$i) {
+            $this->entityManager->persist(new BoosterOpening($user, $booster, $i + 1, new \DateTimeImmutable()));
+        }
+
+        $this->entityManager->flush();
+    }
+}


### PR DESCRIPTION
## Phase 2b — Homepage « VioletHome »

Empilée sur #37 (2a). Réécriture complète de la homepage sur le design du handoff.

### Contenu
- **Hero** : pill « ★ PRESS START », H1 display 124px « Ouvre. / Collec- / tionne. / Frime. » (gradient), CTAs, et les **3 cartes du jour** (mécanique de cache existante) flottantes (`floatY`, rotations décalées) sur logo blurré
- **Ticker** marquee `bg-primary` : **compteurs réels** — packs ouverts (`BoosterOpeningRepository::countAll`, caché 5 min) et univers publiés — + « 2 packs / jour » statique. Pas de compteur de joueurs (décision)
- **Univers** : grille magazine `2fr 1fr 1fr` alimentée par `ExtensionRepository::findPublishedWithPublishedCardCount()` (extensions publiées + nb de cartes publiées) ; code `EX-00n` calculé, tagline = description tronquée ; **4e tuile = teaser « PROCHAIN UNIVERS ▸ SOON »** (absorbe le layout 4 cases avec 3 extensions)
- **Raretés** : 5 colonnes proportionnelles aux poids hardcodés 60/25/10/4/1 (copy marketing — les vrais taux vivent dans `Booster.rarityRates`)
- **Roadmap** hardcodée adaptée au projet + **CTA** hazard stripes « Press start. »
- **CardComponent** réduit à la carte 3D nue (le chrome gris + nom/description sort du composant)
- **Flowbite retiré** (importmap + vendor, `initFlowbite` dans app.js, ligne content Tailwind) : le carousel supprimé était son dernier consommateur. Le bundle composer `tales-from-a-dev/flowbite-bundle` reste installé (aucun form theme configuré, retrait éventuel hors scope)

### Tests
`HomepageTest` : sections présentes, compteurs réels du ticker (2 `BoosterOpening` créés en setUp), extensions DRAFT absentes de la grille, page OK avec un cache `daycards` vide. Cache `cache.app` vidé en setUp (clés partagées).

`make quality` ✅ · `make phpunit` ✅ (43 tests)