### PR TITLE
feat(collection): Phase 2c — page collection (VioletProfile)

### DIFF
--- a/src/Controller/CollectionController.php
+++ b/src/Controller/CollectionController.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Repository\ExtensionRepository;
+use App\Repository\UserCardRepository;
+use App\Service\Booster\BoosterClaimQuotaInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+class CollectionController extends AbstractController
+{
+    #[Route('/collection', name: 'collection')]
+    public function __invoke(
+        Request $request,
+        #[CurrentUser] DiscordUser $user,
+        UserCardRepository $userCardRepository,
+        ExtensionRepository $extensionRepository,
+        BoosterClaimQuotaInterface $boosterClaimQuota,
+    ): Response {
+        $extensions = $extensionRepository->findPublishedWithPublishedCardCount();
+        $currentExtension = $this->resolveExtensionFilter($request, $extensions);
+
+        $ownedByExtension = $userCardRepository->countOwnedGroupedByExtension($user);
+
+        $universes = array_map(static function (array $item) use ($ownedByExtension): array {
+            $owned = $ownedByExtension[(string) $item['extension']->getId()] ?? 0;
+
+            return [
+                'extension' => $item['extension'],
+                'total' => $item['cardCount'],
+                'owned' => $owned,
+                'pct' => $item['cardCount'] > 0 ? (int) round($owned / $item['cardCount'] * 100) : 0,
+            ];
+        }, $extensions);
+
+        $totalPublished = array_sum(array_column($extensions, 'cardCount'));
+        $ownedTotalDistinct = array_sum($ownedByExtension);
+
+        return $this->render('pages/collection.html.twig', [
+            'universes' => $universes,
+            'currentExtension' => $currentExtension,
+            'userCards' => $userCardRepository->findOwnedWithCards($user, $currentExtension),
+            'ownedTotalDistinct' => $ownedTotalDistinct,
+            'ownedTotalQuantity' => $userCardRepository->sumOwnedQuantities($user),
+            'totalPublished' => $totalPublished,
+            'completionPct' => $totalPublished > 0 ? (int) round($ownedTotalDistinct / $totalPublished * 100) : 0,
+            'remainingClaims' => $boosterClaimQuota->getRemainingClaims($user),
+            'dailyLimit' => BoosterClaimQuotaInterface::DAILY_LIMIT,
+        ]);
+    }
+
+    /**
+     * Resolves the ?extension= query parameter against the published
+     * extensions already loaded: no Doctrine lookup, so a malformed uuid is
+     * a plain 404 instead of a conversion error.
+     *
+     * @param list<array{extension: Extension, cardCount: int}> $extensions
+     */
+    private function resolveExtensionFilter(Request $request, array $extensions): ?Extension
+    {
+        $extensionId = $request->query->getString('extension');
+
+        if ('' === $extensionId) {
+            return null;
+        }
+
+        foreach ($extensions as $item) {
+            if ((string) $item['extension']->getId() === $extensionId) {
+                return $item['extension'];
+            }
+        }
+
+        throw $this->createNotFoundException(\sprintf('Unknown extension "%s".', $extensionId));
+    }
+}

--- a/src/Controller/CollectionController.php
+++ b/src/Controller/CollectionController.php
@@ -37,7 +37,7 @@ class CollectionController extends AbstractController
                 'extension' => $item['extension'],
                 'total' => $item['cardCount'],
                 'owned' => $owned,
-                'pct' => $item['cardCount'] > 0 ? (int) round($owned / $item['cardCount'] * 100) : 0,
+                'percentage' => $item['cardCount'] > 0 ? (int) round($owned / $item['cardCount'] * 100) : 0,
             ];
         }, $extensions);
 

--- a/src/Repository/UserCardRepository.php
+++ b/src/Repository/UserCardRepository.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
 use App\Entity\UserCard;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -16,5 +18,74 @@ class UserCardRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, UserCard::class);
