### PR TITLE
feat(booster): Phase 3c — animation d'ouverture (reveal rarest-last)

### DIFF
--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -1,0 +1,222 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Pack opening reveal — `sealed → tearing → reveal → summary` state machine.
+ *
+ * The cards have already been drawn server-side (the live component holds the
+ * opening); this controller only choreographs the presentation. It owns its DOM
+ * subtree (`data-live-ignore`), so no anime.js: timing is plain `setTimeout`
+ * timelines + CSS animations, and the swipe maps the pointer straight to a
+ * `--tp` (tear progress) custom property.
+ *
+ * Reveal order is rarest-last (the server sorts it); per card we light a rarity
+ * aura, slam its label, and play a bigger entrance for shiny cards.
+ */
+
+const RARITY_COLOR = {
+    common: '#9aa3b2',
+    uncommon: '#5be584',
+    rare: '#54a8ff',
+    epic: '#a435f0',
+    legendary: '#ff8a2b',
+};
+const SHINY = new Set(['rare', 'epic', 'legendary']);
+const DRAG_DISTANCE = 210; // px of horizontal drag for a full tear
+const COMMIT_THRESHOLD = 0.6; // release past this commits the tear
+
+export default class extends Controller {
+    static targets = [
+        'sealed', 'pack', 'tearing', 'whiteout', 'flash',
+        'reveal', 'aura', 'label', 'card', 'dot', 'next', 'counter', 'summary',
+    ];
+
+    static values = {
+        count: Number,
+    };
+
+    connect() {
+        this.phase = 'sealed';
+        this.revealIndex = -1;
+        this.tearProgress = 0;
+        this.dragging = false;
+        this.timers = [];
+
+        const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (reduced || this.countValue === 0) {
+            this._toSummary();
+        }
+    }
+
+    disconnect() {
+        this.timers.forEach(clearTimeout);
+        this.timers = [];
+    }
+
+    _after(ms, fn) {
+        const timer = setTimeout(fn, ms);
+        this.timers.push(timer);
+
+        return timer;
+    }
+
+    // ----------------------------------------------------- swipe to slice
+    dragStart(event) {
+        if (this.phase !== 'sealed') {
+            return;
+        }
+        this.dragging = true;
+        this.startX = event.clientX;
+        try {
+            event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+            // pointer capture is best-effort
+        }
+    }
+
+    dragMove(event) {
+        if (!this.dragging) {
+            return;
+        }
+        const progress = Math.max(0, Math.min(1, (event.clientX - this.startX) / DRAG_DISTANCE));
+        this.tearProgress = progress;
+        this.element.style.setProperty('--tp', `${progress}`);
+        this.packTarget.classList.toggle('is-cutting', progress > 0.02);
+    }
+
+    dragEnd() {
+        if (!this.dragging) {
+            return;
+        }
+        this.dragging = false;
+        if (this.tearProgress > COMMIT_THRESHOLD) {
+            this.commitTear();
+        } else {
+            this.tearProgress = 0;
+            this.element.style.setProperty('--tp', '0');
+            this.packTarget.classList.remove('is-cutting');
+        }
+    }
+
+    // fallback: click the pack / button to open in one go
+    openAtOnce() {
+        this.commitTear();
+    }
+
+    // ----------------------------------------------------- tear timeline
+    commitTear() {
+        if (this.phase !== 'sealed') {
+            return;
+        }
+        this.phase = 'tearing';
+        this.tearProgress = 1;
+        this.element.style.setProperty('--tp', '1');
+        this.element.dataset.phase = 'tearing';
+
+        this.sealedTarget.hidden = true;
+        this.tearingTarget.hidden = false;
+        this.whiteoutTarget.classList.add('is-tearing');
+
+        // CSS whiteout peaks at ~1.15s; hand off to the reveal exactly then.
+        this._after(1150, () => this._startReveal());
+    }
+
+    _startReveal() {
+        this.phase = 'reveal';
+        this.element.dataset.phase = 'reveal';
+        this.tearingTarget.hidden = true;
+        this.revealTarget.hidden = false;
+
+        // carry the whiteout seamlessly into the first card, then fade it out
+        this.whiteoutTarget.classList.remove('is-tearing');
+        this.whiteoutTarget.classList.add('is-bridge');
+        this._after(600, () => this.whiteoutTarget.classList.remove('is-bridge'));
+
+        this._showCard(0);
+    }
+
+    // ----------------------------------------------------- reveal cards
+    _showCard(index) {
+        this.revealIndex = index;
+        const card = this.cardTargets[index];
+        const { rarity } = card.dataset;
+        const color = RARITY_COLOR[rarity] || '#ffffff';
+        const shiny = SHINY.has(rarity);
+
+        this.element.style.setProperty('--reveal-color', color);
+        this.element.classList.toggle('is-shiny', shiny);
+
+        this.cardTargets.forEach((node, i) => node.classList.toggle('is-current', i === index));
+        this._retrigger(card, 'is-entering');
+        this._retrigger(this.auraTarget, 'is-on');
+
+        this.labelTarget.textContent = card.dataset.label;
+        this._retrigger(this.labelTarget, 'is-on');
+
+        if (rarity === 'epic' || rarity === 'legendary') {
+            this._flash(0.42, 180);
+            this._shake();
+        } else if (rarity === 'rare') {
+            this._flash(0.24, 140);
+        }
+
+        this.dotTargets.forEach((dot, i) => {
+            dot.style.setProperty('--dot-color', RARITY_COLOR[this.cardTargets[i].dataset.rarity] || '#fff');
+            dot.classList.toggle('is-done', i < index);
+            dot.classList.toggle('is-current', i === index);
+        });
+
+        const last = index >= this.countValue - 1;
+        this.nextTarget.textContent = last ? 'Voir le butin ▸' : 'Carte suivante ▸';
+        if (this.hasCounterTarget) {
+            this.counterTarget.textContent = `${index + 1} / ${this.countValue} · CLIQUE N'IMPORTE OÙ`;
+        }
+    }
+
+    advance(event) {
+        if (this.phase !== 'reveal') {
+            return;
+        }
+        if (event) {
+            event.stopPropagation();
+        }
+        if (this.revealIndex < this.countValue - 1) {
+            this._showCard(this.revealIndex + 1);
+        } else {
+            this._toSummary();
+        }
+    }
+
+    // ----------------------------------------------------- summary
+    _toSummary() {
+        this.phase = 'summary';
+        this.element.dataset.phase = 'summary';
+        if (this.hasSealedTarget) {
+            this.sealedTarget.hidden = true;
+        }
+        if (this.hasTearingTarget) {
+            this.tearingTarget.hidden = true;
+        }
+        if (this.hasRevealTarget) {
+            this.revealTarget.hidden = true;
+        }
+        this.summaryTarget.hidden = false;
+    }
+
+    // ----------------------------------------------------- helpers
+    _retrigger(node, className) {
+        node.classList.remove(className);
+        void node.offsetWidth; // force reflow so the animation restarts
+        node.classList.add(className);
+    }
+
+    _flash(opacity, ms) {
+        this.flashTarget.style.setProperty('--flash', `${opacity}`);
+        this.flashTarget.classList.add('is-on');
+        this._after(ms, () => this.flashTarget.classList.remove('is-on'));
+    }
+
+    _shake() {
+        this.element.classList.add('is-shake');
+        this._after(500, () => this.element.classList.remove('is-shake'));
+    }
+}

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -1,0 +1,418 @@
+/*
+ * Pack opening reveal — sealed → swipe-to-slice → tearing → whiteout → reveal.
+ *
+ * Driven by assets/controllers/booster_opening_controller.js (no anime.js):
+ * the controller sets `data-phase` on `.opening`, a `--tp` (tear progress 0..1)
+ * while the pack is being sliced, `--reveal-color` per revealed card, and
+ * toggles a handful of state classes. Everything else is CSS.
+ *
+ * CRITICAL: every entrance animation that has a start delay uses
+ * `animation-fill-mode: both` — with `forwards` the element would flash its base
+ * style during the delay (off-centre bloom/beam). See the design handoff.
+ */
+
+/* ------------------------------------------------------------------ keyframes */
+@keyframes opening-slitOpen   { 0% { transform: scaleY(0); opacity: 0; } 30% { opacity: 1; } 100% { transform: scaleY(1); opacity: 1; } }
+@keyframes opening-flapTearOff{ 0% { transform: translate(0,0) rotate(0); opacity: 1; } 14% { transform: translate(0,-10px) rotate(-3deg); } 55% { opacity: 1; } 100% { transform: translate(560px,-150px) rotate(46deg) scale(.9); opacity: 0; } }
+@keyframes opening-packBurst  { 0% { filter: brightness(1); } 60% { filter: brightness(1.55); } 100% { filter: brightness(2.5) saturate(1.2); opacity: .82; } }
+@keyframes opening-beamRise   { 0% { transform: translate(-50%,0) scaleY(0); opacity: 0; } 25% { opacity: 1; } 100% { transform: translate(-50%,0) scaleY(1); opacity: .9; } }
+@keyframes opening-coreBloom  { 0% { transform: translate(-50%,-50%) scale(.15); opacity: 0; } 20% { opacity: .9; } 100% { transform: translate(-50%,-50%) scale(1.85); opacity: 1; } }
+@keyframes opening-raysSpin   { 0% { transform: translate(-50%,-50%) rotate(0); } 100% { transform: translate(-50%,-50%) rotate(360deg); } }
+@keyframes opening-fadeIn6    { from { opacity: 0; } to { opacity: .6; } }
+@keyframes opening-particlefly{ 0% { transform: translate(-50%,-50%) rotate(var(--ang)) translateX(0); opacity: 1; } 100% { transform: translate(-50%,-50%) rotate(var(--ang)) translateX(var(--dist)); opacity: 0; } }
+@keyframes opening-whiteout   { 0% { opacity: 0; } 45% { opacity: 0; } 78% { opacity: .9; } 100% { opacity: 1; } }
+@keyframes opening-fadeWhite  { 0% { opacity: 1; } 100% { opacity: 0; } }
+@keyframes opening-cardReveal { 0% { transform: translateY(40px) scale(.7) rotateY(90deg); opacity: 0; } 60% { opacity: 1; } 100% { transform: translateY(0) scale(1) rotateY(0); opacity: 1; } }
+@keyframes opening-cardRevealBig { 0% { transform: translateY(60px) scale(.5) rotateY(180deg); opacity: 0; filter: brightness(3); } 40% { opacity: 1; } 70% { transform: translateY(0) scale(1.12) rotateY(0); filter: brightness(1.4); } 100% { transform: translateY(0) scale(1) rotateY(0); filter: brightness(1); } }
+@keyframes opening-auraPulse  { 0% { transform: translate(-50%,-50%) scale(.4); opacity: 0; } 40% { opacity: 1; } 100% { transform: translate(-50%,-50%) scale(1.1); opacity: 1; } }
+@keyframes opening-labelSlam  { 0% { transform: translateX(-50%) scale(2.4); opacity: 0; filter: blur(8px); } 60% { transform: translateX(-50%) scale(.92); opacity: 1; filter: blur(0); } 100% { transform: translateX(-50%) scale(1); opacity: 1; } }
+@keyframes opening-screenShake{ 0%,100% { transform: translate(0,0); } 25% { transform: translate(-6px,3px); } 50% { transform: translate(6px,-3px); } 75% { transform: translate(-4px,-2px); } }
+@keyframes opening-nudgeX     { 0%,100% { transform: translateX(0); } 50% { transform: translateX(7px); } }
+@keyframes opening-summaryIn  { 0% { transform: translateY(14px) scale(.92); opacity: 0; } 100% { transform: translateY(0) scale(1); opacity: 1; } }
+
+/* --------------------------------------------------------------------- stage */
+.opening {
+    position: relative;
+    display: flex;
+    width: 100%;
+    min-height: min(90vh, 760px);
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.opening.is-shake { animation: opening-screenShake .5s; }
+
+/* ambient violet glow behind the stage */
+.opening::before {
+    content: "";
+    position: absolute;
+    top: -20%;
+    left: 50%;
+    width: 1000px;
+    height: 700px;
+    transform: translateX(-50%);
+    border-radius: 50%;
+    background: radial-gradient(ellipse, #a435f022 0%, transparent 60%);
+    filter: blur(40px);
+    pointer-events: none;
+}
+
+/* stage visibility is driven by [hidden] toggled from the controller */
+.opening__sealed,
+.opening__tearing,
+.opening__reveal { position: relative; z-index: 2; text-align: center; }
+
+/* ====================================================== SEALED — the pack */
+.opening__pack-wrap {
+    display: inline-block;
+    cursor: grab;
+    touch-action: none;
+    animation: floatY 4s ease-in-out infinite;
+}
+.opening__pack-wrap.is-cutting { cursor: grabbing; animation: none; }
+
+.opening__pack {
+    position: relative;
+    width: 300px;
+    height: 430px;
+    filter: drop-shadow(0 30px 50px #000a);
+}
+
+.opening__pack-body {
+    position: absolute;
+    inset: 0;
+    top: 30px;
+    overflow: hidden;
+    border: 1px solid #a435f055;
+    border-radius: 10px;
+    background: linear-gradient(160deg, #2a1356 0%, #14092e 45%, #2a0f44 100%);
+}
+.opening__pack-body img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: .85;
+}
+.opening__pack-body::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    mix-blend-mode: color-dodge;
+    opacity: .5;
+    background: linear-gradient(115deg, transparent 35%, #ff3db077 48%, #00f0ff55 52%, transparent 65%);
+    background-size: 300% 300%;
+    animation: packShimmer 4s linear infinite;
+}
+.opening__pack-banner {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 2;
+    padding: 16px 18px 20px;
+    background: linear-gradient(180deg, transparent, #0b0712 80%);
+    text-align: left;
+}
+.opening__pack-banner .code { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 700; letter-spacing: .25em; color: #ff3db0; }
+.opening__pack-banner .name { margin-top: 4px; font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 22px; line-height: 1; text-transform: uppercase; letter-spacing: -.02em; color: #fff; }
+
+/* top crimp flap that slides off as you slice (driven by --tp) */
+.opening__pack-flap {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 4;
+    height: 50px;
+    transform-origin: left center;
+    transform: translate(calc(var(--tp, 0) * 135px), calc(var(--tp, 0) * -10px)) rotate(calc(var(--tp, 0) * 7deg));
+    transition: transform 70ms linear, opacity 70ms linear;
+    background: linear-gradient(180deg, #2c1758 0%, #170c30 100%);
+    box-shadow: inset 0 2px 0 #ffffff22, inset 0 -3px 7px #00000077;
+    clip-path: polygon(0 0,100% 0,100% 84%,97% 100%,94% 85%,91% 100%,88% 84%,85% 100%,82% 85%,79% 100%,76% 84%,73% 100%,70% 85%,67% 100%,64% 84%,61% 100%,58% 85%,55% 100%,52% 84%,49% 100%,46% 85%,43% 100%,40% 84%,37% 100%,34% 85%,31% 100%,28% 84%,25% 100%,22% 85%,19% 100%,16% 84%,13% 100%,10% 85%,7% 100%,4% 84%,1% 100%,0 88%);
+}
+
+/* light slit opening along the tear line */
+.opening__pack-slit {
+    position: absolute;
+    top: 44px;
+    left: 6px;
+    right: 6px;
+    z-index: 3;
+    height: calc(6px + var(--tp, 0) * 28px);
+    opacity: calc(var(--tp, 0) * 1.4);
+    background: linear-gradient(180deg, #fff, #e9d5ff 50%, transparent);
+    filter: blur(5px);
+    pointer-events: none;
+    transition: height 70ms linear, opacity 70ms linear;
+}
+
+/* glowing torn edge racing left → right with the cut */
+.opening__pack-edge {
+    position: absolute;
+    top: 46px;
+    left: 0;
+    z-index: 5;
+    width: calc(min(100%, var(--tp, 0) * 120%));
+    height: 2px;
+    opacity: .9;
+    background: #fff;
+    box-shadow: 0 0 10px #fff, 0 0 22px #e9d5ff;
+    pointer-events: none;
+    transition: width 70ms linear;
+}
+
+/* perforation guide line — only while untouched */
+.opening__pack-guide {
+    position: absolute;
+    top: 48px;
+    left: 12px;
+    right: 12px;
+    z-index: 5;
+    border-top: 2px dotted #c79bff99;
+    pointer-events: none;
+}
+.is-cutting .opening__pack-guide { display: none; }
+
+/* CUTTER — the bright point of light riding the cut under your finger */
+.opening__pack-cutter {
+    position: absolute;
+    top: 46px;
+    left: calc(min(98%, var(--tp, 0) * 100%));
+    z-index: 6;
+    transform: translate(-50%, -50%);
+    opacity: 0;
+    pointer-events: none;
+    transition: left 60ms linear;
+}
+.is-cutting .opening__pack-cutter { opacity: 1; }
+.opening__pack-cutter .dot {
+    width: 13px;
+    height: 13px;
+    border-radius: 999px;
+    background: #fff;
+    box-shadow: 0 0 14px 5px #fff, 0 0 30px 12px #e9d5ff, 0 0 50px 20px #a435f088;
+}
+.opening__pack-cutter .cross-h,
+.opening__pack-cutter .cross-v {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+.opening__pack-cutter .cross-h { width: 46px; height: 2px; background: linear-gradient(90deg, transparent, #fff 45%, #fff 55%, transparent); }
+.opening__pack-cutter .cross-v { width: 2px; height: 20px; background: linear-gradient(180deg, transparent, #fff, transparent); }
+
+.opening__hint {
+    margin-top: 32px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    letter-spacing: .15em;
+    color: #b9a8cf;
+}
+.opening__hint .arrow { display: inline-block; animation: opening-nudgeX 1.3s ease-in-out infinite; }
+
+.opening__skip {
+    margin-top: 16px;
+    padding: 14px 28px;
+    border: 1px solid #a435f066;
+    background: transparent;
+    color: #fff;
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: .15em;
+    text-transform: uppercase;
+    cursor: pointer;
+}
+.opening__skip:hover { border-color: var(--primary); color: var(--primary); }
+
+/* ===================================================== TEARING — burst fx */
+.opening__beam {
+    position: absolute;
+    left: 50%;
+    top: 4%;
+    z-index: 2;
+    width: 150px;
+    height: 480px;
+    transform-origin: 50% 0%;
+    background: linear-gradient(180deg, #fff 0%, #ecd9ff 42%, transparent 92%);
+    filter: blur(11px);
+    mix-blend-mode: screen;
+    pointer-events: none;
+    animation: opening-beamRise .9s .12s cubic-bezier(.2,.8,.2,1) both;
+}
+.opening__rays {
+    position: absolute;
+    left: 50%;
+    top: 44%;
+    z-index: 2;
+    width: 780px;
+    height: 780px;
+    pointer-events: none;
+    background: repeating-conic-gradient(from 0deg, #ffffff44 0deg 4deg, transparent 4deg 16deg);
+    mask-image: radial-gradient(circle, #000 6%, transparent 58%);
+    -webkit-mask-image: radial-gradient(circle, #000 6%, transparent 58%);
+    animation: opening-raysSpin 9s linear infinite, opening-fadeIn6 .6s .15s ease-out backwards;
+}
+.opening__bloom {
+    position: absolute;
+    left: 50%;
+    top: 44%;
+    z-index: 3;
+    width: 540px;
+    height: 540px;
+    border-radius: 50%;
+    mix-blend-mode: screen;
+    pointer-events: none;
+    background: radial-gradient(circle, #fff 0%, #f0ddff 26%, #c9a0ff55 48%, transparent 72%);
+    animation: opening-coreBloom 1.05s .22s ease-out both;
+}
+.opening__particles span {
+    position: absolute;
+    left: 50%;
+    top: 40%;
+    z-index: 4;
+    width: 6px;
+    height: 6px;
+    border-radius: 999px;
+    box-shadow: 0 0 10px currentColor;
+    animation: opening-particlefly 1s ease-out both;
+}
+
+/* ============================================ WHITEOUT / FLASH overlays */
+.opening__whiteout,
+.opening__flash {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    opacity: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at 50% 44%, #ffffff, #ead8ff 42%, transparent 82%);
+}
+.opening__whiteout.is-tearing { animation: opening-whiteout 1.15s ease-in forwards; }
+.opening__whiteout.is-bridge  { animation: opening-fadeWhite .6s ease-out forwards; }
+.opening__flash { transition: opacity .5s ease-out; }
+.opening__flash.is-on { opacity: var(--flash, .3); }
+
+/* ================================================= REVEAL — one card at a time */
+.opening__reveal {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
+    cursor: pointer;
+}
+.opening__reveal-fx {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    pointer-events: none;
+}
+.opening__aura {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 700px;
+    height: 700px;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    opacity: 0;
+    background: radial-gradient(circle, color-mix(in srgb, var(--reveal-color, #fff) 18%, transparent) 0%, transparent 60%);
+}
+.is-shiny .opening__aura { background: radial-gradient(circle, color-mix(in srgb, var(--reveal-color, #fff) 40%, transparent) 0%, transparent 60%); }
+.opening__aura.is-on { animation: opening-auraPulse 1.6s ease-out forwards; }
+
+.opening__label {
+    position: absolute;
+    top: 4%;
+    left: 50%;
+    z-index: 3;
+    transform: translateX(-50%);
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700;
+    font-size: 40px;
+    text-transform: uppercase;
+    letter-spacing: -.02em;
+    white-space: nowrap;
+    color: var(--reveal-color, #fff);
+    text-shadow: 0 0 30px var(--reveal-color, #fff);
+    opacity: 0;
+    pointer-events: none;
+}
+.opening__label.is-on { animation: opening-labelSlam .6s cubic-bezier(.2,1.4,.4,1) forwards; }
+
+.opening__reveal-cards {
+    position: relative;
+    z-index: 2;
+    margin-top: 64px;
+    display: grid;
+    place-items: center;
+}
+/* all reveal cards stacked in the same cell; only the current one shows */
+.opening__reveal-card {
+    grid-area: 1 / 1;
+    display: none;
+    transform: scale(var(--reveal-card-scale, 1.4));
+    transform-origin: center;
+}
+.opening__reveal-card.is-current { display: block; }
+.opening__reveal-card.is-entering { animation: opening-cardReveal .6s cubic-bezier(.2,.8,.2,1); }
+.opening__reveal-card[data-shiny="1"].is-entering { animation: opening-cardRevealBig .9s cubic-bezier(.2,.8,.2,1); }
+
+.opening__progress {
+    z-index: 2;
+    margin-top: 40px;
+    display: flex;
+    gap: 8px;
+}
+.opening__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: #ffffff22;
+    transition: all .3s;
+}
+.opening__dot.is-done { background: var(--dot-color, #fff); }
+.opening__dot.is-current { width: 28px; background: var(--dot-color, #fff); box-shadow: 0 0 10px var(--dot-color, #fff); }
+
+.opening__next {
+    z-index: 2;
+    margin-top: 24px;
+    padding: 12px 26px;
+    border: 1px solid #a435f066;
+    background: transparent;
+    color: #fff;
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: .15em;
+    text-transform: uppercase;
+    cursor: pointer;
+}
+.opening__next:hover { border-color: var(--primary); }
+.opening__counter {
+    z-index: 2;
+    margin-top: 14px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: .15em;
+    color: #6a5a8a;
+}
+
+/* ===================================================================== SUMMARY */
+.opening__summary { animation: opening-summaryIn .4s ease-out both; }
+
+/* reveal card scale shrinks a touch on short viewports */
+@media (max-height: 760px) {
+    .opening__reveal-card { --reveal-card-scale: 1.1; }
+    .opening__reveal-cards { margin-top: 48px; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .opening__pack-wrap,
+    .opening__pack-body::after { animation: none; }
+}

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -43,6 +43,13 @@
 
 .opening.is-shake { animation: opening-screenShake .5s; }
 
+/*
+ * `[hidden]` (display:none) is a low-priority UA rule — the stages below set an
+ * explicit `display` (flex grid, Tailwind `flex`) which would otherwise win and
+ * leak every stage at once (the summary showing before the pack is opened).
+ */
+.opening [hidden] { display: none !important; }
+
 /* ambient violet glow behind the stage */
 .opening::before {
     content: "";

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -6,6 +6,7 @@ namespace App\Twig\Components;
 
 use App\Entity\Booster;
 use App\Entity\BoosterOpening;
+use App\Entity\Card;
 use App\Entity\DiscordUser;
 use App\Enum\Entity\CardRarityEnum;
 use App\Exception\Booster\BoosterException;
@@ -119,6 +120,39 @@ final class BoosterHub extends AbstractController
         }
 
         return $summary;
+    }
+
+    /**
+     * Individual drawn cards in reveal order: rarest revealed last (the climax),
+     * holo copies flagged so the CardComponent lights up its holo layers.
+     *
+     * @return list<array{card: Card, holo: bool}>
+     */
+    public function getRevealCards(): array
+    {
+        if (!$this->opening instanceof BoosterOpening) {
+            return [];
+        }
+
+        $rank = array_flip(array_map(
+            static fn (CardRarityEnum $rarity): string => $rarity->value,
+            CardRarityEnum::ascending(),
+        ));
+
+        $cards = [];
+        foreach ($this->opening->getBoosterOpeningCards() as $openingCard) {
+            $card = $openingCard->getCard();
+            for ($copy = 0; $copy < $openingCard->getQuantity(); ++$copy) {
+                $cards[] = ['card' => $card, 'holo' => $copy < $openingCard->getHoloQuantity()];
+            }
+        }
+
+        usort(
+            $cards,
+            static fn (array $a, array $b): int => $rank[$a['card']->getRarity()->value] <=> $rank[$b['card']->getRarity()->value],
+        );
+
+        return $cards;
     }
 
     #[LiveAction]

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -102,58 +102,157 @@
         </section>
     </main>
 
-    {# --------------------------------------------------- Loot summary modal #}
+    {# --------------------------------------------- Opening scene (reveal) #}
     {% if opening %}
-        <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/85 p-4 backdrop-blur-sm"
+        {% set revealCards = this.revealCards %}
+        {% set rarityLabels = { common: 'Commune', uncommon: 'Peu commune', rare: 'Rare', epic: 'Épique', legendary: 'Légendaire' } %}
+        {% set raritySuffix = { rare: ' !', epic: ' !!', legendary: ' !!!' } %}
+        <div class="fixed inset-0 z-50 overflow-y-auto bg-black/90 backdrop-blur-sm"
              data-live-id="opening-{{ opening.id }}"
-             data-testid="opening-summary">
-            <div class="flex max-h-[90vh] w-full max-w-5xl flex-col border border-hairline bg-bg">
-                <header class="flex items-center justify-between border-b border-hairline bg-surface px-6 py-5">
-                    <div>
-                        <p class="eyebrow">Ton butin</p>
-                        <h2 class="mt-1 font-display text-2xl font-bold uppercase tracking-[-0.03em] text-ink-strong">
-                            {{ opening.booster.extension.name }}
-                        </h2>
-                    </div>
-                    <button type="button"
-                            data-action="live#action"
-                            data-live-action-param="closeModal"
-                            class="font-mono text-2xl leading-none text-ink-dim transition hover:text-ink-strong"
-                            aria-label="Fermer">×</button>
-                </header>
+             data-testid="opening-scene">
+            <div class="opening"
+                 data-controller="booster-opening"
+                 data-booster-opening-count-value="{{ revealCards|length }}"
+                 data-live-ignore>
 
-                <div class="flex flex-wrap gap-2 border-b border-hairline px-6 py-4" data-testid="rarity-tally">
-                    {% for tier in this.raritySummary %}
-                        <span class="chip-mono border border-hairline px-2.5 py-1 font-bold"
-                              style="color: var(--rarity-{{ tier.rarity.value }});">
-                            {{ tier.rarity.value }} · {{ tier.count }}
-                        </span>
-                    {% endfor %}
+                {# ---------- SEALED — the pack, swipe to slice ---------- #}
+                <div class="opening__sealed" data-booster-opening-target="sealed">
+                    <div class="opening__pack-wrap"
+                         data-booster-opening-target="pack"
+                         data-action="pointerdown->booster-opening#dragStart pointermove->booster-opening#dragMove pointerup->booster-opening#dragEnd pointercancel->booster-opening#dragEnd">
+                        <div class="opening__pack">
+                            <div class="opening__pack-flap"></div>
+                            <div class="opening__pack-slit"></div>
+                            <div class="opening__pack-edge"></div>
+                            <div class="opening__pack-guide"></div>
+                            <div class="opening__pack-cutter">
+                                <div class="dot"></div>
+                                <div class="cross-h"></div>
+                                <div class="cross-v"></div>
+                            </div>
+                            <div class="opening__pack-body">
+                                <img src="{{ opening.booster.imageName ? vich_uploader_asset(opening.booster) : (opening.booster.extension.imageName ? vich_uploader_asset(opening.booster.extension) : asset('images/cards/default_card.png')) }}"
+                                     alt="{{ opening.booster.extension.name }}"
+                                     onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
+                            </div>
+                            <div class="opening__pack-banner">
+                                <div class="code">BOOSTER</div>
+                                <div class="name">{{ opening.booster.extension.name }}</div>
+                            </div>
+                        </div>
+                    </div>
+                    <p class="opening__hint">
+                        TIRE LE HAUT DU PACK&nbsp;<span class="arrow">→</span>&nbsp;POUR LE DÉCHIRER
+                    </p>
+                    <button type="button" class="opening__skip" data-action="booster-opening#openAtOnce">
+                        … ou clique pour ouvrir d'un coup
+                    </button>
                 </div>
 
-                <div class="grid grid-cols-2 gap-5 overflow-y-auto px-6 py-6 sm:grid-cols-3 md:grid-cols-4">
-                    {% for openingCard in opening.boosterOpeningCards %}
-                        {% for copy in 1..openingCard.quantity %}
-                            <div class="relative">
+                {# ---------- TEARING — light burst ---------- #}
+                <div class="opening__tearing" data-booster-opening-target="tearing" hidden>
+                    <div class="opening__beam"></div>
+                    <div class="opening__rays"></div>
+                    <div class="opening__bloom"></div>
+                    <div class="opening__particles">
+                        {% for i in 0..21 %}
+                            <span style="--ang: {{ (i / 22 * 360)|round }}deg; --dist: {{ 140 + (i % 5) * 55 }}px; color: {{ i is odd ? '#ff3db0' : '#d9a8ff' }}; animation-delay: {{ (0.22 + (i % 6) * 0.04) }}s;"></span>
+                        {% endfor %}
+                    </div>
+                </div>
+
+                {# ---------- REVEAL — cards one at a time, rarest last ---------- #}
+                <div class="opening__reveal"
+                     data-booster-opening-target="reveal"
+                     data-action="click->booster-opening#advance"
+                     hidden>
+                    <div class="opening__reveal-fx">
+                        <div class="opening__aura" data-booster-opening-target="aura"></div>
+                    </div>
+                    <div class="opening__label" data-booster-opening-target="label"></div>
+
+                    <div class="opening__reveal-cards">
+                        {% for reveal in revealCards %}
+                            {% set rarity = reveal.card.rarity.value %}
+                            <div class="opening__reveal-card"
+                                 data-booster-opening-target="card"
+                                 data-rarity="{{ rarity }}"
+                                 data-shiny="{{ rarity in ['rare', 'epic', 'legendary'] ? '1' : '0' }}"
+                                 data-label="{{ rarityLabels[rarity]|default(rarity) }}{{ raritySuffix[rarity]|default('') }}">
                                 {{ include('components/CardComponent.html.twig', {
-                                    card: openingCard.card,
-                                    holo: copy <= openingCard.holoQuantity,
-                                    id: 'loot-' ~ loop.parent.loop.index ~ '-' ~ copy,
+                                    card: reveal.card,
+                                    holo: reveal.holo,
+                                    id: 'reveal-' ~ loop.index,
                                 }) }}
-                                {% if (openingCard.card.id ~ '') in newCardIds %}
-                                    <span class="chip-mono absolute -left-2 -top-2 z-10 bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">NOUVEAU</span>
-                                {% endif %}
                             </div>
                         {% endfor %}
-                    {% endfor %}
+                    </div>
+
+                    <div class="opening__progress" data-testid="reveal-progress">
+                        {% for reveal in revealCards %}
+                            <span class="opening__dot" data-booster-opening-target="dot"></span>
+                        {% endfor %}
+                    </div>
+                    <button type="button" class="opening__next" data-booster-opening-target="next" data-action="booster-opening#advance">Carte suivante ▸</button>
+                    <p class="opening__counter" data-booster-opening-target="counter"></p>
                 </div>
 
-                <footer class="border-t border-hairline bg-surface px-6 py-5 text-center">
-                    <button type="button"
-                            data-action="live#action"
-                            data-live-action-param="closeModal"
-                            class="btn-arcade">Ajouter à ma collection ▸</button>
-                </footer>
+                {# ---------- SUMMARY — the loot ---------- #}
+                <div class="opening__summary mx-auto flex min-h-full w-full max-w-5xl flex-col"
+                     data-booster-opening-target="summary"
+                     data-testid="opening-summary"
+                     hidden>
+                    <header class="flex items-center justify-between border-b border-hairline bg-surface px-6 py-5">
+                        <div>
+                            <p class="eyebrow">Ton butin</p>
+                            <h2 class="mt-1 font-display text-2xl font-bold uppercase tracking-[-0.03em] text-ink-strong">
+                                {{ opening.booster.extension.name }}
+                            </h2>
+                        </div>
+                        <button type="button"
+                                data-action="live#action"
+                                data-live-action-param="closeModal"
+                                class="font-mono text-2xl leading-none text-ink-dim transition hover:text-ink-strong"
+                                aria-label="Fermer">×</button>
+                    </header>
+
+                    <div class="flex flex-wrap gap-2 border-b border-hairline px-6 py-4" data-testid="rarity-tally">
+                        {% for tier in this.raritySummary %}
+                            <span class="chip-mono border border-hairline px-2.5 py-1 font-bold"
+                                  style="color: var(--rarity-{{ tier.rarity.value }});">
+                                {{ tier.rarity.value }} · {{ tier.count }}
+                            </span>
+                        {% endfor %}
+                    </div>
+
+                    <div class="grid grid-cols-2 gap-5 px-6 py-6 sm:grid-cols-3 md:grid-cols-4">
+                        {% for openingCard in opening.boosterOpeningCards %}
+                            {% for copy in 1..openingCard.quantity %}
+                                <div class="relative">
+                                    {{ include('components/CardComponent.html.twig', {
+                                        card: openingCard.card,
+                                        holo: copy <= openingCard.holoQuantity,
+                                        id: 'loot-' ~ loop.parent.loop.index ~ '-' ~ copy,
+                                    }) }}
+                                    {% if (openingCard.card.id ~ '') in newCardIds %}
+                                        <span class="chip-mono absolute -left-2 -top-2 z-10 bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">NOUVEAU</span>
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                        {% endfor %}
+                    </div>
+
+                    <footer class="mt-auto border-t border-hairline bg-surface px-6 py-5 text-center">
+                        <button type="button"
+                                data-action="live#action"
+                                data-live-action-param="closeModal"
+                                class="btn-arcade">Ajouter à ma collection ▸</button>
+                    </footer>
+                </div>
+
+                {# whiteout bridge + soft flash overlays (controller-driven) #}
+                <div class="opening__whiteout" data-booster-opening-target="whiteout"></div>
+                <div class="opening__flash" data-booster-opening-target="flash"></div>
             </div>
         </div>
     {% endif %}

--- a/templates/pages/boosters.html.twig
+++ b/templates/pages/boosters.html.twig
@@ -4,6 +4,11 @@
     YOUL TCG — Boosters
 {% endblock %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('styles/opening.css') }}">
+{% endblock %}
+
 {% block body %}
     {{ component('BoosterHub') }}
 {% endblock %}

--- a/tests/Functional/BoosterHubComponentTest.php
+++ b/tests/Functional/BoosterHubComponentTest.php
@@ -6,10 +6,12 @@ namespace App\Tests\Functional;
 
 use App\Entity\UserBooster;
 use App\Entity\UserCard;
+use App\Enum\Entity\CardRarityEnum;
 use App\Repository\BoosterRepository;
 use App\Twig\Components\BoosterHub;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
 
 final class BoosterHubComponentTest extends WebTestCase
@@ -90,6 +92,34 @@ final class BoosterHubComponentTest extends WebTestCase
         $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
 
         $this->assertSame('Tu ne possèdes pas ce booster.', $component->component()->error);
+    }
+
+    public function testRevealRendersCardsOrderedRarestLast(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('claimBooster', ['boosterId' => (string) $booster->getId()]);
+        $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
+
+        $crawler = new Crawler((string) $component->render());
+        $rarities = $crawler->filter('.opening__reveal-card')->each(
+            static fn (Crawler $node): string => (string) $node->attr('data-rarity'),
+        );
+
+        $this->assertCount($booster->getCardCount(), $rarities);
+
+        $rank = array_flip(array_map(
+            static fn (CardRarityEnum $rarity): string => $rarity->value,
+            CardRarityEnum::ascending(),
+        ));
+        $ranks = array_map(static fn (string $rarity): int => $rank[$rarity], $rarities);
+        $sortedRanks = $ranks;
+        sort($sortedRanks);
+
+        $this->assertSame($sortedRanks, $ranks, 'Reveal cards must be ordered from common to rarest (climax last).');
     }
 
     public function testOpeningWithoutInventoryReportsAnError(): void


### PR DESCRIPTION
## Phase 3c — Animation d'ouverture

> ⚠️ **Stack sur la PR #42 (3b)**, elle-même sur #41 (3a). Base = `feat/phase-3b-opening-hub`. À re-targeter en cascade après les merges.

Transforme la modale d'ouverture (3b affichait le butin direct) en **expérience de reveal animée** par-dessus les cartes déjà tirées côté serveur : `sealed → swipe-to-slice → tearing → whiteout → reveal (rarest last) → summary`.

### Contenu
- **`booster_opening_controller.js`** — machine à états **sans anime.js** (timelines `setTimeout` + animations CSS, dans l'esprit des springs rAF de `card_controller.js`) :
  - **swipe-to-slice** : le pointeur pilote `--tp` (cutter lumineux, bord déchiré, crimp flap), commit au-delà de 0.6 (sinon snap-back), fallback « ouvrir d'un coup ».
  - **tearing** : whoosh / boom / phase→reveal calés sur la spec (~1.15 s), beam + bloom + rays + 22 particules + **whiteout** qui se raccorde au premier reveal (pas de frame noire).
  - **reveal séquentiel rarest-last** : aura par rareté, label « slam », entrée `cardRevealBig` pour les cartes shiny (rare/épique/légendaire) sinon `cardReveal`, flash + screen-shake sur épique/légendaire, dots de progression. Clic n'importe où pour avancer.
- **`opening.css`** — keyframes + layout des scènes adaptés du handoff Violet Arcade. **Règle critique respectée** : toute entrée avec délai → `animation-fill-mode: both`.
- **`BoosterHub::getRevealCards()`** — déplie les `BoosterOpeningCard` agrégés en cartes individuelles (part holo taguée) **triées ascendant par rareté** (climax en dernier).
- **`prefers-reduced-motion`** : saute directement au butin.
- `opening.css` chargé en `{% block stylesheets %}` scopé à la page boosters.

### Tests
- `BoosterHubComponentTest::testRevealRendersCardsOrderedRarestLast` — l'ordre DOM des `data-rarity` est non décroissant (rarest last) + count = `cardCount`.
- Le summary (butin + NOUVEAU + tally) reste vérifié ; `make quality` + **67 tests** verts (PHPStan niveau 8 sans baseline).

### Hors scope
- SFX Web Audio (optionnels, spec gardée pour plus tard).
- 3D packs.com = phase 3d.