### PR TITLE
feat(booster): per-slot holo chance + extension→card visual config cascade (Phase 3a)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,18 +98,20 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 **Core Entities:**
 - **Card**: Trading cards with multi-image support (main image, mask, foil)
-  - Fields: name, description, status (DRAFT/PUBLISHED), rarity (CardRarityEnum: common/uncommon/rare/epic/legendary — white/green/blue/purple/orange glows), uniqueFlag
-  - No "type" field: visual customization (glow, borders, CSS aspects) will be an extension-level config overridable per card (future phase)
+  - Fields: name, description, status (DRAFT/PUBLISHED), rarity (CardRarityEnum: common/uncommon/rare/epic/legendary — white/green/blue/purple/orange glows), uniqueFlag, alwaysHolo (forces holo whatever the slot's holoChance), visualConfigOverride (JSON, per-card override of the extension's visualConfig)
+  - No "type" field: visual customization is the extension→card VisualConfig cascade (see below)
   - Uses VichUploaderBundle for file uploads
   - ManyToOne with Extension
 
 - **Extension**: Card sets/expansions
-  - Fields: name, description, status, imageName
+  - Fields: name, description, status, imageName, visualConfig (JSON, set-level card visual defaults), default foil/mask images
   - OneToMany with Card and Booster
 
 - **Booster**: Booster packs containing cards
-  - Fields: rarityRates (JSON, one `{rarity: weight}` map per card slot — the slot count IS the card count), holoRate (0-100 % holo chance per drawn card), imageName
+  - Fields: rarityRates (JSON, one `{rarities: {rarity: weight}, holoChance: int}` entry per card slot — the slot count IS the card count, holoChance is the 0-100 % holo probability of that slot; there is NO global holoRate anymore), imageName
   - ManyToOne with Extension; boosters are free (no currency in v2)
+
+**Visual config cascade:** `CardVisualResolver` (`src/Service/Card/`) resolves `Card.visualConfigOverride` → `Extension.visualConfig` → rarity defaults into a `ResolvedCardVisual` DTO, consumed by templates through the `card_visual(card)` Twig function. Edit visuals through this cascade, never per-template.
 
 **User System:**
 - **DiscordUser**: Main user entity (implements UserInterface)

--- a/assets/styles/cards/holo.css
+++ b/assets/styles/cards/holo.css
@@ -162,3 +162,28 @@
         rgba(0, 0, 0, .55) 90%
     );
 }
+
+/* ------------------------------------------- Holo permanent (carte tirée holo) */
+/*
+ * Une carte marquée .holo garde un voile holo allumé même hors interaction
+ * (reveal / butin) : on rallume les calques au repos avec une opacité douce et
+ * une position de gradient centrée. L'interaction reprend ensuite le dessus.
+ */
+.card.holo {
+    --card-opacity: var(--holo-intensity);
+}
+
+.card.holo:not(.interacting) .card__shine,
+.card.holo:not(.interacting) .card__glare {
+    opacity: calc(var(--holo-intensity) * .55);
+    visibility: visible;
+}
+
+/* --------------------------------------------- Bordure d'accent (config visuelle) */
+/*
+ * Pilotée par --card-border (résolu carte -> extension). Transparent par
+ * défaut : aucune carte sans config n'est affectée.
+ */
+.card__front {
+    box-shadow: inset 0 0 0 1.5px var(--card-border, transparent);
+}

--- a/fixtures/Booster.yaml
+++ b/fixtures/Booster.yaml
@@ -2,22 +2,19 @@ App\Entity\Booster:
     booster_cyberpunk:
         extension: '@extension_cyberpunk'
         imageName: 'default_card.png'
-        holoRate: 10
         rarityRates:
-            - { common: 100 }
-            - { common: 100 }
-            - { common: 55, rare: 25, epic: 15, legendary: 5 }
+            - { rarities: { common: 100 }, holoChance: 5 }
+            - { rarities: { common: 100 }, holoChance: 5 }
+            - { rarities: { common: 55, rare: 25, epic: 15, legendary: 5 }, holoChance: 35 }
     booster_bleach:
         extension: '@extension_bleach'
         imageName: 'default_card.png'
-        holoRate: 100
         rarityRates:
-            - { common: 70, rare: 30 }
-            - { rare: 100 }
+            - { rarities: { common: 70, rare: 30 }, holoChance: 50 }
+            - { rarities: { rare: 100 }, holoChance: 100 }
     booster_magic:
         extension: '@extension_magic'
         imageName: 'default_card.png'
-        holoRate: 0
         rarityRates:
-            - { common: 100 }
-            - { common: 50, uncommon: 30, rare: 15, legendary: 5 }
+            - { rarities: { common: 100 }, holoChance: 0 }
+            - { rarities: { common: 50, uncommon: 30, rare: 15, legendary: 5 }, holoChance: 25 }

--- a/fixtures/Card.yaml
+++ b/fixtures/Card.yaml
@@ -7,6 +7,8 @@ App\Entity\Card:
         imageName: 'default_card.png'
         status: 2
         rarity: 'legendary'
+        alwaysHolo: true
+        visualConfigOverrideJson: '{"glow": "#ff3db0"}'
     card_rogue:
         name: 'Cyberpunk Rogue'
         extension: '@extension_cyberpunk'
@@ -45,3 +47,4 @@ App\Entity\Card:
         imageName: 'default_card.png'
         status: 2
         rarity: 'legendary'
+        alwaysHolo: true

--- a/fixtures/Extension.yaml
+++ b/fixtures/Extension.yaml
@@ -4,6 +4,7 @@ App\Entity\Extension:
         description: 'Cyberpunk 2077 is an open-world, action-adventure story set in Night City, a megalopolis obsessed with power, glamour and body modification. You play as V, a mercenary outlaw going after a one-of-a-kind implant that is the key to immortality. You can customize your character’s cyberware, skillset and playstyle, and explore a vast city where the choices you make shape the story and the world around you.'
         imageName: 'images/cards/default_card.png'
         status: 2
+        visualConfigJson: '{"glow": "#a435f0"}'
     extension_bleach:
         name: 'Bleach'
         description: 'Bleach is a Japanese manga series written and illustrated by Tite Kubo. Bleach follows the adventures of the hotheaded teenager Ichigo Kurosaki, who inherits his parents’ destiny after he obtains the powers of a Soul Reaper—a death personification similar to the Grim Reaper—from another Soul Reaper, Rukia Kuchiki.'