+    }
+
+    /**
+     * Owned inventory entries (most recently obtained first), with the card
+     * and its extension eagerly hydrated for the collection grid.
+     *
+     * @return list<UserCard>
+     */
+    public function findOwnedWithCards(DiscordUser $discordUser, ?Extension $extension = null): array
+    {
+        $queryBuilder = $this->createQueryBuilder('uc')
+            ->join('uc.card', 'c')
+            ->addSelect('c')
+            ->join('c.extension', 'e')
+            ->addSelect('e')
+            ->andWhere('uc.discordUser = :user')
+            ->andWhere('uc.quantity > 0 OR uc.holoQuantity > 0')
+            ->setParameter('user', $discordUser)
+            ->orderBy('uc.updatedAt', 'DESC')
+        ;
+
+        if ($extension instanceof Extension) {
+            $queryBuilder
+                ->andWhere('c.extension = :extension')
+                ->setParameter('extension', $extension)
+            ;
+        }
+
+        /** @var list<UserCard> */
+        return $queryBuilder->getQuery()->getResult();
+    }
+
+    /**
+     * @return array<string, int> extension id => distinct owned cards
+     */
+    public function countOwnedGroupedByExtension(DiscordUser $discordUser): array
+    {
+        /** @var list<array{extensionId: string, ownedCount: string|int}> $rows */
+        $rows = $this->createQueryBuilder('uc')
+            ->select('IDENTITY(c.extension) AS extensionId', 'COUNT(DISTINCT c.id) AS ownedCount')
+            ->join('uc.card', 'c')
+            ->andWhere('uc.discordUser = :user')
+            ->andWhere('uc.quantity > 0 OR uc.holoQuantity > 0')
+            ->setParameter('user', $discordUser)
+            ->groupBy('c.extension')
+            ->getQuery()
+            ->getResult()
+        ;
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[$row['extensionId']] = (int) $row['ownedCount'];
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Total number of cards owned, holo included (collection banner stat).
+     */
+    public function sumOwnedQuantities(DiscordUser $discordUser): int
+    {
+        return (int) $this->createQueryBuilder('uc')
+            ->select('COALESCE(SUM(uc.quantity + uc.holoQuantity), 0)')
+            ->andWhere('uc.discordUser = :user')
+            ->setParameter('user', $discordUser)
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
     }
 }

--- a/templates/pages/collection.html.twig
+++ b/templates/pages/collection.html.twig
@@ -59,7 +59,7 @@
                         <div class="flex-1 p-5 {{ not loop.last ? 'md:border-r md:border-hairline' }}"
                              style="border-top: 3px solid var(--primary);">
                             <p class="font-display text-sm font-bold uppercase text-ink-strong">{{ universe.extension.name }}</p>
-                            <p class="mt-3 font-display text-4xl font-bold tracking-[-0.04em] text-primary">{{ universe.pct }}%</p>
+                            <p class="mt-3 font-display text-4xl font-bold tracking-[-0.04em] text-primary">{{ universe.percentage }}%</p>
                             <p class="chip-mono mt-1 text-ink-dim">{{ universe.owned }}/{{ universe.total }} cartes</p>
                         </div>
                     {% endfor %}

