### PR TITLE
feat(booster): Phase 3b — hub d'ouverture (claim + ouverture + butin)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 1. **BoosterClaimService::claim()** — asks the quota policy (`BoosterClaimQuotaInterface` / `DailyBoosterClaimQuota`) for remaining claims, credits `UserBooster` via UserInventoryService, persists a `BoosterClaim`. In dev only, the `UnlimitedBoosterClaimQuota` decorator (`#[When(env: 'dev')]`) lifts the limit unless `BOOSTER_DAILY_LIMIT_ENABLED=true` is set in `.env.dev` — prod code carries no bypass
 2. **BoosterOpeningService::open()** — one transaction: pessimistic-locked inventory debit, seeded `CardDrawer::draw()` (per-slot weighted rarity roll, uniform pick in the tier, fallback to the nearest tier with cards, holo roll), duplicate aggregation, `UserCard` credit, audit persistence
 3. **RandomService** (`src/Service/Random/`) — seedable `Random\Randomizer` wrapper; the seed is stored on `BoosterOpening`
-4. UI: **not implemented yet** — the booster opening pages arrive with the phase 2 "Violet Arcade" design (`/boosters` is still coming_soon). The engine is fully tested at the service level.
+4. UI: `/boosters` is the opening hub (`BoosterHub` Live Component — claim, open, loot summary). The engine is fully tested at the service level.
 
 **Common Traits:**
 - `IdUuidTrait` (from barlito/utils): UUID primary keys
@@ -152,7 +152,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 **Frontend (`src/Controller/`):**
 - **BaseController**: Homepage with 3 random published cards (cached daily)
-  - Routes: `/` (homepage), `/extensions` (coming soon), `/boosters` (coming soon — phase 2 design)
+  - Routes: `/` (homepage), `/extensions` (coming soon), `/boosters` (opening hub)
   - Uses custom `CardRepository::findRandomCardId()` with RANDOM() DQL function
 
 **Admin (`src/Controller/Admin/`):**