--- a/migrations/Version20260613140000.php
+++ b/migrations/Version20260613140000.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Holo refonte + visual config cascade:
+ *  - per-slot holo chance folded into booster.rarity_rates (drops the global
+ *    booster.holo_rate), migrating existing data;
+ *  - card.always_holo flag;
+ *  - per-card visual override (card.visual_config_override) and per-extension
+ *    default visual config (extension.visual_config) + default foil/mask.
+ */
+final class Version20260613140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Per-slot holo chance in rarity_rates, always_holo flag, and the extension->card visual config cascade';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Read the current boosters before the schema changes drop holo_rate.
+        $boosters = $this->connection->fetchAllAssociative('SELECT id, rarity_rates, holo_rate FROM booster');
+
+        $this->addSql("ALTER TABLE card ADD always_holo BOOLEAN DEFAULT false NOT NULL");
+        $this->addSql("ALTER TABLE card ADD visual_config_override JSON DEFAULT '{}' NOT NULL");
+        $this->addSql("ALTER TABLE extension ADD image_foil_name VARCHAR(255) DEFAULT NULL");
+        $this->addSql("ALTER TABLE extension ADD image_mask_name VARCHAR(255) DEFAULT NULL");
+        $this->addSql("ALTER TABLE extension ADD visual_config JSON DEFAULT '{}' NOT NULL");
+
+        foreach ($boosters as $booster) {
+            $oldSlots = json_decode((string) $booster['rarity_rates'], true, flags: \JSON_THROW_ON_ERROR);
+            $holoChance = (int) $booster['holo_rate'];
+
+            $newSlots = array_map(
+                static fn (array $rarities): array => ['rarities' => $rarities, 'holoChance' => $holoChance],
+                \is_array($oldSlots) ? $oldSlots : [],
+            );
+
+            $this->addSql(
+                'UPDATE booster SET rarity_rates = ? WHERE id = ?',
+                [json_encode($newSlots, \JSON_THROW_ON_ERROR), $booster['id']],
+            );
+        }
+
+        $this->addSql('ALTER TABLE booster DROP holo_rate');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $boosters = $this->connection->fetchAllAssociative('SELECT id, rarity_rates FROM booster');
+
+        $this->addSql("ALTER TABLE booster ADD holo_rate INT DEFAULT 10 NOT NULL");
+
+        foreach ($boosters as $booster) {
+            $newSlots = json_decode((string) $booster['rarity_rates'], true, flags: \JSON_THROW_ON_ERROR);
+            $newSlots = \is_array($newSlots) ? $newSlots : [];
+
+            $holoChance = isset($newSlots[0]['holoChance']) ? (int) $newSlots[0]['holoChance'] : 10;
+            $oldSlots = array_map(
+                static fn (array $slot): array => $slot['rarities'] ?? [],
+                $newSlots,
+            );
+
+            $this->addSql(
+                'UPDATE booster SET rarity_rates = ?, holo_rate = ? WHERE id = ?',
+                [json_encode($oldSlots, \JSON_THROW_ON_ERROR), $holoChance, $booster['id']],
+            );
+        }
+
+        $this->addSql('ALTER TABLE card DROP always_holo');
+        $this->addSql('ALTER TABLE card DROP visual_config_override');
+        $this->addSql('ALTER TABLE extension DROP image_foil_name');
+        $this->addSql('ALTER TABLE extension DROP image_mask_name');
+        $this->addSql('ALTER TABLE extension DROP visual_config');
+    }
+}

--- a/src/Controller/Admin/BoosterCrudController.php
+++ b/src/Controller/Admin/BoosterCrudController.php
@@ -84,14 +84,11 @@ class BoosterCrudController extends AbstractCrudController
             ->setLabel('Cards')
             ->hideOnForm()
         ;
-        yield IntegerField::new('holoRate')
-            ->setHelp('Chance (0-100 %) for each drawn card to be holo')
-        ;
         yield CodeEditorField::new('rarityRatesJson')
             ->setLabel('Rarity rates')
             ->setLanguage('js')
             ->onlyOnForms()
-            ->setHelp('One weight map per card slot. Example: [{"common": 100}, {"common": 100}, {"common": 60, "rare": 30, "legendary": 10}]')
+            ->setHelp('One slot per card: a rarity weight map plus a holo chance (0-100 %). Example: [{"rarities": {"common": 100}, "holoChance": 5}, {"rarities": {"common": 60, "rare": 30, "legendary": 10}, "holoChance": 30}]')
         ;
         yield Field::new('rarityRates')->onlyOnDetail();
         yield VichImageField::new('imageFile')->onlyOnForms();

--- a/src/Controller/Admin/CardCrudController.php
+++ b/src/Controller/Admin/CardCrudController.php
@@ -16,6 +16,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\CodeEditorField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ImageField;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
@@ -94,7 +95,27 @@ class CardCrudController extends AbstractCrudController
             ->setLabel('Unique Flag')
             ->renderAsSwitch(false)
         ;
+        yield BooleanField::new('alwaysHolo')
+            ->setLabel('Always holo')
+            ->setHelp('Always drawn holo, whatever the slot holo chance')
+            ->renderAsSwitch(false)
+        ;
         yield AssociationField::new('extension');
         yield VichImageField::new('imageFile')->onlyOnForms();
+        yield VichImageField::new('imageFoilFile')
+            ->setLabel('Foil texture')
+            ->onlyOnForms()
+        ;
+        yield VichImageField::new('imageMaskFile')
+            ->setLabel('Holo mask')
+            ->onlyOnForms()
+        ;
+        yield CodeEditorField::new('visualConfigOverrideJson')
+            ->setLabel('Visual overrides')
+            ->setLanguage('js')
+            ->onlyOnForms()
+            ->setHelp('Optional per-card overrides. Example: {"glow": "#ff3db0", "cssClass": "my-card"}')
+        ;
+        yield Field::new('visualConfigOverrideJson')->setLabel('Visual overrides')->onlyOnDetail();
     }
 }

--- a/src/Controller/Admin/ExtensionCrudController.php
+++ b/src/Controller/Admin/ExtensionCrudController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Admin;
 
+use App\Admin\Field\ImageField as VichImageField;
 use App\Entity\Extension;
 use App\Enum\Entity\ExtensionStatusEnum;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