--- a/templates/pages/collection.html.twig
+++ b/templates/pages/collection.html.twig
@@ -1,0 +1,122 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    YOUL TCG — Ma collection
+{% endblock %}
+
+{% block body %}
+    <main>
+        {# ----------------------------------------------------- Bandeau user #}
+        <section class="relative border-b border-hairline px-6 py-10 lg:px-12">
+            <div class="glow-ambient" aria-hidden="true"></div>
+            <div class="relative mx-auto grid max-w-7xl items-center gap-8 md:grid-cols-[auto_1fr_auto]">
+                <div class="notched-avatar h-[100px] w-[100px] bg-gradient-to-br from-primary to-magenta p-[3px]">
+                    <div class="notched-avatar flex h-full w-full items-center justify-center bg-bg font-display text-[44px] font-bold text-primary">
+                        {{ app.user.username|first|upper }}
+                    </div>
+                </div>
+
+                <div>
+                    <h1 class="font-display text-4xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-5xl">
+                        {{ app.user.username }}
+                    </h1>
+                    <p class="mt-1.5 font-mono text-xs text-ink-dim">joueur depuis {{ app.user.createdAt|date('m/Y') }}</p>
+
+                    <div class="mt-4 max-w-md" data-testid="global-completion">
+                        <div class="chip-mono mb-1 flex justify-between text-ink-muted">
+                            <span>Complétion</span>
+                            <span>{{ ownedTotalDistinct }} / {{ totalPublished }} cartes · {{ completionPct }}%</span>
+                        </div>
+                        <div class="h-2 border border-hairline bg-surface">
+                            <div class="h-full bg-gradient-to-r from-primary to-magenta shadow-[0_0_10px_#a435f0]"
+                                 style="width: {{ completionPct }}%;"></div>
+                        </div>
+                    </div>
+                    <p class="chip-mono mt-2 text-ink-dim">Cartes possédées · {{ ownedTotalQuantity }}</p>
+                </div>
+
+                <div class="flex flex-col items-start gap-2.5 md:items-end">
+                    <div class="bg-primary px-5 py-3.5 text-black" data-testid="daily-packs">
+                        <p class="font-mono text-[10px] font-bold tracking-[.2em]">PACKS / JOUR</p>
+                        <p class="mt-1 font-display text-3xl font-bold leading-none">
+                            {{ remainingClaims }}<span class="text-lg opacity-50"> / {{ dailyLimit }}</span>
+                        </p>
+                    </div>
+                    <a href="{{ path('boosters') }}"
+                       class="border border-primary bg-black px-5 py-3.5 font-display text-[13px] font-bold uppercase tracking-[.15em] text-primary">
+                        Ouvrir un pack ▸
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        {# ----------------------------------------- Complétion par univers #}
+        <section class="border-b border-hairline px-6 py-8 lg:px-12">
+            <div class="mx-auto max-w-7xl">
+                <p class="eyebrow">Complétion par univers</p>
+                <div class="mt-4 flex flex-col md:flex-row" data-testid="completion-strip">
+                    {% for universe in universes %}
+                        <div class="flex-1 p-5 {{ not loop.last ? 'md:border-r md:border-hairline' }}"
+                             style="border-top: 3px solid var(--primary);">
+                            <p class="font-display text-sm font-bold uppercase text-ink-strong">{{ universe.extension.name }}</p>
+                            <p class="mt-3 font-display text-4xl font-bold tracking-[-0.04em] text-primary">{{ universe.pct }}%</p>
+                            <p class="chip-mono mt-1 text-ink-dim">{{ universe.owned }}/{{ universe.total }} cartes</p>
+                        </div>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+
+        {# --------------------------------------------------------- Filtres #}
+        <section class="px-6 pb-4 pt-8 lg:px-12">
+            <div class="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4">
+                <nav class="flex flex-wrap" data-testid="filters">
+                    {{ _self.filter_tab(path('collection'), 'Tout', ownedTotalDistinct, currentExtension is null) }}
+                    {% for universe in universes %}
+                        {{ _self.filter_tab(
+                            path('collection', { extension: universe.extension.id }),
+                            universe.extension.name,
+                            universe.owned,
+                            currentExtension is not null and currentExtension.id == universe.extension.id,
+                        ) }}
+                    {% endfor %}
+                </nav>
+                <span class="font-mono text-[11px] tracking-[.15em] text-ink-dim">TRI: RÉCENTS ↓</span>
+            </div>
+        </section>
+
+        {# ---------------------------------------------------------- Grille #}
+        <section class="px-6 pb-24 pt-6 lg:px-12">
+            <div class="mx-auto max-w-7xl">
+                {% if userCards is not empty %}
+                    <div class="grid grid-cols-2 gap-6 md:grid-cols-3 xl:grid-cols-5" data-testid="collection-grid">
+                        {% for userCard in userCards %}
+                            <div class="relative">
+                                {{ include('components/CardComponent.html.twig', { card: userCard.card }) }}
+                                <div class="pointer-events-none absolute -right-2 -top-2 z-10 flex gap-1.5">
+                                    <span class="chip-mono bg-black/90 px-2 py-1 font-bold text-white">×{{ userCard.quantity }}</span>
+                                    {% if userCard.holoQuantity > 0 %}
+                                        <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">✦{{ userCard.holoQuantity }}</span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                {% else %}
+                    <div class="border border-dashed border-hairline px-8 py-20 text-center text-ink-dim" data-testid="empty-state">
+                        <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Vide.</p>
+                        <p class="mt-3 text-sm">Aucune carte de cet univers. Ouvre un pack.</p>
+                        <a href="{{ path('boosters') }}" class="btn-arcade mt-8">Ouvrir un pack ▸</a>
+                    </div>
+                {% endif %}
+            </div>
+        </section>
+    </main>
+{% endblock %}
+
+{% macro filter_tab(url, label, count, isActive) %}
+    <a href="{{ url }}"
+       class="border border-hairline px-4 py-2.5 font-display text-xs font-bold uppercase tracking-[.1em] {{ isActive ? 'bg-primary text-black' : 'text-ink-muted hover:text-ink-strong' }}">
+        {{ label }} · {{ count }}
+    </a>
+{% endmacro %}

--- a/templates/parts/_header.html.twig
+++ b/templates/parts/_header.html.twig
@@ -11,6 +11,7 @@
 
         <nav class="hidden items-center gap-7 font-display text-sm font-semibold uppercase tracking-[.1em] md:flex">
             {{ _self.nav_link('homepage', 'Accueil') }}
+            {{ _self.nav_link('collection', 'Collection') }}
             {{ _self.nav_link('extensions', 'Univers') }}
             {{ _self.nav_link('boosters', 'Boosters') }}
             {{ _self.nav_soon('Échanges') }}

--- a/tests/Functional/CollectionControllerTest.php
+++ b/tests/Functional/CollectionControllerTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Entity\UserCard;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class CollectionControllerTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private KernelBrowser $client;
+
+    private EntityManagerInterface $entityManager;
+
+    private DiscordUser $user;
+
+    private Extension $extensionA;
+
+    private Extension $extensionB;
+
+    /** @var list<Card> */
+    private array $cardsA = [];
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->user = $this->authenticateClient($this->client);
+
+        $this->createScenario();
+    }
+
+    public function testBannerShowsUserAndRealQuota(): void
+    {
+        $crawler = $this->client->request('GET', '/collection');
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString($this->user->getUsername(), $crawler->filter('h1')->text());
+
+        $quota = $crawler->filter('[data-testid="daily-packs"]')->text();
+        $this->assertStringContainsString('2', $quota);
+        $this->assertStringContainsString('/ 2', $quota);
+
+        $this->assertStringContainsString(
+            'Cartes possédées · 5',
+            $crawler->filter('main')->text(),
+        );
+    }
+
+    public function testCompletionStripShowsPerUniverseNumbers(): void
+    {
+        $crawler = $this->client->request('GET', '/collection');
+
+        self::assertResponseIsSuccessful();
+        $strip = $crawler->filter('[data-testid="completion-strip"]')->text();
+        // Extension A: 2 owned out of 4 published (the draft card must not count).
+        $this->assertStringContainsString('50%', $strip);
+        $this->assertStringContainsString('2/4 cartes', $strip);
+        // Extension B: nothing owned.
+        $this->assertStringContainsString('0/2 cartes', $strip);
+    }
+
+    public function testFilterTabsShowOwnedCounts(): void
+    {
+        $crawler = $this->client->request('GET', '/collection');
+
+        self::assertResponseIsSuccessful();
+        $filters = $crawler->filter('[data-testid="filters"]')->text();
+        $this->assertStringContainsString(\sprintf('%s · 2', $this->extensionA->getName()), $filters);
+        $this->assertStringContainsString(\sprintf('%s · 0', $this->extensionB->getName()), $filters);
+    }
+
+    public function testGridShowsOwnedCardsWithQuantityBadges(): void
+    {
+        $crawler = $this->client->request('GET', '/collection');
+
+        self::assertResponseIsSuccessful();
+        $grid = $crawler->filter('[data-testid="collection-grid"]');
+        $this->assertStringContainsString('×3', $grid->text());
+        $this->assertStringContainsString('✦1', $grid->text());
+        // The zero-quantity inventory row must not produce a card.
+        $this->assertCount(0, $grid->filter(\sprintf('img[alt="%s"]', $this->cardsA[2]->getName())));
+    }
+
+    public function testExtensionFilterOnlyShowsItsCards(): void
+    {
+        $crawler = $this->client->request('GET', '/collection?extension=' . $this->extensionA->getId());
+
+        self::assertResponseIsSuccessful();
+        $grid = $crawler->filter('[data-testid="collection-grid"]');
+        $this->assertCount(1, $grid->filter(\sprintf('img[alt="%s"]', $this->cardsA[0]->getName())));
+        $this->assertCount(1, $grid->filter(\sprintf('img[alt="%s"]', $this->cardsA[1]->getName())));
+
+        // Active tab is highlighted.
+        $this->assertStringContainsString(
+            $this->extensionA->getName(),
+            $crawler->filter('[data-testid="filters"] a.bg-primary')->text(),
+        );
+    }
+
+    public function testEmptyStateWhenNoCardOwnedInExtension(): void
+    {
+        $crawler = $this->client->request('GET', '/collection?extension=' . $this->extensionB->getId());
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(0, $crawler->filter('[data-testid="collection-grid"]'));
+        $this->assertStringContainsString('Vide.', $crawler->filter('[data-testid="empty-state"]')->text());
+    }
+
+    public function testUnknownExtensionIsNotFound(): void
+    {
+        $this->client->request('GET', '/collection?extension=' . Uuid::v4());
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testMalformedExtensionIsNotFound(): void
+    {
+        $this->client->request('GET', '/collection?extension=not-a-uuid');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * Extension A: 4 published cards (+1 draft) — the user owns 2 of them
+     * (one ×3 with 1 holo, one ×1) plus a zero-quantity leftover row.
+     * Extension B: 2 published cards — the user owns none.
+     */
+    private function createScenario(): void
+    {
+        $this->extensionA = $this->createExtension('Collection ext A ' . uniqid());
+        $this->extensionB = $this->createExtension('Collection ext B ' . uniqid());
+
+        for ($i = 0; $i < 4; ++$i) {
+            $this->cardsA[] = $this->createCard($this->extensionA, \sprintf('Card A%d %s', $i, uniqid()));
+        }
+        $this->createCard($this->extensionA, 'Draft card ' . uniqid(), CardStatusEnum::DRAFT);
+
+        for ($i = 0; $i < 2; ++$i) {
+            $this->createCard($this->extensionB, \sprintf('Card B%d %s', $i, uniqid()));
+        }
+
+        $this->createUserCard($this->cardsA[0], quantity: 3, holoQuantity: 1);
+        $this->createUserCard($this->cardsA[1], quantity: 1);
+        $this->createUserCard($this->cardsA[2], quantity: 0);
+
+        $this->entityManager->flush();
+    }
+
+    private function createExtension(string $name): Extension
+    {
+        $extension = new Extension()
+            ->setName($name)
+            ->setDescription('Test extension')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($extension);
+
+        return $extension;
+    }
+
+    private function createCard(Extension $extension, string $name, CardStatusEnum $status = CardStatusEnum::PUBLISHED): Card
+    {
+        $card = new Card()
+            ->setName($name)
+            ->setDescription('Test card')
+            ->setStatus($status)
+            ->setRarity(CardRarityEnum::COMMON)
+            ->setExtension($extension)
+        ;
+        $card->setImageName('default_card.png');
+        $this->entityManager->persist($card);
+
+        return $card;
+    }
+
+    private function createUserCard(Card $card, int $quantity, int $holoQuantity = 0): void
+    {
+        $userCard = new UserCard()
+            ->setDiscordUser($this->user)
+            ->setCard($card)
+            ->setQuantity($quantity)
+            ->setHoloQuantity($holoQuantity)
+        ;
+        $this->entityManager->persist($userCard);
+    }
+}


### PR DESCRIPTION
## Phase 2c — Page `/collection` (nouvelle feature)

Empilée sur #38 (2b). Implémente le profil/collection du design Violet Arcade — l'inventaire `UserCard` n'avait aucune UI jusqu'ici.

### Contenu
- **`CollectionController`** : `/collection?extension={uuid}` — filtre **server-side** (décision review) ; le param est résolu contre la liste des extensions publiées déjà chargée (pas de lookup Doctrine → un uuid malformé donne un 404 propre, pas une ConversionException)
- **`UserCardRepository`** :
  - `findOwnedWithCards()` — join+addSelect carte+extension (pas de N+1 malgré l'EAGER), `quantity > 0 OR holoQuantity > 0`, tri `updatedAt DESC` (= « RÉCENTS »)
  - `countOwnedGroupedByExtension()`, `sumOwnedQuantities()`
  - Les totaux par extension réutilisent `findPublishedWithPublishedCardCount()` de la 2b
- **Bandeau adapté** (le XP/level/duels du design est hors scope — pas de feature derrière) : avatar octogone gradient, pseudo, « joueur depuis », **barre de complétion globale** à la place de l'XP, total de cartes possédées, tuile **PACKS / JOUR réelle** (`BoosterClaimQuotaInterface`) + CTA vers `/boosters`
- **Strip de complétion par univers** (pct, owned/total), **tabs de filtres** avec compteurs, **grille 5 colonnes** de cartes 3D avec badges `×n` / `✦n` (holo), **empty state** dashed
- Entrée **Collection** dans la nav

### Tests
`CollectionControllerTest` (données créées en setUp, rattachées au user fixture authentifié par cookie JWT) : bandeau + quota 2/2, complétion 50% & 2/4 (la carte DRAFT ne compte pas), compteurs de tabs, filtre par extension + tab active, badges, ligne 0/0 masquée, 404 uuid inconnu/malformé, empty state.

`make quality` ✅ · `make phpunit` ✅ (51 tests)