--- a/assets/controllers/countdown_controller.js
+++ b/assets/controllers/countdown_controller.js
@@ -1,17 +1,20 @@
 import { Controller } from '@hotwired/stimulus';
 
 /**
- * Live countdown to a target datetime (ISO 8601 in `data-countdown-target-value`).
- * Reloads the page once the target is reached so quota-dependent UI refreshes.
+ * Live countdown from a server-computed number of seconds
+ * (`data-countdown-seconds-value`). Counting locally keeps the display
+ * immune to client clock skew: the deadline is the server's, not the
+ * client's. Reloads the page once so quota-dependent UI refreshes.
  */
 export default class extends Controller {
     static values = {
-        target: String
+        seconds: Number
     }
 
     connect() {
-        this.updateCountdown();
-        this.interval = setInterval(() => this.updateCountdown(), 1000);
+        this.remaining = Math.max(0, Math.floor(this.secondsValue));
+        this.render();
+        this.interval = setInterval(() => this.tick(), 1000);
     }
 
     disconnect() {
@@ -20,19 +23,22 @@ export default class extends Controller {
         }
     }
 
-    updateCountdown() {
-        const now = new Date();
-        const target = new Date(this.targetValue);
-        const diff = target - now;
+    tick() {
+        this.remaining -= 1;
 
-        if (diff <= 0) {
+        if (this.remaining <= 0) {
+            clearInterval(this.interval);
             window.location.reload();
             return;
         }
 
-        const hours = Math.floor(diff / (1000 * 60 * 60));
-        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
-        const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+        this.render();
+    }
+
+    render() {
+        const hours = Math.floor(this.remaining / 3600);
+        const minutes = Math.floor((this.remaining % 3600) / 60);
+        const seconds = this.remaining % 60;
 
         this.element.textContent = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
     }

--- a/assets/controllers/countdown_controller.js
+++ b/assets/controllers/countdown_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Live countdown to a target datetime (ISO 8601 in `data-countdown-target-value`).
+ * Reloads the page once the target is reached so quota-dependent UI refreshes.
+ */
+export default class extends Controller {
+    static values = {
+        target: String
+    }
+
+    connect() {
+        this.updateCountdown();
+        this.interval = setInterval(() => this.updateCountdown(), 1000);
+    }
+
+    disconnect() {
+        if (this.interval) {
+            clearInterval(this.interval);
+        }
+    }
+
+    updateCountdown() {
+        const now = new Date();
+        const target = new Date(this.targetValue);
+        const diff = target - now;
+
+        if (diff <= 0) {
+            window.location.reload();
+            return;
+        }
+
+        const hours = Math.floor(diff / (1000 * 60 * 60));
+        const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+        const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+
+        this.element.textContent = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+    }
+}

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -57,6 +57,6 @@ class BaseController extends AbstractController
     #[Route('/boosters', name: 'boosters')]
     public function boosters(): Response
     {
-        return $this->render('pages/coming_soon.html.twig');
+        return $this->render('pages/boosters.html.twig');
     }
 }

--- a/src/Exception/Booster/BoosterException.php
+++ b/src/Exception/Booster/BoosterException.php
@@ -6,4 +6,17 @@ namespace App\Exception\Booster;
 
 abstract class BoosterException extends \RuntimeException
 {
+    /**
+     * @param string $message     technical message (logs, tests)
+     * @param string $userMessage player-facing French message, safe to render as-is
+     */
+    public function __construct(string $message, private readonly string $userMessage)
+    {
+        parent::__construct($message);
+    }
+
+    public function getUserMessage(): string
+    {
+        return $this->userMessage;
+    }
 }

--- a/src/Repository/UserCardRepository.php
+++ b/src/Repository/UserCardRepository.php
@@ -76,6 +76,27 @@ class UserCardRepository extends ServiceEntityRepository
     }
 
     /**
+     * Ids of the distinct cards the user owns (any quantity), used to flag
+     * freshly obtained cards after a booster opening.
+     *
+     * @return list<string>
+     */
+    public function findOwnedCardIds(DiscordUser $discordUser): array
+    {
+        /** @var list<array{cardId: string}> $rows */
+        $rows = $this->createQueryBuilder('uc')
+            ->select('IDENTITY(uc.card) AS cardId')
+            ->andWhere('uc.discordUser = :user')
+            ->andWhere('uc.quantity > 0 OR uc.holoQuantity > 0')
+            ->setParameter('user', $discordUser)
+            ->getQuery()
+            ->getResult()
+        ;
+
+        return array_map(static fn (array $row): string => (string) $row['cardId'], $rows);
+    }
+
+    /**
      * Total number of cards owned, holo included (collection banner stat).
      */
     public function sumOwnedQuantities(DiscordUser $discordUser): int

--- a/src/Service/Booster/BoosterClaimService.php
+++ b/src/Service/Booster/BoosterClaimService.php
@@ -42,7 +42,10 @@ final readonly class BoosterClaimService
     public function claim(DiscordUser $discordUser, Booster $booster): BoosterClaim
     {
         if ($this->quota->getRemainingClaims($discordUser) < 1) {
-            throw new DailyClaimLimitReachedException(\sprintf('Daily limit of %d boosters reached, come back tomorrow.', BoosterClaimQuotaInterface::DAILY_LIMIT));
+            throw new DailyClaimLimitReachedException(
+                \sprintf('Daily limit of %d boosters reached, come back tomorrow.', BoosterClaimQuotaInterface::DAILY_LIMIT),
+                \sprintf('Limite quotidienne de %d boosters atteinte, reviens demain !', BoosterClaimQuotaInterface::DAILY_LIMIT),
+            );
         }
 
         $this->userInventoryService->creditBooster($discordUser, $booster);

--- a/src/Service/Booster/CardDrawer.php
+++ b/src/Service/Booster/CardDrawer.php
@@ -37,7 +37,10 @@ final readonly class CardDrawer
         $pool = $this->loadPool($booster->getExtension());
 
         if ([] === $pool) {
-            throw new NoCardAvailableException(\sprintf('Extension "%s" has no published card to draw from.', $booster->getExtension()->getName()));
+            throw new NoCardAvailableException(
+                \sprintf('Extension "%s" has no published card to draw from.', $booster->getExtension()->getName()),
+                'Ce booster n\'a aucune carte à tirer pour le moment, réessaie plus tard.',
+            );
         }
 
         $drawnCards = [];
@@ -121,6 +124,9 @@ final readonly class CardDrawer
             }
         }
 