@@ -11,6 +12,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\CodeEditorField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 
 /**
@@ -51,5 +53,21 @@ class ExtensionCrudController extends AbstractCrudController
         yield ChoiceField::new('status')
             ->setChoices(ExtensionStatusEnum::cases())
         ;
+        yield VichImageField::new('imageFoilFile')
+            ->setLabel('Default foil texture')
+            ->setHelp('Holo foil fallback for cards of this extension that have none')
+            ->onlyOnForms()
+        ;
+        yield VichImageField::new('imageMaskFile')
+            ->setLabel('Default holo mask')
+            ->onlyOnForms()
+        ;
+        yield CodeEditorField::new('visualConfigJson')
+            ->setLabel('Visual config')
+            ->setLanguage('js')
+            ->onlyOnForms()
+            ->setHelp('Default visuals for the extension cards. Example: {"glow": "#a435f0", "borderColor": "#ff3db0"}')
+        ;
+        yield Field::new('visualConfigJson')->setLabel('Visual config')->onlyOnDetail();
     }
 }

--- a/src/Controller/Dev/CardEffectsDemoController.php
+++ b/src/Controller/Dev/CardEffectsDemoController.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Controller\Dev;
 
+use App\Dto\VisualConfig;
 use App\Entity\Card;
+use App\Entity\Extension;
 use App\Enum\Entity\CardRarityEnum;
 use App\Enum\Entity\CardStatusEnum;
 use App\Repository\CardRepository;
@@ -15,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Dev-only showcase of card visual effects: the same card rendered at the
  * five rarity tiers (glow + holo recipe keyed by data-rarity, see
- * assets/styles/cards/holo.css), plus free-color overrides previewing the
- * future extension-level visual config (default glow per extension,
- * overridable per card).
+ * assets/styles/cards/holo.css), plus free-color overrides exercising the
+ * real visual-config cascade (Card::visualConfigOverride beating the
+ * data-rarity default through CardVisualResolver).
  *
  * The service only exists in the dev container (#[When]) and the route is
  * declared in config/routes.yaml under when@dev (a #[Route] attribute would
@@ -27,8 +29,8 @@ use Symfony\Component\HttpFoundation\Response;
 class CardEffectsDemoController extends AbstractController
 {
     /**
-     * Free glow overrides: any color works (--card-glow inherited from a
-     * wrapper beats the data-rarity default).
+     * Free glow overrides: any color works (a per-card override beats the
+     * extension default and the data-rarity default).
      */
     private const array GLOW_OVERRIDES = [
         'violet arcade' => '#a435f0',
@@ -40,10 +42,14 @@ class CardEffectsDemoController extends AbstractController
         $referenceCard = $cardRepository->findOneBy(['status' => CardStatusEnum::PUBLISHED])
             ?? throw $this->createNotFoundException('No published card found, load the fixtures first.');
 
+        // A bare transient extension so the rarity showcase shows pure
+        // data-rarity defaults, free of any extension-level glow config.
+        $bareExtension = new Extension()->setName('Demo')->setDescription('Demo');
+
         $rarityDemos = [];
         foreach (CardRarityEnum::cases() as $rarity) {
             $rarityDemos[] = [
-                'card' => $this->variant($referenceCard, $rarity->value, \sprintf('data-rarity: %s', $rarity->value))
+                'card' => $this->variant($referenceCard, $bareExtension, $rarity->value)
                     ->setRarity($rarity),
                 'rarity' => $rarity->value,
             ];
@@ -52,7 +58,8 @@ class CardEffectsDemoController extends AbstractController
         $overrideDemos = [];
         foreach (self::GLOW_OVERRIDES as $label => $glow) {
             $overrideDemos[] = [
-                'card' => $this->variant($referenceCard, $label, \sprintf('--card-glow: %s', $glow)),
+                'card' => $this->variant($referenceCard, $bareExtension, $label)
+                    ->setVisualConfigOverride(new VisualConfig(glow: $glow)),
                 'label' => $label,
                 'glow' => $glow,
             ];
@@ -65,13 +72,13 @@ class CardEffectsDemoController extends AbstractController
     }
 
     /**
-     * Transient clone, never persisted: same artwork, demo label.
+     * Transient clone, never persisted: same artwork, bare extension, demo label.
      */
-    private function variant(Card $referenceCard, string $label, string $description): Card
+    private function variant(Card $referenceCard, Extension $extension, string $label): Card
     {
         $variant = clone $referenceCard;
         $variant->setName(ucfirst($label));
-        $variant->setDescription($description);
+        $variant->setExtension($extension);
 
         return $variant;
     }

--- a/src/Dto/ResolvedCardVisual.php
+++ b/src/Dto/ResolvedCardVisual.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+/**
+ * The visual properties of a card after the resolution cascade
+ * (card -> extension -> system default), ready to be consumed by
+ * CardComponent. URLs are public asset paths; colours/classes are null when
+ * nothing overrides the rarity-keyed default of holo.css.
+ */
+final readonly class ResolvedCardVisual
+{
+    public function __construct(
+        public ?string $foilUrl = null,
+        public ?string $maskUrl = null,
+        public ?string $glow = null,
+        public ?string $borderColor = null,
+        public ?string $cssClass = null,
+    ) {
+    }
+
+    public function hasMask(): bool
+    {
+        return null !== $this->maskUrl;
+    }
+}

--- a/src/Dto/VisualConfig.php
+++ b/src/Dto/VisualConfig.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+/**
+ * Visual customisation of a card: ambient glow colour, border accent colour
+ * and an extra CSS class. Configured at the Extension level and overridable
+ * per Card; every field is independently nullable so a card override can set
+ * the glow while inheriting the rest of the extension's configuration.
+ *
+ * Persisted as a JSON map; a null/absent field falls through the resolution
+ * cascade (card override -> extension config -> system default keyed by
+ * rarity in holo.css).
+ */
+final readonly class VisualConfig
+{
+    public function __construct(
+        public ?string $glow = null,
+        public ?string $borderColor = null,
+        public ?string $cssClass = null,
+    ) {
+    }
+
+    /**
+     * @param array<string, mixed>|null $data
+     */
+    public static function fromArray(?array $data): self
+    {
+        $data ??= [];
+
+        return new self(
+            glow: self::stringOrNull($data['glow'] ?? null),
+            borderColor: self::stringOrNull($data['borderColor'] ?? null),
+            cssClass: self::stringOrNull($data['cssClass'] ?? null),
+        );
+    }
+
+    /**
+     * @return array<string, string> only the set fields, ready for JSON storage
+     */
+    public function toArray(): array
+    {
+        return array_filter(
+            [
+                'glow' => $this->glow,
+                'borderColor' => $this->borderColor,
+                'cssClass' => $this->cssClass,
+            ],
+            static fn (?string $value): bool => null !== $value,
+        );
+    }
+
+    public function isEmpty(): bool
+    {
+        return null === $this->glow && null === $this->borderColor && null === $this->cssClass;
+    }
+
+    private static function stringOrNull(mixed $value): ?string
+    {
+        if (!\is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+
+        return '' === $trimmed ? null : $trimmed;
+    }
+}

--- a/src/Entity/Booster.php
+++ b/src/Entity/Booster.php
@@ -11,7 +11,6 @@ use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
 #[Vich\Uploadable]
@@ -22,21 +21,17 @@ class Booster implements \Stringable
     use TimestampableEntity;
 
     /**
-     * One weight map per card slot, keys are CardRarityEnum values.
-     * Example for a 3-card booster: [{common: 100}, {common: 100}, {common: 60, rare: 30, legendary: 10}].
+     * One slot per card the booster yields. Each slot carries its own rarity
+     * weight map (keys are CardRarityEnum values) and its own holo chance
+     * (0-100 %) rolled independently for the card drawn in that slot.
+     * Example for a 2-card booster:
+     * [{rarities: {common: 100}, holoChance: 5}, {rarities: {common: 60, rare: 40}, holoChance: 30}].
      *
-     * @var list<array<string, int>>
+     * @var list<array{rarities: array<string, int>, holoChance: int}>
      */
     #[ValidRarityRates]
     #[ORM\Column(type: Types::JSON, options: ['default' => '[]'])]
     private array $rarityRates = [];
-
-    /**
-     * Chance (0-100 %) for each drawn card to be holo.
-     */
-    #[Assert\Range(min: 0, max: 100)]
-    #[ORM\Column(options: ['default' => 10])]
-    private int $holoRate = 10;
 
     #[Vich\UploadableField(mapping: 'boosters', fileNameProperty: 'imageName')]
     private ?File $imageFile = null;
@@ -54,7 +49,7 @@ class Booster implements \Stringable
     }
 
     /**
-     * @return list<array<string, int>>
+     * @return list<array{rarities: array<string, int>, holoChance: int}>
      */
     public function getRarityRates(): array
     {
@@ -62,7 +57,7 @@ class Booster implements \Stringable
     }
 
     /**
-     * @param list<array<string, int>> $rarityRates
+     * @param list<array{rarities: array<string, int>, holoChance: int}> $rarityRates
      */
     public function setRarityRates(array $rarityRates): static
     {
@@ -94,18 +89,6 @@ class Booster implements \Stringable
         }
 
         $this->rarityRates = \is_array($decoded) ? array_values($decoded) : [];
-    }
-
-    public function getHoloRate(): int
-    {
-        return $this->holoRate;
-    }
-
-    public function setHoloRate(int $holoRate): static
-    {
-        $this->holoRate = $holoRate;
-
-        return $this;
     }
 
     /**

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Dto\VisualConfig;
 use App\Enum\Entity\CardRarityEnum;
 use App\Enum\Entity\CardStatusEnum;
 use App\Repository\CardRepository;
 use Barlito\Utils\Traits\IdUuidTrait;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\HttpFoundation\File\File;
@@ -39,6 +41,13 @@ class Card
     #[ORM\Column]
     private bool $uniqueFlag = false;
 
+    /**
+     * When true the card is always drawn holo, whatever the slot's holoChance
+     * (e.g. legendaries that should always shine).
+     */
+    #[ORM\Column(options: ['default' => false])]
+    private bool $alwaysHolo = false;
+
     #[Assert\Valid]
     #[Assert\NotBlank]
     #[ORM\ManyToOne(fetch: 'EAGER', inversedBy: 'cards')]
@@ -61,6 +70,15 @@ class Card
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private ?string $imageFoilName = null;
+
+    /**
+     * Per-card visual overrides (glow / border / css class); each set field
+     * beats the extension's default in the resolution cascade.
+     *
+     * @var array<string, string>
+     */
+    #[ORM\Column(type: Types::JSON, options: ['default' => '{}'])]
+    private array $visualConfigOverride = [];
 
     public function getName(): string
     {
@@ -118,6 +136,18 @@ class Card
     public function setUnique(bool $uniqueFlag): static
     {
         $this->uniqueFlag = $uniqueFlag;
+
+        return $this;
+    }
+
+    public function isAlwaysHolo(): bool
+    {
+        return $this->alwaysHolo;
+    }
+
+    public function setAlwaysHolo(bool $alwaysHolo): static
+    {
+        $this->alwaysHolo = $alwaysHolo;
 
         return $this;
     }
@@ -229,5 +259,36 @@ class Card
     public function getImageFoilName(): ?string
     {
         return $this->imageFoilName;
+    }
+
+    public function getVisualConfigOverride(): VisualConfig
+    {
+        return VisualConfig::fromArray($this->visualConfigOverride);
+    }
+
+    public function setVisualConfigOverride(VisualConfig $visualConfig): static
+    {
+        $this->visualConfigOverride = $visualConfig->toArray();
+
+        return $this;
+    }
+
+    public function getVisualConfigOverrideJson(): string
+    {
+        return json_encode($this->visualConfigOverride, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Invalid JSON resolves to no override.
+     */
+    public function setVisualConfigOverrideJson(string $json): void
+    {
+        try {
+            $decoded = json_decode($json, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $decoded = null;
+        }
+
+        $this->visualConfigOverride = VisualConfig::fromArray(\is_array($decoded) ? $decoded : [])->toArray();
     }
 }

--- a/src/Entity/Extension.php
+++ b/src/Entity/Extension.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Entity;
 
+use App\Dto\VisualConfig;
 use App\Enum\Entity\ExtensionStatusEnum;
 use App\Repository\ExtensionRepository;
 use Barlito\Utils\Traits\IdUuidTrait;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\HttpFoundation\File\File;
@@ -37,6 +39,34 @@ class Extension implements \Stringable
 
     #[ORM\Column(type: 'string', length: 255, nullable: true)]
     private ?string $imageName = null;
+
+    /**
+     * Default holo foil texture for the extension's cards (cascade fallback
+     * when a card has no foil of its own).
+     */
+    #[Vich\UploadableField(mapping: 'foils', fileNameProperty: 'imageFoilName')]
+    private ?File $imageFoilFile = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $imageFoilName = null;
+
+    /**
+     * Default holo mask for the extension's cards (cascade fallback).
+     */
+    #[Vich\UploadableField(mapping: 'masks', fileNameProperty: 'imageMaskName')]
+    private ?File $imageMaskFile = null;
+
+    #[ORM\Column(type: 'string', length: 255, nullable: true)]
+    private ?string $imageMaskName = null;
+
+    /**
+     * Default visual configuration (glow / border / css class) applied to the
+     * extension's cards, each card may override individual fields.
+     *
+     * @var array<string, string>
+     */
+    #[ORM\Column(type: Types::JSON, options: ['default' => '{}'])]
+    private array $visualConfig = [];
 
     /**
      * @var Collection<int, Card>
@@ -126,6 +156,85 @@ class Extension implements \Stringable
     public function getImageName(): ?string
     {
         return $this->imageName;
+    }
+
+    public function setImageFoilFile(?File $imageFoilFile = null): void
+    {
+        $this->imageFoilFile = $imageFoilFile;
+
+        if ($imageFoilFile instanceof File) {
+            $this->updatedAt = new \DateTime();
+        }
+    }
+
+    public function getImageFoilFile(): ?File
+    {
+        return $this->imageFoilFile;
+    }
+
+    public function setImageFoilName(?string $imageFoilName): void
+    {
+        $this->imageFoilName = $imageFoilName;
+    }
+
+    public function getImageFoilName(): ?string
+    {
+        return $this->imageFoilName;
+    }
+
+    public function setImageMaskFile(?File $imageMaskFile = null): void
+    {
+        $this->imageMaskFile = $imageMaskFile;
+
+        if ($imageMaskFile instanceof File) {
+            $this->updatedAt = new \DateTime();
+        }
+    }
+
+    public function getImageMaskFile(): ?File
+    {
+        return $this->imageMaskFile;
+    }
+
+    public function setImageMaskName(?string $imageMaskName): void
+    {
+        $this->imageMaskName = $imageMaskName;
+    }
+
+    public function getImageMaskName(): ?string
+    {
+        return $this->imageMaskName;
+    }
+
+    public function getVisualConfig(): VisualConfig
+    {
+        return VisualConfig::fromArray($this->visualConfig);
+    }
+
+    public function setVisualConfig(VisualConfig $visualConfig): static
+    {
+        $this->visualConfig = $visualConfig->toArray();
+
+        return $this;
+    }
+
+    public function getVisualConfigJson(): string
+    {
+        return json_encode($this->visualConfig, \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Invalid JSON resolves to an empty configuration (no override).
+     */
+    public function setVisualConfigJson(string $json): void
+    {
+        try {
+            $decoded = json_decode($json, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            $decoded = null;
+        }
+
+        $this->visualConfig = VisualConfig::fromArray(\is_array($decoded) ? $decoded : [])->toArray();
     }
 
     /**

--- a/src/Service/Booster/CardDrawer.php
+++ b/src/Service/Booster/CardDrawer.php
@@ -42,11 +42,11 @@ final readonly class CardDrawer
 
         $drawnCards = [];
 
-        foreach ($booster->getRarityRates() as $weights) {
-            $rarity = $this->resolveAvailableRarity($pool, $this->drawRarity($weights));
+        foreach ($booster->getRarityRates() as $slot) {
+            $rarity = $this->resolveAvailableRarity($pool, $this->drawRarity($slot['rarities']));
             $candidates = $pool[$rarity->value];
             $card = $candidates[$this->randomService->getInt(0, \count($candidates) - 1)];
-            $holo = $this->randomService->getInt(1, 100) <= $booster->getHoloRate();
+            $holo = $card->isAlwaysHolo() || $this->randomService->getInt(1, 100) <= $slot['holoChance'];
 
             $drawnCards[] = new DrawnCard($card, $rarity, $holo);
         }

--- a/src/Service/Card/CardVisualResolver.php
+++ b/src/Service/Card/CardVisualResolver.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Card;
+
+use App\Dto\ResolvedCardVisual;
+use App\Entity\Card;
+use App\Entity\Extension;
+use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
+
+/**
+ * Resolves the effective visuals of a card through the cascade
+ * card -> extension -> system default:
+ *  - foil/mask textures: the card's own upload, else the extension's default;
+ *  - glow / border / css class: the card's override field, else the
+ *    extension's configuration, else null (the rarity-keyed default of
+ *    holo.css takes over).
+ */
+final readonly class CardVisualResolver
+{
+    public function __construct(
+        private UploaderHelper $uploaderHelper,
+    ) {
+    }
+
+    public function resolve(Card $card): ResolvedCardVisual
+    {
+        $extension = $card->getExtension();
+        $override = $card->getVisualConfigOverride();
+        $config = $extension->getVisualConfig();
+
+        return new ResolvedCardVisual(
+            foilUrl: $this->foilUrl($card, $extension),
+            maskUrl: $this->maskUrl($card, $extension),
+            glow: $override->glow ?? $config->glow,
+            borderColor: $override->borderColor ?? $config->borderColor,
+            cssClass: $override->cssClass ?? $config->cssClass,
+        );
+    }
+
+    private function foilUrl(Card $card, Extension $extension): ?string
+    {
+        if (null !== $card->getImageFoilName()) {
+            return $this->uploaderHelper->asset($card, 'imageFoilFile');
+        }
+
+        if (null !== $extension->getImageFoilName()) {
+            return $this->uploaderHelper->asset($extension, 'imageFoilFile');
+        }
+
+        return null;
+    }
+
+    private function maskUrl(Card $card, Extension $extension): ?string
+    {
+        if (null !== $card->getImageMaskName()) {
+            return $this->uploaderHelper->asset($card, 'imageMaskFile');
+        }
+
+        if (null !== $extension->getImageMaskName()) {
+            return $this->uploaderHelper->asset($extension, 'imageMaskFile');
+        }
+
+        return null;
+    }
+}

--- a/src/Twig/CardVisualExtension.php
+++ b/src/Twig/CardVisualExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use App\Dto\ResolvedCardVisual;
+use App\Entity\Card;
+use App\Service\Card\CardVisualResolver;
+use Twig\Attribute\AsTwigFunction;
+
+/**
+ * Exposes the resolved visuals of a card (cascade card -> extension ->
+ * default) to templates, so CardComponent renders foil/mask/glow without
+ * reaching into the entity itself.
+ */
+final readonly class CardVisualExtension
+{
+    public function __construct(
+        private CardVisualResolver $cardVisualResolver,
+    ) {
+    }
+
+    #[AsTwigFunction(name: 'card_visual')]
+    public function cardVisual(Card $card): ResolvedCardVisual
+    {
+        return $this->cardVisualResolver->resolve($card);
+    }
+}

--- a/src/Validator/ValidRarityRates.php
+++ b/src/Validator/ValidRarityRates.php
@@ -9,8 +9,10 @@ use Symfony\Component\Validator\Constraint;
 #[\Attribute(\Attribute::TARGET_PROPERTY)]
 final class ValidRarityRates extends Constraint
 {
-    public string $emptyMessage = 'A booster needs at least one slot (one weight map per card).';
-    public string $invalidSlotMessage = 'Slot #{{ slot }} must be a non-empty map of rarity => weight.';
+    public string $emptyMessage = 'A booster needs at least one slot (one entry per card).';
+    public string $invalidSlotMessage = 'Slot #{{ slot }} must be an object with a non-empty "rarities" map and a "holoChance".';
+    public string $invalidRaritiesMessage = 'Slot #{{ slot }} must have a non-empty "rarities" map of rarity => weight.';
     public string $invalidRarityMessage = 'Slot #{{ slot }} uses unknown rarity "{{ rarity }}". Valid rarities: {{ rarities }}.';
     public string $invalidWeightMessage = 'Slot #{{ slot }}, rarity "{{ rarity }}": weight must be a positive integer.';
+    public string $invalidHoloChanceMessage = 'Slot #{{ slot }}: "holoChance" must be an integer between 0 and 100.';
 }

--- a/src/Validator/ValidRarityRatesValidator.php
+++ b/src/Validator/ValidRarityRatesValidator.php
@@ -35,7 +35,7 @@ final class ValidRarityRatesValidator extends ConstraintValidator
 
     private function validateSlot(ValidRarityRates $constraint, int $slotNumber, mixed $slot): void
     {
-        if (!\is_array($slot) || [] === $slot) {
+        if (!\is_array($slot) || !\array_key_exists('rarities', $slot) || !\array_key_exists('holoChance', $slot)) {
             $this->context->buildViolation($constraint->invalidSlotMessage)
                 ->setParameter('{{ slot }}', (string) $slotNumber)
                 ->addViolation()
@@ -44,7 +44,22 @@ final class ValidRarityRatesValidator extends ConstraintValidator
             return;
         }
 
-        foreach ($slot as $rarity => $weight) {
+        $this->validateRarities($constraint, $slotNumber, $slot['rarities']);
+        $this->validateHoloChance($constraint, $slotNumber, $slot['holoChance']);
+    }
+
+    private function validateRarities(ValidRarityRates $constraint, int $slotNumber, mixed $rarities): void
+    {
+        if (!\is_array($rarities) || [] === $rarities) {
+            $this->context->buildViolation($constraint->invalidRaritiesMessage)
+                ->setParameter('{{ slot }}', (string) $slotNumber)
+                ->addViolation()
+            ;
+
+            return;
+        }
+
+        foreach ($rarities as $rarity => $weight) {
             if (null === CardRarityEnum::tryFrom((string) $rarity)) {
                 $this->context->buildViolation($constraint->invalidRarityMessage)
                     ->setParameter('{{ slot }}', (string) $slotNumber)
@@ -61,6 +76,16 @@ final class ValidRarityRatesValidator extends ConstraintValidator
                     ->addViolation()
                 ;
             }
+        }
+    }
+
+    private function validateHoloChance(ValidRarityRates $constraint, int $slotNumber, mixed $holoChance): void
+    {
+        if (!\is_int($holoChance) || $holoChance < 0 || $holoChance > 100) {
+            $this->context->buildViolation($constraint->invalidHoloChanceMessage)
+                ->setParameter('{{ slot }}', (string) $slotNumber)
+                ->addViolation()
+            ;
         }
     }
 }

--- a/templates/components/CardComponent.html.twig
+++ b/templates/components/CardComponent.html.twig
@@ -1,8 +1,15 @@
-{%- set maskUrl = card.imageMaskName ? vich_uploader_asset(card, 'imageMaskFile') : null -%}
-{%- set foilUrl = card.imageFoilName ? vich_uploader_asset(card, 'imageFoilFile') : null -%}
-<div id="{{ card.id }}" class="card interactive{{ maskUrl ? ' masked' }}" data-rarity="{{ card.rarity.value }}"
+{%- set holo = holo|default(false) -%}
+{%- set visual = card_visual(card) -%}
+{%- set styleVars = [] -%}
+{%- if visual.maskUrl %}{% set styleVars = styleVars|merge(["--mask: url('#{visual.maskUrl}')"]) %}{% endif -%}
+{%- if visual.foilUrl %}{% set styleVars = styleVars|merge(["--foil: url('#{visual.foilUrl}')"]) %}{% endif -%}
+{%- if visual.glow %}{% set styleVars = styleVars|merge(["--card-glow: #{visual.glow}"]) %}{% endif -%}
+{%- if visual.borderColor %}{% set styleVars = styleVars|merge(["--card-border: #{visual.borderColor}"]) %}{% endif -%}
+<div id="{{ card.id }}"
+     class="card interactive{{ visual.hasMask ? ' masked' }}{{ holo ? ' holo' }}{{ visual.cssClass ? ' ' ~ visual.cssClass }}"
+     data-rarity="{{ card.rarity.value }}"
      data-controller="card"
-     {%- if maskUrl or foilUrl %} style="{{ maskUrl ? "--mask: url('#{maskUrl}');" }}{{ foilUrl ? " --foil: url('#{foilUrl}');" }}"{% endif %}>
+     {%- if styleVars is not empty %} style="{{ styleVars|join('; ') }}"{% endif %}>
     <div class="card__translater">
         <div class="card__rotator">
             <div class="card__front">

--- a/templates/dev/card_effects.html.twig
+++ b/templates/dev/card_effects.html.twig
@@ -46,12 +46,13 @@
 
         <h2 class="mb-4 mt-12 font-display text-2xl font-bold text-ink-strong">Override libre du glow</h2>
         <p class="mb-4 max-w-3xl text-ink-muted">
-            Un wrapper <code class="text-primary">style="--card-glow: …"</code> écrase la couleur du palier :
-            c'est le mécanisme que la future <strong>config visuelle par extension</strong> (override par carte) pilotera.
+            Chaque carte porte un <code class="text-primary">visualConfigOverride</code> qui écrase la couleur du palier
+            via <code class="text-primary">CardVisualResolver</code> : c'est la <strong>cascade carte → extension → défaut</strong>
+            réelle (et non plus un simple wrapper CSS).
         </p>
         <div class="grid grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-4">
             {% for demo in overrideDemos %}
-                <div class="force-glow" style="--card-glow: {{ demo.glow }};">
+                <div class="force-glow">
                     {{ include('components/CardComponent.html.twig', { card: demo.card }) }}
                     <div class="mt-2 flex items-center gap-2 px-1">
                         <span class="inline-block h-4 w-4 rounded-full border border-white/30" style="background: {{ demo.glow }};"></span>
@@ -67,7 +68,7 @@
             <ul class="list-inside list-disc space-y-2 text-ink-muted">
                 <li><strong>Masques/foils Vich</strong> : une carte avec <code class="text-primary">imageMaskName</code>/<code class="text-primary">imageFoilName</code> reçoit la classe <code class="text-primary">masked</code> et les variables <code class="text-primary">--mask</code>/<code class="text-primary">--foil</code> (cf. CardComponent) — uploade un masque en admin pour le voir ici.</li>
                 <li><strong>Springs</strong> : la rotation est lissée par une boucle rAF maison (plus d'anime.js) ; les calques d'effet sont éteints hors interaction (perf grille).</li>
-                <li><strong>Config visuelle extension → carte</strong> : chantier futur — ces overrides en sont la préfiguration.</li>
+                <li><strong>Config visuelle extension → carte</strong> : câblée — <code class="text-primary">Extension.visualConfig</code> (défaut) overridable par <code class="text-primary">Card.visualConfigOverride</code>, résolus par <code class="text-primary">CardVisualResolver</code> (glow / border / classe CSS + foil/mask Vich en cascade).</li>
             </ul>
         </div>
     </main>

--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -136,8 +136,7 @@ final class HomepageTest extends WebTestCase
 
         $booster = new Booster()
             ->setExtension($extension)
-            ->setHoloRate(0)
-            ->setRarityRates([['common' => 100]])
+            ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]])
         ;
         $booster->setImageName('default_card.png');
         $this->entityManager->persist($booster);

--- a/tests/Integration/Service/BoosterOpeningServiceTest.php
+++ b/tests/Integration/Service/BoosterOpeningServiceTest.php
@@ -72,9 +72,9 @@ final class BoosterOpeningServiceTest extends KernelTestCase
         $this->assertSame(2, $userCards[0]->getQuantity());
     }
 
-    public function testFullHoloRateCreditsHoloQuantities(): void
+    public function testFullHoloChanceCreditsHoloQuantities(): void
     {
-        $scenario = $this->createScenario(boosterQuantity: 1, holoRate: 100, rarityRates: [['common' => 100], ['common' => 100]]);
+        $scenario = $this->createScenario(boosterQuantity: 1, holoChance: 100, rarityRates: [['common' => 100], ['common' => 100]]);
 
         $this->openingService->open($scenario['user'], $scenario['booster']);
 
@@ -86,9 +86,9 @@ final class BoosterOpeningServiceTest extends KernelTestCase
         $this->assertSame(2, $userCards[0]->getHoloQuantity());
     }
 
-    public function testZeroHoloRateCreditsNoHolo(): void
+    public function testZeroHoloChanceCreditsNoHolo(): void
     {
-        $scenario = $this->createScenario(boosterQuantity: 1, holoRate: 0);
+        $scenario = $this->createScenario(boosterQuantity: 1, holoChance: 0);
 
         $this->openingService->open($scenario['user'], $scenario['booster']);
 
@@ -134,13 +134,13 @@ final class BoosterOpeningServiceTest extends KernelTestCase
     }
 
     /**
-     * @param list<array<string, int>>|null $rarityRates
+     * @param list<array<string, int>>|null $rarityRates plain weight maps, wrapped per-slot with $holoChance
      *
      * @return array{user: DiscordUser, booster: Booster}
      */
     private function createScenario(
         int $boosterQuantity,
-        int $holoRate = 10,
+        int $holoChance = 10,
         ?array $rarityRates = null,
         bool $withPublishedCards = true,
     ): array {
@@ -171,10 +171,13 @@ final class BoosterOpeningServiceTest extends KernelTestCase
             }
         }
 
+        $weightMaps = $rarityRates ?? [['common' => 100], ['common' => 100], ['common' => 60, 'rare' => 30, 'legendary' => 10]];
         $booster = new Booster()
             ->setExtension($extension)
-            ->setHoloRate($holoRate)
-            ->setRarityRates($rarityRates ?? [['common' => 100], ['common' => 100], ['common' => 60, 'rare' => 30, 'legendary' => 10]])
+            ->setRarityRates(array_map(
+                static fn (array $rarities): array => ['rarities' => $rarities, 'holoChance' => $holoChance],
+                $weightMaps,
+            ))
         ;
         $booster->setImageName('default_card.png');
         $this->entityManager->persist($booster);

--- a/tests/Integration/Service/CardVisualResolverTest.php
+++ b/tests/Integration/Service/CardVisualResolverTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Service;
+
+use App\Dto\VisualConfig;
+use App\Entity\Card;
+use App\Entity\Extension;
+use App\Service\Card\CardVisualResolver;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Uses the real CardVisualResolver from the container: UploaderHelper is
+ * final and cannot be doubled, but asset() resolves to the mapping's
+ * uri_prefix + filename without touching the filesystem, which is enough to
+ * assert the cascade.
+ */
+final class CardVisualResolverTest extends KernelTestCase
+{
+    private CardVisualResolver $resolver;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->resolver = self::getContainer()->get(CardVisualResolver::class);
+    }
+
+    public function testCardFoilAndMaskWinOverExtensionDefaults(): void
+    {
+        $extension = $this->extension();
+        $extension->setImageFoilName('extension-foil.png');
+        $extension->setImageMaskName('extension-mask.png');
+        $card = $this->card($extension);
+        $card->setImageFoilName('card-foil.png');
+        $card->setImageMaskName('card-mask.png');
+
+        $resolved = $this->resolver->resolve($card);
+
+        $this->assertSame('/images/foils/card-foil.png', $resolved->foilUrl);
+        $this->assertSame('/images/masks/card-mask.png', $resolved->maskUrl);
+        $this->assertTrue($resolved->hasMask());
+    }
+
+    public function testFallsBackToExtensionFoilAndMask(): void
+    {
+        $extension = $this->extension();
+        $extension->setImageFoilName('extension-foil.png');
+        $extension->setImageMaskName('extension-mask.png');
+
+        $resolved = $this->resolver->resolve($this->card($extension));
+
+        $this->assertSame('/images/foils/extension-foil.png', $resolved->foilUrl);
+        $this->assertSame('/images/masks/extension-mask.png', $resolved->maskUrl);
+    }
+
+    public function testNoFoilNorMaskResolvesToNull(): void
+    {
+        $resolved = $this->resolver->resolve($this->card($this->extension()));
+
+        $this->assertNull($resolved->foilUrl);
+        $this->assertNull($resolved->maskUrl);
+        $this->assertFalse($resolved->hasMask());
+    }
+
+    public function testCardOverrideWinsOverExtensionConfig(): void
+    {
+        $extension = $this->extension()->setVisualConfig(new VisualConfig(glow: '#000000', cssClass: 'ext-class'));
+        $card = $this->card($extension)->setVisualConfigOverride(new VisualConfig(glow: '#ffffff'));
+
+        $resolved = $this->resolver->resolve($card);
+
+        // glow overridden, cssClass falls through to the extension's value.
+        $this->assertSame('#ffffff', $resolved->glow);
+        $this->assertSame('ext-class', $resolved->cssClass);
+    }
+
+    public function testFallsBackToExtensionConfigThenNull(): void
+    {
+        $extension = $this->extension()->setVisualConfig(new VisualConfig(glow: '#a435f0', borderColor: '#ff3db0'));
+
+        $resolved = $this->resolver->resolve($this->card($extension));
+
+        $this->assertSame('#a435f0', $resolved->glow);
+        $this->assertSame('#ff3db0', $resolved->borderColor);
+        $this->assertNull($resolved->cssClass);
+    }
+
+    private function extension(): Extension
+    {
+        return new Extension()->setName('Test extension')->setDescription('Test');
+    }
+
+    private function card(Extension $extension): Card
+    {
+        return new Card()
+            ->setName('Test card')
+            ->setExtension($extension)
+        ;
+    }
+}

--- a/tests/Unit/Service/CardDrawerTest.php
+++ b/tests/Unit/Service/CardDrawerTest.php
@@ -95,23 +95,52 @@ final class CardDrawerTest extends TestCase
         }
     }
 