-        throw new NoCardAvailableException('No rarity tier with available cards found in the pool.');
+        throw new NoCardAvailableException(
+            'No rarity tier with available cards found in the pool.',
+            'Ce booster n\'a aucune carte à tirer pour le moment, réessaie plus tard.',
+        );
     }
 }

--- a/src/Service/Booster/UserInventoryService.php
+++ b/src/Service/Booster/UserInventoryService.php
@@ -53,7 +53,7 @@ class UserInventoryService
         $userBooster = $this->userBoosterRepository->findOneForUpdate($discordUser, $booster);
 
         if (!$userBooster instanceof UserBooster || $userBooster->getQuantity() < 1) {
-            throw new NoBoosterInInventoryException('You do not own this booster.');
+            throw new NoBoosterInInventoryException('You do not own this booster.', 'Tu ne possèdes pas ce booster.');
         }
 
         return $userBooster->setQuantity($userBooster->getQuantity() - 1);

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -15,6 +15,7 @@ use App\Repository\UserCardRepository;
 use App\Service\Booster\BoosterClaimService;
 use App\Service\Booster\BoosterOpeningService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Uid\Uuid;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
 use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveArg;
@@ -71,6 +72,15 @@ final class BoosterHub extends AbstractController
     }
 
     /**
+     * Server-computed remaining seconds before the quota reset, so the
+     * client countdown never depends on the client clock.
+     */
+    public function getSecondsUntilReset(): int
+    {
+        return max(0, $this->getNextResetTime()->getTimestamp() - time());
+    }
+
+    /**
      * @return array<string, int> booster id => owned quantity
      */
     public function getInventory(): array
@@ -116,9 +126,9 @@ final class BoosterHub extends AbstractController
     {
         $this->error = null;
 
-        $booster = $this->boosterRepository->find($boosterId);
+        $booster = $this->findBooster($boosterId);
 
-        if (null === $booster) {
+        if (!$booster instanceof Booster) {
             $this->error = 'Booster introuvable.';
 
             return;
@@ -127,7 +137,7 @@ final class BoosterHub extends AbstractController
         try {
             $this->boosterClaimService->claim($this->getDiscordUser(), $booster);
         } catch (BoosterException $exception) {
-            $this->error = $exception->getMessage();
+            $this->error = $exception->getUserMessage();
         }
     }
 
@@ -136,9 +146,9 @@ final class BoosterHub extends AbstractController
     {
         $this->error = null;
 
-        $booster = $this->boosterRepository->find($boosterId);
+        $booster = $this->findBooster($boosterId);
 
-        if (null === $booster) {
+        if (!$booster instanceof Booster) {
             $this->error = 'Booster introuvable.';
 
             return;
@@ -150,7 +160,7 @@ final class BoosterHub extends AbstractController
         try {
             $this->opening = $this->boosterOpeningService->open($user, $booster);
         } catch (BoosterException $exception) {
-            $this->error = $exception->getMessage();
+            $this->error = $exception->getUserMessage();
 
             return;
         }
@@ -170,6 +180,19 @@ final class BoosterHub extends AbstractController
         $this->opening = null;
         $this->newCardIds = [];
         $this->error = null;
+    }
+
+    /**
+     * The id is client-provided (LiveArg): a malformed uuid must resolve to
+     * "not found" instead of a Doctrine conversion error.
+     */
+    private function findBooster(string $boosterId): ?Booster
+    {
+        if (!Uuid::isValid($boosterId)) {
+            return null;
+        }
+
+        return $this->boosterRepository->find($boosterId);
     }
 
     private function getDiscordUser(): DiscordUser

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Components;
+
+use App\Entity\Booster;
+use App\Entity\BoosterOpening;
+use App\Entity\DiscordUser;
+use App\Enum\Entity\CardRarityEnum;
+use App\Exception\Booster\BoosterException;
+use App\Repository\BoosterRepository;
+use App\Repository\UserBoosterRepository;
+use App\Repository\UserCardRepository;
+use App\Service\Booster\BoosterClaimService;
+use App\Service\Booster\BoosterOpeningService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
+ */
+#[AsLiveComponent]
+final class BoosterHub extends AbstractController
+{
+    use DefaultActionTrait;
+
+    #[LiveProp]
+    public ?BoosterOpening $opening = null;
+
+    /**
+     * Card ids that the user did not own before the last opening (NOUVEAU badge).
+     *
+     * @var list<string>
+     */
+    #[LiveProp]
+    public array $newCardIds = [];
+
+    #[LiveProp]
+    public ?string $error = null;
+
+    public function __construct(
+        private readonly BoosterRepository $boosterRepository,
+        private readonly UserBoosterRepository $userBoosterRepository,
+        private readonly UserCardRepository $userCardRepository,
+        private readonly BoosterClaimService $boosterClaimService,
+        private readonly BoosterOpeningService $boosterOpeningService,
+    ) {
+    }
+
+    /**
+     * @return list<Booster>
+     */
+    public function getBoosters(): array
+    {
+        return $this->boosterRepository->findPublished();
+    }
+
+    public function getRemainingClaims(): int
+    {
+        return $this->boosterClaimService->getRemainingClaims($this->getDiscordUser());
+    }
+
+    public function getNextResetTime(): \DateTimeImmutable
+    {
+        return $this->boosterClaimService->getNextResetTime();
+    }
+
+    /**
+     * @return array<string, int> booster id => owned quantity
+     */
+    public function getInventory(): array
+    {
+        $inventory = [];
+
+        foreach ($this->userBoosterRepository->findBy(['discordUser' => $this->getDiscordUser()]) as $userBooster) {
+            $inventory[(string) $userBooster->getBooster()->getId()] = $userBooster->getQuantity();
+        }
+
+        return $inventory;
+    }
+
+    /**
+     * Per-rarity count of the last opening, ordered from common to legendary.
+     *
+     * @return list<array{rarity: CardRarityEnum, count: int}>
+     */
+    public function getRaritySummary(): array
+    {
+        if (!$this->opening instanceof BoosterOpening) {
+            return [];
+        }
+
+        $counts = [];
+        foreach ($this->opening->getBoosterOpeningCards() as $openingCard) {
+            $rarity = $openingCard->getCard()->getRarity()->value;
+            $counts[$rarity] = ($counts[$rarity] ?? 0) + $openingCard->getQuantity();
+        }
+
+        $summary = [];
+        foreach (CardRarityEnum::ascending() as $rarity) {
+            if (isset($counts[$rarity->value])) {
+                $summary[] = ['rarity' => $rarity, 'count' => $counts[$rarity->value]];
+            }
+        }
+
+        return $summary;
+    }
+
+    #[LiveAction]
+    public function claimBooster(#[LiveArg] string $boosterId): void
+    {
+        $this->error = null;
+
+        $booster = $this->boosterRepository->find($boosterId);
+
+        if (null === $booster) {
+            $this->error = 'Booster introuvable.';
+
+            return;
+        }
+
+        try {
+            $this->boosterClaimService->claim($this->getDiscordUser(), $booster);
+        } catch (BoosterException $exception) {
+            $this->error = $exception->getMessage();
+        }
+    }
+
+    #[LiveAction]
+    public function openBooster(#[LiveArg] string $boosterId): void
+    {
+        $this->error = null;
+
+        $booster = $this->boosterRepository->find($boosterId);
+
+        if (null === $booster) {
+            $this->error = 'Booster introuvable.';
+
+            return;
+        }
+
+        $user = $this->getDiscordUser();
+        $ownedBefore = $this->userCardRepository->findOwnedCardIds($user);
+
+        try {
+            $this->opening = $this->boosterOpeningService->open($user, $booster);
+        } catch (BoosterException $exception) {
+            $this->error = $exception->getMessage();
+
+            return;
+        }
+
+        $this->newCardIds = [];
+        foreach ($this->opening->getBoosterOpeningCards() as $openingCard) {
+            $cardId = (string) $openingCard->getCard()->getId();
+            if (!\in_array($cardId, $ownedBefore, true)) {
+                $this->newCardIds[] = $cardId;
+            }
+        }
+    }
+
+    #[LiveAction]
+    public function closeModal(): void
+    {
+        $this->opening = null;
+        $this->newCardIds = [];
+        $this->error = null;
+    }
+
+    private function getDiscordUser(): DiscordUser
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof DiscordUser) {
+            throw $this->createAccessDeniedException();
+        }
+
+        return $user;
+    }
+}

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -1,0 +1,160 @@
+<div {{ attributes }}>
+    <main>
+        {# ----------------------------------------------------- Hero / quota #}
+        <section class="relative border-b border-hairline px-6 py-10 lg:px-12">
+            <div class="glow-ambient" aria-hidden="true"></div>
+            <div class="relative mx-auto flex max-w-7xl flex-col gap-8 md:flex-row md:items-end md:justify-between">
+                <div>
+                    <p class="eyebrow">03 / Ouverture</p>
+                    <h1 class="mt-2 font-display text-4xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-5xl">
+                        Boosters
+                    </h1>
+                    <p class="mt-2 max-w-md text-sm text-ink-muted">
+                        Récupère tes packs gratuits du jour et ouvre-les pour compléter ta collection.
+                    </p>
+                </div>
+
+                <div class="flex flex-col items-start gap-2.5 md:items-end">
+                    <div class="bg-primary px-5 py-3.5 text-black" data-testid="daily-packs">
+                        <p class="font-mono text-[10px] font-bold tracking-[.2em]">PACKS / JOUR</p>
+                        <p class="mt-1 font-display text-3xl font-bold leading-none">
+                            {{ this.remainingClaims }}<span class="text-lg opacity-50"> / {{ constant('App\\Service\\Booster\\BoosterClaimQuotaInterface::DAILY_LIMIT') }}</span>
+                        </p>
+                    </div>
+
+                    {% if this.remainingClaims == 0 %}
+                        <p class="chip-mono text-ink-dim">
+                            Prochains packs dans
+                            <span class="text-primary"
+                                  data-controller="countdown"
+                                  data-countdown-target-value="{{ this.nextResetTime.format('c') }}">--:--:--</span>
+                        </p>
+                    {% else %}
+                        <p class="chip-mono text-live">✦ {{ this.remainingClaims }} pack{{ this.remainingClaims > 1 ? 's' }} à récupérer</p>
+                    {% endif %}
+                </div>
+            </div>
+        </section>
+
+        {% if error %}
+            <div class="mx-auto mt-6 max-w-7xl px-6 lg:px-12">
+                <div class="border border-magenta/50 bg-magenta/10 px-4 py-3 font-mono text-xs text-magenta" data-testid="hub-error">
+                    ⚠ {{ error }}
+                </div>
+            </div>
+        {% endif %}
+
+        {# ----------------------------------------------------- Packs grid #}
+        <section class="px-6 pb-24 pt-10 lg:px-12">
+            <div class="mx-auto max-w-7xl">
+                {% if this.boosters is empty %}
+                    <div class="border border-dashed border-hairline px-8 py-20 text-center text-ink-dim">
+                        <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Aucun pack.</p>
+                        <p class="mt-3 text-sm">Reviens bientôt, de nouveaux univers arrivent.</p>
+                    </div>
+                {% else %}
+                    {% set inventory = this.inventory %}
+                    {% set remainingClaims = this.remainingClaims %}
+                    <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3" data-testid="boosters-grid">
+                        {% for booster in this.boosters %}
+                            {% set owned = inventory[booster.id]|default(0) %}
+                            <article class="group flex flex-col border border-hairline bg-surface">
+                                <div class="relative aspect-[16/10] overflow-hidden border-b border-hairline bg-bg">
+                                    <img src="{{ booster.imageName ? vich_uploader_asset(booster) : (booster.extension.imageName ? vich_uploader_asset(booster.extension) : asset('images/cards/default_card.png')) }}"
+                                         alt="{{ booster.extension.name }}"
+                                         class="h-full w-full object-cover opacity-80 transition duration-300 group-hover:scale-[1.03] group-hover:opacity-100"
+                                         onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
+                                    <div class="absolute inset-0 bg-gradient-to-t from-bg via-bg/20 to-transparent"></div>
+                                    <span class="chip-mono absolute right-3 top-3 bg-black/80 px-2 py-1 font-bold text-ink-strong">×{{ owned }}</span>
+                                </div>
+
+                                <div class="flex flex-1 flex-col p-5">
+                                    <h3 class="font-display text-xl font-bold uppercase tracking-[-0.02em] text-ink-strong">{{ booster.extension.name }}</h3>
+                                    <p class="chip-mono mt-1 text-ink-dim">{{ booster.cardCount }} cartes</p>
+                                    <p class="mt-2 line-clamp-2 text-sm text-ink-muted">{{ booster.extension.description }}</p>
+
+                                    <div class="mt-auto grid grid-cols-2 gap-3 pt-5">
+                                        <button type="button"
+                                                data-action="live#action"
+                                                data-live-action-param="claimBooster"
+                                                data-live-booster-id-param="{{ booster.id }}"
+                                                class="border border-primary bg-black px-4 py-3 font-display text-xs font-bold uppercase tracking-[.12em] text-primary transition hover:bg-primary hover:text-black disabled:cursor-not-allowed disabled:opacity-40"
+                                                {% if remainingClaims == 0 %}disabled{% endif %}>
+                                            <span data-loading="hide">Récupérer</span>
+                                            <span data-loading="show" class="hidden">···</span>
+                                        </button>
+                                        <button type="button"
+                                                data-action="live#action"
+                                                data-live-action-param="openBooster"
+                                                data-live-booster-id-param="{{ booster.id }}"
+                                                class="btn-arcade w-full text-center disabled:cursor-not-allowed disabled:opacity-40"
+                                                {% if owned == 0 %}disabled{% endif %}>
+                                            <span data-loading="hide">Ouvrir ▸</span>
+                                            <span data-loading="show" class="hidden">···</span>
+                                        </button>
+                                    </div>
+                                </div>
+                            </article>
+                        {% endfor %}
+                    </div>
+                {% endif %}
+            </div>
+        </section>
+    </main>
+
+    {# --------------------------------------------------- Loot summary modal #}
+    {% if opening %}
+        <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/85 p-4 backdrop-blur-sm"
+             data-live-id="opening-{{ opening.id }}"
+             data-testid="opening-summary">
+            <div class="flex max-h-[90vh] w-full max-w-5xl flex-col border border-hairline bg-bg">
+                <header class="flex items-center justify-between border-b border-hairline bg-surface px-6 py-5">
+                    <div>
+                        <p class="eyebrow">Ton butin</p>
+                        <h2 class="mt-1 font-display text-2xl font-bold uppercase tracking-[-0.03em] text-ink-strong">
+                            {{ opening.booster.extension.name }}
+                        </h2>
+                    </div>
+                    <button type="button"
+                            data-action="live#action"
+                            data-live-action-param="closeModal"
+                            class="font-mono text-2xl leading-none text-ink-dim transition hover:text-ink-strong"
+                            aria-label="Fermer">×</button>
+                </header>
+
+                <div class="flex flex-wrap gap-2 border-b border-hairline px-6 py-4" data-testid="rarity-tally">
+                    {% for tier in this.raritySummary %}
+                        <span class="chip-mono border border-hairline px-2.5 py-1 font-bold"
+                              style="color: var(--rarity-{{ tier.rarity.value }});">
+                            {{ tier.rarity.value }} · {{ tier.count }}
+                        </span>
+                    {% endfor %}
+                </div>
+
+                <div class="grid grid-cols-2 gap-5 overflow-y-auto px-6 py-6 sm:grid-cols-3 md:grid-cols-4">
+                    {% for openingCard in opening.boosterOpeningCards %}
+                        {% for copy in 1..openingCard.quantity %}
+                            <div class="relative">
+                                {{ include('components/CardComponent.html.twig', {
+                                    card: openingCard.card,
+                                    holo: copy <= openingCard.holoQuantity,
+                                    id: 'loot-' ~ loop.parent.loop.index ~ '-' ~ copy,
+                                }) }}
+                                {% if (openingCard.card.id ~ '') in newCardIds %}
+                                    <span class="chip-mono absolute -left-2 -top-2 z-10 bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">NOUVEAU</span>
+                                {% endif %}
+                            </div>
+                        {% endfor %}
+                    {% endfor %}
+                </div>
+
+                <footer class="border-t border-hairline bg-surface px-6 py-5 text-center">
+                    <button type="button"
+                            data-action="live#action"
+                            data-live-action-param="closeModal"
+                            class="btn-arcade">Ajouter à ma collection ▸</button>
+                </footer>
+            </div>
+        </div>
+    {% endif %}
+</div>

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -27,7 +27,7 @@
                             Prochains packs dans
                             <span class="text-primary"
                                   data-controller="countdown"
-                                  data-countdown-target-value="{{ this.nextResetTime.format('c') }}">--:--:--</span>
+                                  data-countdown-seconds-value="{{ this.secondsUntilReset }}">--:--:--</span>
                         </p>
                     {% else %}
                         <p class="chip-mono text-live">✦ {{ this.remainingClaims }} pack{{ this.remainingClaims > 1 ? 's' }} à récupérer</p>

--- a/templates/components/CardComponent.html.twig
+++ b/templates/components/CardComponent.html.twig
@@ -1,11 +1,12 @@
 {%- set holo = holo|default(false) -%}
+{%- set id = id|default(card.id) -%}
 {%- set visual = card_visual(card) -%}
 {%- set styleVars = [] -%}
 {%- if visual.maskUrl %}{% set styleVars = styleVars|merge(["--mask: url('#{visual.maskUrl}')"]) %}{% endif -%}
 {%- if visual.foilUrl %}{% set styleVars = styleVars|merge(["--foil: url('#{visual.foilUrl}')"]) %}{% endif -%}
 {%- if visual.glow %}{% set styleVars = styleVars|merge(["--card-glow: #{visual.glow}"]) %}{% endif -%}
 {%- if visual.borderColor %}{% set styleVars = styleVars|merge(["--card-border: #{visual.borderColor}"]) %}{% endif -%}
-<div id="{{ card.id }}"
+<div id="{{ id }}"
      class="card interactive{{ visual.hasMask ? ' masked' }}{{ holo ? ' holo' }}{{ visual.cssClass ? ' ' ~ visual.cssClass }}"
      data-rarity="{{ card.rarity.value }}"
      data-controller="card"

--- a/templates/pages/boosters.html.twig
+++ b/templates/pages/boosters.html.twig
@@ -1,0 +1,9 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    YOUL TCG — Boosters
+{% endblock %}
+
+{% block body %}
+    {{ component('BoosterHub') }}
+{% endblock %}

--- a/tests/Functional/BoosterHubComponentTest.php
+++ b/tests/Functional/BoosterHubComponentTest.php
@@ -69,6 +69,29 @@ final class BoosterHubComponentTest extends WebTestCase
         $this->assertSame($booster->getCardCount(), $totalCards);
     }
 
+    public function testClaimBoosterWithMalformedIdReportsNotFoundInsteadOfCrashing(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('claimBooster', ['boosterId' => 'not-a-uuid']);
+
+        $this->assertSame('Booster introuvable.', $component->component()->error);
+    }
+
+    public function testErrorsAreReportedInFrench(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
+
+        $this->assertSame('Tu ne possèdes pas ce booster.', $component->component()->error);
+    }
+
     public function testOpeningWithoutInventoryReportsAnError(): void
     {
         $client = static::createClient();

--- a/tests/Functional/BoosterHubComponentTest.php
+++ b/tests/Functional/BoosterHubComponentTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\UserBooster;
+use App\Entity\UserCard;
+use App\Repository\BoosterRepository;
+use App\Twig\Components\BoosterHub;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
+
+final class BoosterHubComponentTest extends WebTestCase
+{
+    use InteractsWithLiveComponents;
+    use JwtAuthTrait;
+
+    // Juju has no UserBooster fixture, unlike Barlito who starts with a stocked inventory.
+    private const string USER_WITHOUT_INVENTORY = '195659530363731968';
+
+    public function testClaimBoosterCreditsTheInventoryAndDecrementsTheQuota(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('claimBooster', ['boosterId' => (string) $booster->getId()]);
+
+        $userBooster = static::getContainer()->get(EntityManagerInterface::class)
+            ->getRepository(UserBooster::class)
+            ->findOneBy(['discordUser' => $user, 'booster' => $booster])
+        ;
+
+        $this->assertNotNull($userBooster);
+        $this->assertSame(1, $userBooster->getQuantity());
+        $this->assertNull($component->component()->error);
+    }
+
+    public function testOpeningAClaimedBoosterFillsTheCollectionAndTheSummary(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('claimBooster', ['boosterId' => (string) $booster->getId()]);
+        $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
+
+        $hub = $component->component();
+        $this->assertNull($hub->error);
+        $this->assertNotNull($hub->opening);
+
+        $rendered = (string) $component->render();
+        $this->assertStringContainsString('Ton butin', $rendered);
+        // Every drawn card was new for this empty-inventory user.
+        $this->assertStringContainsString('NOUVEAU', $rendered);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $userBooster = $entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $user, 'booster' => $booster]);
+        $this->assertNotNull($userBooster);
+        $this->assertSame(0, $userBooster->getQuantity());
+
+        $userCards = $entityManager->getRepository(UserCard::class)->findBy(['discordUser' => $user]);
+        $totalCards = array_sum(array_map(static fn (UserCard $userCard): int => $userCard->getQuantity(), $userCards));
+        $this->assertSame($booster->getCardCount(), $totalCards);
+    }
+
+    public function testOpeningWithoutInventoryReportsAnError(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
+
+        $hub = $component->component();
+        $this->assertNull($hub->opening);
+        $this->assertNotNull($hub->error);
+    }
+
+    private function firstPublishedBooster(): \App\Entity\Booster
+    {
+        // The Cyberpunk extension is the one with published cards in the fixtures.
+        foreach (static::getContainer()->get(BoosterRepository::class)->findPublished() as $booster) {
+            if (str_starts_with($booster->getExtension()->getName(), 'Cyberpunk')) {
+                return $booster;
+            }
+        }
+
+        $this->fail('Fixture booster for the Cyberpunk extension not found, load the alice fixtures first.');
+    }
+}

--- a/tests/Functional/BoosterPageTest.php
+++ b/tests/Functional/BoosterPageTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class BoosterPageTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    public function testBoostersPageRedirectsWhenNotAuthenticated(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/boosters');
+
+        $this->assertContains($client->getResponse()->getStatusCode(), [302, 307]);
+    }
+
+    public function testBoostersPageListsPublishedBoosters(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', '/boosters');
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorTextContains('section h1', 'Boosters');
+        $this->assertStringContainsString('Récupérer', $client->getResponse()->getContent());
+        $this->assertGreaterThan(0, $crawler->filter('[data-live-action-param="claimBooster"]')->count());
+    }
+}


### PR DESCRIPTION
## Phase 3b — Hub d'ouverture de boosters

> ⚠️ **Stack sur la PR #41 (3a)** : base = `feat/phase-3a-holo-backend`. À re-targeter sur `master` une fois la #41 mergée.

`/boosters` quitte `coming_soon` et rend le hub d'ouverture sous le design **Violet Arcade**. Boucle jouable : connexion → claim → ouverture → summary « butin » → collection. **Pas d'animation de déchirure** ici (c'est la 3c) : l'ouverture affiche directement le butin.

### Contenu
- **`BoosterHub` Live Component** recyclé du spike phase-1, plus :
  - `getRaritySummary()` — tally par rareté (common → legendary).
  - badges **NOUVEAU** via `UserCardRepository::findOwnedCardIds()` (snapshot de l'inventaire *avant* l'ouverture).
- **Template Violet Arcade** : grille de packs, tuile PACKS/JOUR + compte à rebours reset, boutons Récupérer / Ouvrir, modale summary (anti-morphing `data-live-id`) avec grille `CardComponent` + tally par rareté.
- `CardComponent` accepte une prop `id` optionnelle (les copies dupliquées d'une même carte ne partagent plus le même id DOM).
- `countdown_controller.js` recyclé (timer de reset).
- `BaseController::boosters()` rend `pages/boosters.html.twig`.

### Tests
- `BoosterPageTest` + `BoosterHubComponentTest` (claim, ouverture → butin/NOUVEAU, erreur sans inventaire).
- `LayoutTest` couvre désormais le hub rendu (`/boosters` n'est plus coming_soon).
- `make quality` (phpcs / cs-fixer / phpstan niveau 8 sans baseline / rector / composer validate) + **66 tests** verts.