-    public function testZeroHoloRateNeverDrawsHolo(): void
+    public function testZeroHoloChanceNeverDrawsHolo(): void
     {
         $drawer = $this->createDrawer([$this->card('Common card', CardRarityEnum::COMMON)]);
-        $booster = $this->booster([['common' => 100]], holoRate: 0);
+        $booster = $this->booster([['common' => 100]], holoChance: 0);
 
         for ($i = 0; $i < 200; ++$i) {
             $this->assertFalse($drawer->draw($booster)[0]->holo);
         }
     }
 
-    public function testFullHoloRateAlwaysDrawsHolo(): void
+    public function testFullHoloChanceAlwaysDrawsHolo(): void
     {
         $drawer = $this->createDrawer([$this->card('Common card', CardRarityEnum::COMMON)]);
-        $booster = $this->booster([['common' => 100]], holoRate: 100);
+        $booster = $this->booster([['common' => 100]], holoChance: 100);
 
         for ($i = 0; $i < 200; ++$i) {
             $this->assertTrue($drawer->draw($booster)[0]->holo);
+        }
+    }
+
+    public function testAlwaysHoloCardIsHoloEvenWithZeroChance(): void
+    {
+        $card = $this->card('Legendary card', CardRarityEnum::LEGENDARY)->setAlwaysHolo(true);
+        $drawer = $this->createDrawer([$card]);
+        $booster = $this->booster([['legendary' => 100]], holoChance: 0);
+
+        for ($i = 0; $i < 200; ++$i) {
+            $this->assertTrue($drawer->draw($booster)[0]->holo);
+        }
+    }
+
+    public function testHoloChanceIsResolvedPerSlot(): void
+    {
+        $drawer = $this->createDrawer([$this->card('Common card', CardRarityEnum::COMMON)]);
+        $booster = new Booster()
+            ->setExtension($this->extension())
+            ->setRarityRates([
+                ['rarities' => ['common' => 100], 'holoChance' => 0],
+                ['rarities' => ['common' => 100], 'holoChance' => 100],
+            ])
+        ;
+
+        for ($i = 0; $i < 200; ++$i) {
+            $drawnCards = $drawer->draw($booster);
+            $this->assertFalse($drawnCards[0]->holo);
+            $this->assertTrue($drawnCards[1]->holo);
         }
     }
 
@@ -181,14 +210,21 @@ final class CardDrawerTest extends TestCase
     }
 
     /**
-     * @param list<array<string, int>> $rarityRates
+     * Wraps plain rarity weight maps into the per-slot shape
+     * ({rarities, holoChance}), applying the same holo chance to every slot.
+     *
+     * @param list<array<string, int>> $raritySlots
      */
-    private function booster(array $rarityRates, int $holoRate = 10): Booster
+    private function booster(array $raritySlots, int $holoChance = 10): Booster
     {
+        $rarityRates = array_map(
+            static fn (array $rarities): array => ['rarities' => $rarities, 'holoChance' => $holoChance],
+            $raritySlots,
+        );
+
         return new Booster()
             ->setExtension($this->extension())
             ->setRarityRates($rarityRates)
-            ->setHoloRate($holoRate)
         ;
     }
 


### PR DESCRIPTION
## Phase 3a — Backend de la refonte holo + cascade de config visuelle

Première PR de la phase 3 (ouverture de boosters). **Backend uniquement** : aucune UI d'ouverture ici — `/boosters` reste en `coming_soon` (vient en 3b).

### Refonte holo par slot
- `Booster.rarityRates` porte désormais une entrée `{rarities, holoChance}` **par slot** ; le `Booster.holoRate` global est supprimé et sa valeur repliée dans chaque slot par la migration (transformation de données).
- `Card.alwaysHolo` : force une carte holo quelle que soit la proba du slot (ex. légendaires).
- `CardDrawer` roll le holo **par slot** (en respectant `alwaysHolo`) ; `ValidRarityRates` valide la nouvelle forme.

### Cascade de config visuelle (défaut extension, overridable par carte)
- Value object `VisualConfig` (glow / borderColor / cssClass) stocké en JSON sur `Extension.visualConfig` et `Card.visualConfigOverride` ; l'extension reçoit aussi un foil/mask **par défaut** (Vich).
- `CardVisualResolver` résout foil/mask (carte → extension) et glow/border/cssClass (override → extension → défaut rareté), exposé aux templates via la fonction Twig `card_visual()`.
- `CardComponent` consomme le résolu et gagne un flag optionnel `holo` ; `holo.css` ajoute un voile holo au repos + un accent `--card-border`.

### Admin & dev
- CRUD Booster (drop `holoRate`, exemple JSON mis à jour), Extension (visualConfig + foil/mask), Card (`alwaysHolo`, foil/mask, overrides).
- `/dev/card-effects` rebranché sur la vraie cascade (`visualConfigOverride`).

### Migration
`Version20260613140000` : drop `booster.holo_rate`, add `card.always_holo` / `card.visual_config_override` / `extension.visual_config` / `extension.image_foil_name` / `extension.image_mask_name`, et transforme `booster.rarity_rates` vers la forme par slot. Vérifiée up sur les bases test et dev.

### Tests
`make quality` (phpcs / php-cs-fixer / PHPStan niveau 8 sans baseline / rector) et `make phpunit` (61 tests) verts. Couverture ajoutée : holo par slot, `alwaysHolo`, cascade `CardVisualResolver`.