### PR TITLE
feat(booster): Phase 3d — ouverture 3D du pack (façon packs.com)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@
 /.claude/settings.local.json
 /.claude/design_handoff_youl/
 ###< Claude Code ###
+
+# packs.com placeholder 3D pack model (dev only — never committed)
+/public/models/

--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -257,8 +257,15 @@ export default class extends Controller {
         this.labelTarget.textContent = card.dataset.label;
         this._retrigger(this.labelTarget, 'is-on');
 
-        if (isLast || rarity === 'epic' || rarity === 'legendary') {
-            this._flash(isLast ? 0.6 : 0.42, isLast ? 220 : 180);
+        // Burst on EVERY epic / legendary, whatever its slot — not just the last
+        // card. Legendary gets the strongest hit; the climax still pops if it
+        // happens to be a lesser rarity. The burst is tinted by --reveal-color.
+        if (rarity === 'legendary') {
+            this._flash(0.62, 240);
+        } else if (rarity === 'epic') {
+            this._flash(0.44, 190);
+        } else if (isLast) {
+            this._flash(0.5, 200);
         } else if (rarity === 'rare') {
             this._flash(0.24, 140);
         }

--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -1,16 +1,22 @@
 import { Controller } from '@hotwired/stimulus';
 
 /**
- * Pack opening reveal — `sealed → tearing → reveal → summary` state machine.
+ * Booster opening reveal — drives the dedicated packs.com-style page.
  *
- * The cards have already been drawn server-side (the live component holds the
- * opening); this controller only choreographs the presentation. It owns its DOM
- * subtree (`data-live-ignore`), so no anime.js: timing is plain `setTimeout`
- * timelines + CSS animations, and the swipe maps the pointer straight to a
- * `--tp` (tear progress) custom property.
+ * The cards are already drawn server-side (the BoosterOpening live component
+ * holds the opening); this controller only choreographs the presentation. It
+ * lives on the persistent `.opening` page root, alongside the 3D pack (which
+ * sits in a `data-live-ignore` subtree and bubbles a `pack3d:opened` event when
+ * peeled).
  *
- * Reveal order is rarest-last (the server sorts it); per card we light a rarity
- * aura, slam its label, and play a bigger entrance for shiny cards.
+ * Flow: once the pack has been opened server-side this controller arms the pack
+ * (a `pack3d:arm` window event) so it can be peeled. Peeling fires
+ * `pack3d:opened` → `startReveal()`, which reveals the drawn cards one at a time
+ * in the centre showcase (rarest last, the last one a face-down climax flip) and
+ * lights up the matching card in the right-hand set list. When every card is up
+ * it surfaces the "open another / back" footer.
+ *
+ * No anime.js: plain `setTimeout` timelines + CSS animations.
  */
 
 const RARITY_COLOR = {
@@ -20,14 +26,20 @@ const RARITY_COLOR = {
     epic: '#a435f0',
     legendary: '#ff8a2b',
 };
+const RARITY_LABEL = {
+    common: 'Commune',
+    uncommon: 'Peu commune',
+    rare: 'Rare',
+    epic: 'Épique',
+    legendary: 'Légendaire',
+};
+const RARITY_RANK = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 };
 const SHINY = new Set(['rare', 'epic', 'legendary']);
-const DRAG_DISTANCE = 210; // px of horizontal drag for a full tear
-const COMMIT_THRESHOLD = 0.6; // release past this commits the tear
 
 export default class extends Controller {
     static targets = [
-        'sealed', 'pack', 'tearing', 'whiteout', 'flash',
-        'reveal', 'aura', 'label', 'card', 'dot', 'next', 'counter', 'summary',
+        'showcase', 'aura', 'label', 'card', 'next', 'counter',
+        'slot', 'best', 'revealedCount', 'flash', 'foot', 'cta',
     ];
 
     static values = {
@@ -35,21 +47,69 @@ export default class extends Controller {
     };
 
     connect() {
-        this.phase = 'sealed';
-        this.revealIndex = -1;
-        this.tearProgress = 0;
-        this.dragging = false;
-        this.timers = [];
-
-        const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        if (reduced || this.countValue === 0) {
-            this._toSummary();
-        }
+        this._ensureInit();
     }
 
     disconnect() {
         this.timers.forEach(clearTimeout);
         this.timers = [];
+    }
+
+    // The `.opening` root is stable across the live re-render of `open()`, so
+    // Stimulus does NOT re-run connect() — it fires this value-changed callback
+    // when the draw lands (count 0 → N) or is cleared on reset (N → 0). Note it
+    // can run before connect(), hence the explicit init guard.
+    countValueChanged(current, previous) {
+        this._ensureInit();
+
+        if (current > 0) {
+            // a fresh opening — reset the reveal state and let the pack be peeled
+            this._resetReveal();
+            this.lastIndex = current - 1;
+            window.dispatchEvent(new CustomEvent('pack3d:arm'));
+
+            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+                this._after(0, () => this._revealAllAtOnce());
+            }
+        } else if (previous > 0) {
+            // "open another": re-seal the (data-live-ignore) pack for the next draw
+            window.dispatchEvent(new CustomEvent('pack3d:reset'));
+            this._resetReveal();
+        }
+    }
+
+    _ensureInit() {
+        if (this._inited) {
+            return;
+        }
+        this._inited = true;
+        this.timers = [];
+        this._resetReveal();
+    }
+
+    _resetReveal() {
+        this.timers?.forEach(clearTimeout);
+        this.timers = [];
+        this.phase = 'idle';
+        this.revealIndex = -1;
+        this.bestRank = -1;
+        if (this.hasShowcaseTarget) {
+            this.showcaseTarget.hidden = true;
+            this.showcaseTarget.style.pointerEvents = '';
+        }
+        if (this.hasFootTarget) {
+            this.footTarget.hidden = true;
+        }
+        // restore the in-showcase prompt + the tear CTA that _end() hides
+        if (this.hasNextTarget) {
+            this.nextTarget.hidden = false;
+        }
+        if (this.hasCounterTarget) {
+            this.counterTarget.hidden = false;
+        }
+        if (this.hasCtaTarget) {
+            this.ctaTarget.hidden = false;
+        }
     }
 
     _after(ms, fn) {
@@ -59,86 +119,56 @@ export default class extends Controller {
         return timer;
     }
 
-    // ----------------------------------------------------- swipe to slice
-    dragStart(event) {
-        if (this.phase !== 'sealed') {
+    // ask the (data-live-ignore) 3D pack to tear itself open in one go
+    forceOpen() {
+        window.dispatchEvent(new CustomEvent('pack3d:commit'));
+    }
+
+    // The 3D pack lives in a data-live-ignore subtree and can be re-instantiated by
+    // a live re-render *after* our one-shot `pack3d:arm` (from countValueChanged)
+    // has already fired, leaving it sealed. Whenever it (re)announces readiness,
+    // re-arm it if a draw is already on the table — closes that ordering race.
+    syncPack() {
+        if (this.hasCountValue && this.countValue > 0) {
+            window.dispatchEvent(new CustomEvent('pack3d:arm'));
+        }
+    }
+
+    // ----------------------------------------------------- reveal sequence
+    startReveal() {
+        if (this.phase !== 'idle' || !this.hasCountValue || this.countValue === 0) {
             return;
         }
-        this.dragging = true;
-        this.startX = event.clientX;
-        try {
-            event.currentTarget.setPointerCapture(event.pointerId);
-        } catch {
-            // pointer capture is best-effort
-        }
-    }
-
-    dragMove(event) {
-        if (!this.dragging) {
-            return;
-        }
-        const progress = Math.max(0, Math.min(1, (event.clientX - this.startX) / DRAG_DISTANCE));
-        this.tearProgress = progress;
-        this.element.style.setProperty('--tp', `${progress}`);
-        this.packTarget.classList.toggle('is-cutting', progress > 0.02);
-    }
-
-    dragEnd() {
-        if (!this.dragging) {
-            return;
-        }
-        this.dragging = false;
-        if (this.tearProgress > COMMIT_THRESHOLD) {
-            this.commitTear();
-        } else {
-            this.tearProgress = 0;
-            this.element.style.setProperty('--tp', '0');
-            this.packTarget.classList.remove('is-cutting');
-        }
-    }
-
-    // fallback: click the pack / button to open in one go
-    openAtOnce() {
-        this.commitTear();
-    }
-
-    // ----------------------------------------------------- tear timeline
-    commitTear() {
-        if (this.phase !== 'sealed') {
-            return;
-        }
-        this.phase = 'tearing';
-        this.tearProgress = 1;
-        this.element.style.setProperty('--tp', '1');
-        this.element.dataset.phase = 'tearing';
-
-        this.sealedTarget.hidden = true;
-        this.tearingTarget.hidden = false;
-        this.whiteoutTarget.classList.add('is-tearing');
-
-        // CSS whiteout peaks at ~1.15s; hand off to the reveal exactly then.
-        this._after(1150, () => this._startReveal());
-    }
-
-    _startReveal() {
         this.phase = 'reveal';
-        this.element.dataset.phase = 'reveal';
-        this.tearingTarget.hidden = true;
-        this.revealTarget.hidden = false;
+        this.showcaseTarget.hidden = false;
 
-        // carry the whiteout seamlessly into the first card, then fade it out
-        this.whiteoutTarget.classList.remove('is-tearing');
-        this.whiteoutTarget.classList.add('is-bridge');
-        this._after(600, () => this.whiteoutTarget.classList.remove('is-bridge'));
-
-        this._showCard(0);
+        if (this.countValue <= 1) {
+            this._revealLast();
+        } else {
+            this._revealCard(0);
+        }
     }
 
-    // ----------------------------------------------------- reveal cards
-    _showCard(index) {
+    advance(event) {
+        if (this.phase !== 'reveal') {
+            return;
+        }
+        if (event) {
+            event.stopPropagation();
+        }
+
+        const next = this.revealIndex + 1;
+        if (next >= this.lastIndex) {
+            this._revealLast();
+        } else {
+            this._revealCard(next);
+        }
+    }
+
+    _revealCard(index, big = false) {
         this.revealIndex = index;
         const card = this.cardTargets[index];
-        const { rarity } = card.dataset;
+        const { rarity, cardId } = card.dataset;
         const color = RARITY_COLOR[rarity] || '#ffffff';
         const shiny = SHINY.has(rarity);
 
@@ -152,54 +182,104 @@ export default class extends Controller {
         this.labelTarget.textContent = card.dataset.label;
         this._retrigger(this.labelTarget, 'is-on');
 
-        if (rarity === 'epic' || rarity === 'legendary') {
-            this._flash(0.42, 180);
-            this._shake();
+        if (big || rarity === 'epic' || rarity === 'legendary') {
+            this._flash(big ? 0.6 : 0.42, big ? 220 : 180);
         } else if (rarity === 'rare') {
             this._flash(0.24, 140);
         }
 
-        this.dotTargets.forEach((dot, i) => {
-            dot.style.setProperty('--dot-color', RARITY_COLOR[this.cardTargets[i].dataset.rarity] || '#fff');
-            dot.classList.toggle('is-done', i < index);
-            dot.classList.toggle('is-current', i === index);
-        });
+        this._lightSlot(cardId);
+        this._bumpBest(rarity);
+        this._updateRevealedCount(index + 1);
 
-        const last = index >= this.countValue - 1;
-        this.nextTarget.textContent = last ? 'Voir le butin ▸' : 'Carte suivante ▸';
         if (this.hasCounterTarget) {
-            this.counterTarget.textContent = `${index + 1} / ${this.countValue} · CLIQUE N'IMPORTE OÙ`;
+            this.counterTarget.textContent = `${index + 1} / ${this.countValue} · CLIQUE POUR CONTINUER`;
         }
     }
 
-    advance(event) {
-        if (this.phase !== 'reveal') {
+    // ----------------------------------------------------- climax (rarest last)
+    // The rarest card is last: reveal it with the big entrance and finish right
+    // away — the card stays on screen and the loot (set list + actions) is already
+    // there, so there's no extra "voir le butin" step.
+    _revealLast() {
+        this._revealCard(this.lastIndex, true);
+        this._end();
+    }
+
+    _end() {
+        this.phase = 'done';
+        // keep the last card on screen; retire the in-showcase prompt + tear CTA
+        // and surface the back / open-another actions under the booster
+        if (this.hasNextTarget) {
+            this.nextTarget.hidden = true;
+        }
+        if (this.hasCounterTarget) {
+            this.counterTarget.hidden = true;
+        }
+        if (this.hasCtaTarget) {
+            this.ctaTarget.hidden = true;
+        }
+        // the card stays visible, but the overlay must stop eating clicks meant for
+        // the actions sitting under the booster
+        if (this.hasShowcaseTarget) {
+            this.showcaseTarget.style.pointerEvents = 'none';
+        }
+        if (this.hasFootTarget) {
+            this.footTarget.hidden = false;
+        }
+    }
+
+    // reduced motion / fallback: everything revealed instantly, no peel needed
+    _revealAllAtOnce() {
+        this.phase = 'done';
+        this.cardTargets.forEach((card) => {
+            this._lightSlot(card.dataset.cardId);
+            this._bumpBest(card.dataset.rarity);
+        });
+        this._updateRevealedCount(this.countValue);
+        // keep the showcase visible (the footer lives inside it now), just let
+        // clicks through to the actions
+        if (this.hasShowcaseTarget) {
+            this.showcaseTarget.hidden = false;
+            this.showcaseTarget.style.pointerEvents = 'none';
+        }
+        if (this.hasCtaTarget) {
+            this.ctaTarget.hidden = true;
+        }
+        if (this.hasFootTarget) {
+            this.footTarget.hidden = false;
+        }
+    }
+
+    // ----------------------------------------------------- set list (aside)
+    _lightSlot(cardId) {
+        const slot = this.slotTargets.find((node) => node.dataset.cardId === cardId);
+        if (!slot) {
             return;
         }
-        if (event) {
-            event.stopPropagation();
+        slot.classList.add('is-revealed');
+        // reveal the real name (masked as "???" until owned / revealed)
+        const nameEl = slot.querySelector('.opening__slot-name');
+        if (nameEl && slot.dataset.cardName) {
+            nameEl.textContent = slot.dataset.cardName;
         }
-        if (this.revealIndex < this.countValue - 1) {
-            this._showCard(this.revealIndex + 1);
-        } else {
-            this._toSummary();
-        }
+        this._retrigger(slot, 'is-popping');
     }
 
-    // ----------------------------------------------------- summary
-    _toSummary() {
-        this.phase = 'summary';
-        this.element.dataset.phase = 'summary';
-        if (this.hasSealedTarget) {
-            this.sealedTarget.hidden = true;
+    _bumpBest(rarity) {
+        const rank = RARITY_RANK[rarity] ?? -1;
+        if (rank <= this.bestRank || !this.hasBestTarget) {
+            return;
         }
-        if (this.hasTearingTarget) {
-            this.tearingTarget.hidden = true;
+        this.bestRank = rank;
+        this.bestTarget.textContent = RARITY_LABEL[rarity] || rarity;
+        this.bestTarget.style.color = RARITY_COLOR[rarity] || '#fff';
+    }
+
+    _updateRevealedCount(count) {
+        if (this.hasRevealedCountTarget) {
+            this.revealedCountTarget.textContent = `${count}`;
         }
-        if (this.hasRevealTarget) {
-            this.revealTarget.hidden = true;
-        }
-        this.summaryTarget.hidden = false;
     }
 
     // ----------------------------------------------------- helpers
@@ -210,13 +290,11 @@ export default class extends Controller {
     }
 
     _flash(opacity, ms) {
+        if (!this.hasFlashTarget) {
+            return;
+        }
         this.flashTarget.style.setProperty('--flash', `${opacity}`);
         this.flashTarget.classList.add('is-on');
         this._after(ms, () => this.flashTarget.classList.remove('is-on'));
-    }
-
-    _shake() {
-        this.element.classList.add('is-shake');
-        this._after(500, () => this.element.classList.remove('is-shake'));
     }
 }

--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -11,10 +11,12 @@ import { Controller } from '@hotwired/stimulus';
  *
  * Flow: once the pack has been opened server-side this controller arms the pack
  * (a `pack3d:arm` window event) so it can be peeled. Peeling fires
- * `pack3d:opened` → `startReveal()`, which reveals the drawn cards one at a time
- * in the centre showcase (rarest last, the last one a face-down climax flip) and
- * lights up the matching card in the right-hand set list. When every card is up
- * it surfaces the "open another / back" footer.
+ * `pack3d:opened` → `startReveal()`, which presents the drawn cards one at a time
+ * in the centre showcase, each face-DOWN with the remaining cards stacked behind
+ * it (packs.com style). Clicking the card flips it (3D rotateY) to reveal the
+ * face — per-card state machine 'back' → 'flipping' → 'face' — which lights up the
+ * matching card in the right-hand set list. Cards run common → rarest (climax
+ * last); when the last one is up it surfaces the "open another / back" footer.
  *
  * No anime.js: plain `setTimeout` timelines + CSS animations.
  */
@@ -36,9 +38,12 @@ const RARITY_LABEL = {
 const RARITY_RANK = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 };
 const SHINY = new Set(['rare', 'epic', 'legendary']);
 
+// must match the .opening__flip CSS transition duration
+const FLIP_MS = 560;
+
 export default class extends Controller {
     static targets = [
-        'showcase', 'aura', 'label', 'card', 'next', 'counter',
+        'showcase', 'aura', 'label', 'card', 'flip', 'stack', 'next', 'counter',
         'slot', 'best', 'revealedCount', 'flash', 'foot', 'cta',
     ];
 
@@ -92,21 +97,32 @@ export default class extends Controller {
         this.timers = [];
         this.phase = 'idle';
         this.revealIndex = -1;
+        this.cardState = 'back'; // back → flipping → face, per current card
         this.bestRank = -1;
         if (this.hasShowcaseTarget) {
             this.showcaseTarget.hidden = true;
             this.showcaseTarget.style.pointerEvents = '';
         }
+        // every card face-down again, nothing current
+        this.cardTargets?.forEach((node) => node.classList.remove('is-current', 'is-pop'));
+        this.flipTargets?.forEach((flip) => flip.classList.remove('is-flipped'));
+        if (this.hasLabelTarget) {
+            this.labelTarget.textContent = '';
+            this.labelTarget.classList.remove('is-on');
+        }
+        this._updateStack(0);
         if (this.hasFootTarget) {
             this.footTarget.hidden = true;
         }
-        // restore the in-showcase prompt + the tear CTA that _end() hides
+        // the "carte suivante" button only surfaces once a card has been flipped
         if (this.hasNextTarget) {
-            this.nextTarget.hidden = false;
+            this.nextTarget.hidden = true;
         }
         if (this.hasCounterTarget) {
             this.counterTarget.hidden = false;
+            this.counterTarget.textContent = '';
         }
+        // restore the tear CTA that _end() hides
         if (this.hasCtaTarget) {
             this.ctaTarget.hidden = false;
         }
@@ -135,38 +151,95 @@ export default class extends Controller {
     }
 
     // ----------------------------------------------------- reveal sequence
+    // packs.com flow: each card is presented face-DOWN; the player clicks the card
+    // to flip it (3D rotateY) and reveal the face, then advances to the next one.
+    // Per-card state machine: 'back' → 'flipping' → 'face'.
     startReveal() {
         if (this.phase !== 'idle' || !this.hasCountValue || this.countValue === 0) {
             return;
         }
         this.phase = 'reveal';
         this.showcaseTarget.hidden = false;
-
-        if (this.countValue <= 1) {
-            this._revealLast();
-        } else {
-            this._revealCard(0);
+        // the pack is open now — drop the tear instruction / "ouvrir d'un coup" CTA
+        if (this.hasCtaTarget) {
+            this.ctaTarget.hidden = true;
         }
+
+        this._present(0);
     }
 
-    advance(event) {
+    // single entry point for clicks on the showcase: flip the current card, or
+    // (once it is face-up) advance to the next one.
+    tap() {
         if (this.phase !== 'reveal') {
             return;
         }
-        if (event) {
-            event.stopPropagation();
-        }
-
-        const next = this.revealIndex + 1;
-        if (next >= this.lastIndex) {
-            this._revealLast();
-        } else {
-            this._revealCard(next);
+        if (this.cardState === 'back') {
+            this._flip();
+        } else if (this.cardState === 'face') {
+            this.advance();
         }
     }
 
-    _revealCard(index, big = false) {
+    // "Carte suivante" button (accessibility alternative to clicking the card);
+    // only meaningful once the current card has been flipped face-up.
+    advance(event) {
+        if (this.phase !== 'reveal' || this.cardState !== 'face') {
+            return;
+        }
+        if (event) {
+            event.stopPropagation(); // don't let the button click bubble to tap()
+        }
+
+        const next = this.revealIndex + 1;
+        if (next <= this.lastIndex) {
+            this._present(next);
+        }
+    }
+
+    // show card `index` face-down, with the remaining cards stacked behind it
+    _present(index) {
         this.revealIndex = index;
+        this.cardState = 'back';
+
+        this.cardTargets.forEach((node, i) => node.classList.toggle('is-current', i === index));
+        const card = this.cardTargets[index];
+        const flip = this.flipTargets[index];
+        card.classList.remove('is-pop');
+        flip.classList.remove('is-flipped'); // back toward the player
+        this._retrigger(card, 'is-entering');
+
+        // neutral centre while it sits face-down
+        this.labelTarget.classList.remove('is-on');
+        this.labelTarget.textContent = '';
+        this.element.classList.remove('is-shiny');
+
+        if (this.hasNextTarget) {
+            this.nextTarget.hidden = true;
+        }
+        // cards still waiting behind this one
+        this._updateStack(this.lastIndex - index);
+
+        if (this.hasCounterTarget) {
+            this.counterTarget.textContent = `${index + 1} / ${this.countValue} · CLIQUE POUR RÉVÉLER`;
+        }
+    }
+
+    // flip the current card face-up, then run the reveal payoff
+    _flip() {
+        if (this.cardState !== 'back') {
+            return;
+        }
+        this.cardState = 'flipping';
+        this.flipTargets[this.revealIndex].classList.add('is-flipped');
+        this._after(FLIP_MS, () => this._onRevealed());
+    }
+
+    // the card has landed face-up: light it up, sync the set list, surface "next"
+    _onRevealed() {
+        this.cardState = 'face';
+        const index = this.revealIndex;
+        const isLast = index === this.lastIndex;
         const card = this.cardTargets[index];
         const { rarity, cardId } = card.dataset;
         const color = RARITY_COLOR[rarity] || '#ffffff';
@@ -175,15 +248,17 @@ export default class extends Controller {
         this.element.style.setProperty('--reveal-color', color);
         this.element.classList.toggle('is-shiny', shiny);
 
-        this.cardTargets.forEach((node, i) => node.classList.toggle('is-current', i === index));
-        this._retrigger(card, 'is-entering');
+        // a punchier landing for shinies and the rarest-last climax
+        if (shiny || isLast) {
+            card.classList.remove('is-entering'); // free the animation slot for the pop
+            this._retrigger(card, 'is-pop');
+        }
         this._retrigger(this.auraTarget, 'is-on');
-
         this.labelTarget.textContent = card.dataset.label;
         this._retrigger(this.labelTarget, 'is-on');
 
-        if (big || rarity === 'epic' || rarity === 'legendary') {
-            this._flash(big ? 0.6 : 0.42, big ? 220 : 180);
+        if (isLast || rarity === 'epic' || rarity === 'legendary') {
+            this._flash(isLast ? 0.6 : 0.42, isLast ? 220 : 180);
         } else if (rarity === 'rare') {
             this._flash(0.24, 140);
         }
@@ -191,19 +266,27 @@ export default class extends Controller {
         this._lightSlot(cardId);
         this._bumpBest(rarity);
         this._updateRevealedCount(index + 1);
+        this._updateStack(this.lastIndex - index);
 
-        if (this.hasCounterTarget) {
-            this.counterTarget.textContent = `${index + 1} / ${this.countValue} · CLIQUE POUR CONTINUER`;
+        if (isLast) {
+            // rarest card is last: it stays on screen and the loot/actions surface
+            this._end();
+        } else if (this.hasNextTarget) {
+            this.nextTarget.hidden = false;
+            if (this.hasCounterTarget) {
+                this.counterTarget.textContent = `${index + 1} / ${this.countValue} · CLIQUE POUR CONTINUER`;
+            }
         }
     }
 
-    // ----------------------------------------------------- climax (rarest last)
-    // The rarest card is last: reveal it with the big entrance and finish right
-    // away — the card stays on screen and the loot (set list + actions) is already
-    // there, so there's no extra "voir le butin" step.
-    _revealLast() {
-        this._revealCard(this.lastIndex, true);
-        this._end();
+    // a stacked deck of card backs peeking behind the current card (up to 3 layers)
+    _updateStack(remaining) {
+        if (!this.hasStackTarget) {
+            return;
+        }
+        const layers = Array.from(this.stackTarget.children);
+        layers.forEach((layer, i) => { layer.hidden = i >= remaining; });
+        this.stackTarget.hidden = remaining <= 0;
     }
 
     _end() {
@@ -229,9 +312,12 @@ export default class extends Controller {
         }
     }
 
-    // reduced motion / fallback: everything revealed instantly, no peel needed
+    // reduced motion / fallback: everything revealed instantly, no peel/flip needed
     _revealAllAtOnce() {
         this.phase = 'done';
+        this.cardState = 'face';
+        this.flipTargets.forEach((flip) => flip.classList.add('is-flipped'));
+        this._updateStack(0);
         this.cardTargets.forEach((card) => {
             this._lightSlot(card.dataset.cardId);
             this._bumpBest(card.dataset.rarity);

--- a/assets/controllers/crt_toggle_controller.js
+++ b/assets/controllers/crt_toggle_controller.js
@@ -1,0 +1,30 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Toggles the site-wide CRT scanlines overlay (.scanlines) on/off and remembers
+ * the choice in localStorage. Adds `crt-off` on <html> when disabled; the CSS
+ * hides the overlay from there. Default: CRT on.
+ */
+const KEY = 'youl:crt';
+
+export default class extends Controller {
+    static targets = ['checkbox'];
+
+    connect() {
+        this.enabled = localStorage.getItem(KEY) !== 'off';
+        this._apply();
+    }
+
+    toggle() {
+        this.enabled = this.hasCheckboxTarget ? this.checkboxTarget.checked : !this.enabled;
+        localStorage.setItem(KEY, this.enabled ? 'on' : 'off');
+        this._apply();
+    }
+
+    _apply() {
+        document.documentElement.classList.toggle('crt-off', !this.enabled);
+        if (this.hasCheckboxTarget) {
+            this.checkboxTarget.checked = this.enabled;
+        }
+    }
+}

--- a/assets/controllers/pack_front_controller.js
+++ b/assets/controllers/pack_front_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from '@hotwired/stimulus';
+import { drawPackFront, PACK_FRONT_W, PACK_FRONT_H } from '../lib/pack_front.js';
+
+/**
+ * Paints a YOUL pack front into its own <canvas> — the same composite used by the
+ * 3D opening pack (drawPackFront), so a boosters-grid tile looks like a real pack
+ * without any WebGL. Static: drawn once on connect, then CSS scales it down.
+ *
+ * Values mirror the 3D pack: bgUrl (extension/booster artwork, empty → fallback),
+ * fallbackUrl + logoUrl (the branded YOUL front), name + count.
+ */
+export default class extends Controller {
+    static values = {
+        bgUrl: String,
+        fallbackUrl: String,
+        logoUrl: String,
+        name: String,
+        count: Number,
+    };
+
+    async connect() {
+        this.element.width = PACK_FRONT_W;
+        this.element.height = PACK_FRONT_H;
+
+        let hero = this.hasBgUrlValue && this.bgUrlValue ? await this._load(this.bgUrlValue) : null;
+        const fallback = !hero;
+        if (fallback && this.hasFallbackUrlValue && this.fallbackUrlValue) {
+            hero = await this._load(this.fallbackUrlValue);
+        }
+        const logo = fallback && this.hasLogoUrlValue && this.logoUrlValue ? await this._load(this.logoUrlValue) : null;
+
+        if (this._gone) {
+            return; // disconnected while images were loading
+        }
+
+        drawPackFront(this.element.getContext('2d'), {
+            hero,
+            logo,
+            name: this.hasNameValue ? this.nameValue : '',
+            count: this.hasCountValue && this.countValue ? this.countValue : 5,
+            fallback,
+        });
+    }
+
+    disconnect() {
+        this._gone = true;
+    }
+
+    _load(src) {
+        return new Promise((resolve) => {
+            const img = new Image();
+            img.onload = () => resolve(img);
+            img.onerror = () => resolve(null);
+            img.src = src;
+        });
+    }
+}

--- a/assets/controllers/pack_opening_3d_controller.js
+++ b/assets/controllers/pack_opening_3d_controller.js
@@ -21,10 +21,13 @@ import { drawPackFront, PACK_FRONT_W, PACK_FRONT_H } from '../lib/pack_front.js'
  *   - a continuous idle float + a damped pointer-driven parallax tilt.
  * Contact shadow + vignette live in opening.css (the canvas is alpha).
  *
- * Strictly additive: if WebGL is unavailable, the model fails to load, or the
- * user prefers reduced motion, this controller does nothing and the 2D swipe
- * pack stays in place (CSS only hides it once `is-ready` is set here). Anything
- * cosmetic (sparkles, normal map) is best-effort and never aborts the pack.
+ * Strictly additive: if WebGL is unavailable or the model fails to load, the
+ * controller marks itself `is-unavailable` (CSS hides the dead canvas) and
+ * `arm()` commits immediately — the reveal starts right after the server-side
+ * draw, no peel required, so the booster is never debited without a reveal.
+ * Under prefers-reduced-motion the reveal controller shows everything at once
+ * on its own. Anything cosmetic (sparkles, normal map) is best-effort and
+ * never aborts the pack.
  */
 
 // A full tear is a share of the pack's on-screen WIDTH — the baked flap peels
@@ -73,11 +76,18 @@ export default class extends Controller {
         this.pointer = { x: 0, y: 0 };
         this.dragDistance = DRAG_DISTANCE;
 
-        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches || !this._webglAvailable()) {
-            return;
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            return; // the reveal controller shows everything at once on its own
         }
 
-        this._init().catch(() => this._teardown());
+        if (this._webglAvailable()) {
+            this._init().catch(() => {
+                this._teardown();
+                this._markUnavailable();
+            });
+        } else {
+            this._markUnavailable();
+        }
 
         // We live in a data-live-ignore subtree, so a bubbling event is our only
         // channel to the reveal controller — and a live re-render can re-instantiate
@@ -197,7 +207,7 @@ export default class extends Controller {
         this.clock = new THREE.Clock();
         this._applyProgress(0); // sealed at rest (clip time 0)
 
-        this.element.classList.add('is-ready'); // CSS hides the 2D fallback pack
+        this.element.classList.add('is-ready'); // styling hook: the 3D pack is live
         this._updateDragDistance();
         this._onResize = () => this._resize();
         window.addEventListener('resize', this._onResize);
@@ -423,10 +433,25 @@ export default class extends Controller {
         });
     }
 
+    // No 3D pack to peel (WebGL missing or model failed to load): the draw is
+    // already persisted server-side, so hand off to the reveal immediately —
+    // never leave a debited booster stuck behind a dead canvas.
+    _markUnavailable() {
+        this.unavailable = true;
+        this.element.classList.add('is-unavailable');
+        if (this.armed && !this.committed) {
+            this._commit();
+        }
+    }
+
     // Enable peeling — fired (via a window event) once the booster has been drawn
     // server-side, so the wrapper can't be torn before there are cards to reveal.
     arm() {
         this.armed = true;
+
+        if (this.unavailable && !this.committed) {
+            this._commit();
+        }
     }
 
     // Re-seal for another draw — this pack lives in a data-live-ignore subtree and
@@ -480,9 +505,9 @@ export default class extends Controller {
         }
     }
 
-    // fallback: click to open in one go
+    // fallback: click to open in one go — must work without a renderer too
     openAtOnce() {
-        if (this.renderer && this.armed && !this.committed) {
+        if (this.armed && !this.committed) {
             this._commit();
         }
     }

--- a/assets/controllers/pack_opening_3d_controller.js
+++ b/assets/controllers/pack_opening_3d_controller.js
@@ -1,25 +1,54 @@
 import { Controller } from '@hotwired/stimulus';
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { drawPackFront, PACK_FRONT_W, PACK_FRONT_H } from '../lib/pack_front.js';
 
 /**
  * 3D pack opening — packs.com-style progressive enhancement over the 2D swipe.
  *
  * Loads a GLTF pack (rigid body + a foil flap carrying a pre-baked cloth-tear as
- * morph targets) with an unlit material, and **scrubs the GLTF animation with
- * the drag**: the tear follows your finger forwards and back, snaps back below
- * the threshold, commits at the top. On commit it hands off to the existing 2D
- * reveal (`booster-opening` controller) via a bubbling `pack3d:opened` event.
+ * morph targets) and **scrubs the GLTF animation with the drag**: the tear
+ * follows your finger forwards and back, snaps back below the threshold, commits
+ * at the top. On commit it hands off to the existing 2D reveal
+ * (`booster-opening` controller) via a bubbling `pack3d:opened` event.
+ *
+ * Rendering aims at the packs.com look (see refs-packs/RAPPORT-OUVERTURE-3D.md):
+ *   - glossy plastic-film foil: MeshPhysicalMaterial (metalness + clearcoat),
+ *     artwork kept colour-accurate via an emissive map, sheen from a procedural
+ *     environment so a specular highlight sweeps the surface as the pack tilts;
+ *   - a procedural normal map for the crimp/creases of the wrapper;
+ *   - drifting, twinkling sparkles (THREE.Points) floating around the pack;
+ *   - a continuous idle float + a damped pointer-driven parallax tilt.
+ * Contact shadow + vignette live in opening.css (the canvas is alpha).
  *
  * Strictly additive: if WebGL is unavailable, the model fails to load, or the
  * user prefers reduced motion, this controller does nothing and the 2D swipe
- * pack stays in place (CSS only hides it once `is-ready` is set here).
+ * pack stays in place (CSS only hides it once `is-ready` is set here). Anything
+ * cosmetic (sparkles, normal map) is best-effort and never aborts the pack.
  */
 
-const DRAG_DISTANCE = 130; // px of drag for a full tear (packs.com threshold)
-const COMMIT_THRESHOLD = 0.98;
-const TEAR_START = 0.4; // the first 40% of the clip settles the body; the tear scrubs 0.4 → 1
-const TILT = 0.18; // how far the pack leans toward the pointer
+// A full tear is a share of the pack's on-screen WIDTH — the baked flap peels
+// sideways (ΔX dominant), so we drag horizontally and scale the throw to width
+// (narrower than the height, hence the larger ratio) for a consistent feel.
+const DRAG_RATIO = 0.34;
+const DRAG_MIN = 90; // floor so tiny viewports still need a deliberate pull
+const DRAG_DISTANCE = 150; // fallback before the stage has been measured
+const COMMIT_THRESHOLD = 0.6; // pull ~60% of the way and release → it tears open
+const TILT = 0.2; // how far the pack leans toward the pointer
+
+// idle "alive" float (packs.com homepage feel) — damped out as you grab/tear
+const IDLE_BOB_AMP = 0.08; // vertical bob amplitude (fit units)
+const IDLE_BOB_SPEED = 1.4;
+const IDLE_ROCK_AMP = 0.1; // gentle yaw rock (rad)
+const IDLE_ROCK_SPEED = 0.55;
+const BASE_TILT = 0.1; // slight resting lean so the pack never reads flat
+
+// Front-face UV rect baked into the GLTF (U 0.111..0.896, V 0.085..0.996),
+// in pixels on the 1618×6672 sheet with flipY=false → pixelY = (1-V)·H.
+const SHEET = { w: 1618, h: 6672 };
+const FRONT = { x: 179, y: 26, w: 1270, h: 6076 };
+
+const SPARKLE_COUNT = 140;
 
 export default class extends Controller {
     static targets = ['canvas'];
@@ -27,20 +56,35 @@ export default class extends Controller {
     static values = {
         model: String,
         texture: String,
+        bgUrl: String,
+        fallbackUrl: String,
+        logoUrl: String,
+        extensionName: String,
+        cardCount: Number,
+        armed: Boolean,
     };
 
     connect() {
         this.committed = false;
+        this.armed = this.hasArmedValue ? this.armedValue : false;
         this.progress = 0;
         this.targetProgress = 0;
         this.tilt = { x: 0, y: 0 };
         this.pointer = { x: 0, y: 0 };
+        this.dragDistance = DRAG_DISTANCE;
 
         if (window.matchMedia('(prefers-reduced-motion: reduce)').matches || !this._webglAvailable()) {
             return;
         }
 
         this._init().catch(() => this._teardown());
+
+        // We live in a data-live-ignore subtree, so a bubbling event is our only
+        // channel to the reveal controller — and a live re-render can re-instantiate
+        // us *after* its one-shot `pack3d:arm` already fired, leaving us sealed
+        // (connect() resets `armed` to false). Announce readiness so the reveal
+        // controller re-arms us whenever a draw is already on the table.
+        this.dispatch('ready', { prefix: 'pack3d', bubbles: true });
     }
 
     disconnect() {
@@ -65,28 +109,63 @@ export default class extends Controller {
         }
 
         const width = this.element.clientWidth || 360;
-        const height = this.element.clientHeight || 460;
+        const height = this.element.clientHeight || 480;
 
         this.renderer = new THREE.WebGLRenderer({ canvas: this.canvasTarget, alpha: true, antialias: true });
         this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
         this.renderer.setSize(width, height, false);
+        // No tone mapping: the artwork rides the emissive channel and is already in
+        // sRGB, so ACES only desaturated/flattened it ("délavé"). Render it 1:1 for
+        // punchy, accurate colours; the foil specular still pops via env + clearcoat.
+        this.renderer.toneMapping = THREE.NoToneMapping;
 
         this.scene = new THREE.Scene();
         this.camera = new THREE.PerspectiveCamera(35, width / height, 0.1, 100);
         this.camera.position.set(0, 0, 6);
 
-        // unlit material → swap the texture freely, colours stay pixel-perfect
-        if (this.hasTextureValue && this.textureValue) {
-            const texture = await new THREE.TextureLoader().loadAsync(this.textureValue);
-            texture.flipY = false; // glTF UV convention
-            texture.colorSpace = THREE.SRGBColorSpace;
-            gltf.scene.traverse((node) => {
-                if (node.isMesh && node.material) {
-                    node.material.map = texture;
-                    node.material.needsUpdate = true;
-                }
+        // glossy plastic-film reflections + a key/rim rig. The env hotspot lives
+        // top-left, so tilting the pack sweeps a specular highlight across it.
+        this.scene.environment = this._buildEnvironment();
+        const key = new THREE.DirectionalLight(0xffffff, 2.2);
+        key.position.set(-2.5, 3.5, 4);
+        this.scene.add(key);
+        const rim = new THREE.DirectionalLight(0xc9a0ff, 1.3);
+        rim.position.set(3, 1.5, -2);
+        this.scene.add(rim);
+        this.scene.add(new THREE.AmbientLight(0xffffff, 0.3));
+
+        const texture = await this._loadArtwork();
+        const normalMap = this._buildNormalMap();
+
+        // Swap the export's flat "test" material for a foil PBR material. The
+        // artwork rides the emissive channel so colours stay pixel-accurate
+        // (unlit look), while metalness + clearcoat + the env catch a moving
+        // highlight. Morph-target tear keeps working — it's geometry-driven.
+        this.materials = [];
+        gltf.scene.traverse((node) => {
+            if (!node.isMesh) {
+                return;
+            }
+            const material = new THREE.MeshPhysicalMaterial({
+                color: 0x080808,
+                map: texture,
+                emissive: 0xffffff,
+                emissiveMap: texture,
+                emissiveIntensity: 1,
+                metalness: 0.6,
+                roughness: 0.28,
+                clearcoat: 1,
+                clearcoatRoughness: 0.18,
+                envMapIntensity: 1.4,
+                side: THREE.DoubleSide,
             });
-        }
+            if (normalMap) {
+                material.normalMap = normalMap;
+                material.normalScale = new THREE.Vector2(0.15, 0.15);
+            }
+            node.material = material;
+            this.materials.push(material);
+        });
 
         // centre + frame the pack
         this.pack = gltf.scene;
@@ -94,36 +173,278 @@ export default class extends Controller {
         const center = box.getCenter(new THREE.Vector3());
         const size = box.getSize(new THREE.Vector3());
         this.pack.position.sub(center);
-        const fit = 3.4 / Math.max(size.x, size.y, size.z);
+        // fill most of the frame (packs.com immersion); headroom kept for the peel
+        // flap + idle bob so the pack never clips at the canvas edges
+        const fit = 4.6 / Math.max(size.x, size.y, size.z);
         this.pack.scale.setScalar(fit);
         this.pivot = new THREE.Group();
         this.pivot.add(this.pack);
         this.scene.add(this.pivot);
 
+        this._buildSparkles(); // best-effort; never aborts the pack
+
         // pause every clip and drive time by hand
         this.mixer = new THREE.AnimationMixer(gltf.scene);
+        this.actions = [];
         this.duration = 0;
         for (const clip of gltf.animations) {
             const action = this.mixer.clipAction(clip);
             action.play();
             action.paused = true;
+            this.actions.push(action);
             this.duration = Math.max(this.duration, clip.duration);
         }
-        this._applyProgress(0);
+        this.clock = new THREE.Clock();
+        this._applyProgress(0); // sealed at rest (clip time 0)
 
         this.element.classList.add('is-ready'); // CSS hides the 2D fallback pack
+        this._updateDragDistance();
         this._onResize = () => this._resize();
         window.addEventListener('resize', this._onResize);
+        // track the cursor across the whole scene so the pack leans toward it even
+        // when the pointer is not directly over the (small) pack element
+        this._onPointerMove = (event) => this._trackPointer(event);
+        window.addEventListener('pointermove', this._onPointerMove);
         this._loop();
+    }
+
+    // Artwork: either an explicit texture URL, or a composed pack front built on
+    // a canvas (packs.com's runtime drawImage trick — the shipped filmstrip
+    // texture maps wrong onto the UV rect, so we paint a real front instead).
+    async _loadArtwork() {
+        const value = this.hasTextureValue ? this.textureValue : '';
+        if (value && value !== 'composite') {
+            const texture = await new THREE.TextureLoader().loadAsync(value);
+            texture.flipY = false; // glTF UV convention
+            texture.colorSpace = THREE.SRGBColorSpace;
+
+            return texture;
+        }
+
+        return this._buildCompositeTexture();
+    }
+
+    // Procedural studio environment: a bright top-left hotspot fading through
+    // violet to dark, pushed through PMREM. Cheaper than an HDR and gives the
+    // moving specular sweep without an addon (no importmap change needed).
+    _buildEnvironment() {
+        const canvas = document.createElement('canvas');
+        canvas.width = 512;
+        canvas.height = 256;
+        const ctx = canvas.getContext('2d');
+
+        const grad = ctx.createLinearGradient(0, 0, 0, canvas.height);
+        grad.addColorStop(0, '#fdfbff');
+        grad.addColorStop(0.32, '#9d7bd6');
+        grad.addColorStop(0.62, '#3a1f63');
+        grad.addColorStop(1, '#0a0614');
+        ctx.fillStyle = grad;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        // bright specular hotspot, upper-left
+        const hot = ctx.createRadialGradient(150, 50, 0, 150, 50, 150);
+        hot.addColorStop(0, 'rgba(255,255,255,0.95)');
+        hot.addColorStop(1, 'rgba(255,255,255,0)');
+        ctx.fillStyle = hot;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+        const equirect = new THREE.CanvasTexture(canvas);
+        equirect.mapping = THREE.EquirectangularReflectionMapping;
+
+        const pmrem = new THREE.PMREMGenerator(this.renderer);
+        const env = pmrem.fromEquirectangular(equirect).texture;
+        pmrem.dispose();
+        equirect.dispose();
+
+        return env;
+    }
+
+    // Subtle normal map: faint vertical micro-creases (cylindrical film curve)
+    // plus a crimped top edge. Best-effort — returns null on any failure.
+    _buildNormalMap() {
+        try {
+            const w = 256;
+            const h = 512;
+            const canvas = document.createElement('canvas');
+            canvas.width = w;
+            canvas.height = h;
+            const ctx = canvas.getContext('2d');
+            const image = ctx.createImageData(w, h);
+            const data = image.data;
+
+            for (let y = 0; y < h; y++) {
+                for (let x = 0; x < w; x++) {
+                    // x-derivative of gentle vertical creases → R channel
+                    const crease = Math.sin((x / w) * Math.PI * 26) * 32;
+                    // dense crimp ridges near the very top edge → extra wobble
+                    const crimp = y < 24 ? Math.sin((x / w) * Math.PI * 80) * 70 : 0;
+                    const i = (y * w + x) * 4;
+                    data[i] = Math.max(0, Math.min(255, 128 + crease + crimp));
+                    data[i + 1] = 128; // flat in Y
+                    data[i + 2] = 255; // pointing out
+                    data[i + 3] = 255;
+                }
+            }
+            ctx.putImageData(image, 0, 0);
+
+            const texture = new THREE.CanvasTexture(canvas);
+            texture.wrapS = THREE.RepeatWrapping;
+            texture.wrapT = THREE.RepeatWrapping;
+
+            return texture;
+        } catch {
+            return null;
+        }
+    }
+
+    // Drifting, twinkling sparkles around the pack (packs.com sparticles feel),
+    // as a single additive THREE.Points field. Best-effort: a shader failure
+    // leaves the pack untouched.
+    _buildSparkles() {
+        try {
+            const positions = new Float32Array(SPARKLE_COUNT * 3);
+            const scales = new Float32Array(SPARKLE_COUNT);
+            const phases = new Float32Array(SPARKLE_COUNT);
+            for (let i = 0; i < SPARKLE_COUNT; i++) {
+                positions[i * 3] = (Math.random() - 0.5) * 7;
+                positions[i * 3 + 1] = (Math.random() - 0.5) * 8;
+                positions[i * 3 + 2] = (Math.random() - 0.5) * 3 - 1; // mostly behind the pack
+                scales[i] = 0.5 + Math.random() * 1.8;
+                phases[i] = Math.random() * Math.PI * 2;
+            }
+
+            const geometry = new THREE.BufferGeometry();
+            geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+            geometry.setAttribute('aScale', new THREE.BufferAttribute(scales, 1));
+            geometry.setAttribute('aPhase', new THREE.BufferAttribute(phases, 1));
+
+            const material = new THREE.ShaderMaterial({
+                transparent: true,
+                depthWrite: false,
+                blending: THREE.AdditiveBlending,
+                uniforms: {
+                    uTime: { value: 0 },
+                    uSize: { value: 26 * this.renderer.getPixelRatio() },
+                    uColor: { value: new THREE.Color(0xe7d4ff) },
+                },
+                vertexShader: `
+                    attribute float aScale;
+                    attribute float aPhase;
+                    uniform float uTime;
+                    uniform float uSize;
+                    varying float vTw;
+                    void main() {
+                        vec4 mv = modelViewMatrix * vec4(position, 1.0);
+                        float tw = 0.5 + 0.5 * sin(uTime * 2.0 + aPhase);
+                        vTw = tw;
+                        gl_PointSize = uSize * aScale * (0.35 + tw) * (1.0 / -mv.z);
+                        gl_Position = projectionMatrix * mv;
+                    }
+                `,
+                fragmentShader: `
+                    varying float vTw;
+                    uniform vec3 uColor;
+                    void main() {
+                        float d = length(gl_PointCoord - 0.5);
+                        float a = smoothstep(0.5, 0.0, d);
+                        gl_FragColor = vec4(uColor, a * (0.2 + 0.8 * vTw));
+                    }
+                `,
+            });
+
+            this.sparkles = new THREE.Points(geometry, material);
+            this.sparkles.renderOrder = -1;
+            this.scene.add(this.sparkles);
+        } catch {
+            this.sparkles = null;
+        }
+    }
+
+    // Compose a real pack front on a canvas and blit it into the GLTF's UV rect.
+    // Artwork + wordmark + card count come from the opened extension (dynamic).
+    // The front itself is drawn by the shared drawPackFront() so the grid tiles
+    // and this 3D pack look identical.
+    async _buildCompositeTexture() {
+        let hero = this.hasBgUrlValue && this.bgUrlValue ? await this._loadImage(this.bgUrlValue) : null;
+        // no extension art → fall back to the branded YOUL front
+        const fallback = !hero;
+        if (fallback && this.hasFallbackUrlValue && this.fallbackUrlValue) {
+            hero = await this._loadImage(this.fallbackUrlValue);
+        }
+        const logo = fallback && this.hasLogoUrlValue && this.logoUrlValue
+            ? await this._loadImage(this.logoUrlValue)
+            : null;
+
+        const front = document.createElement('canvas');
+        front.width = PACK_FRONT_W;
+        front.height = PACK_FRONT_H;
+        drawPackFront(front.getContext('2d'), {
+            hero,
+            logo,
+            name: this.hasExtensionNameValue ? this.extensionNameValue : '',
+            count: this.hasCardCountValue && this.cardCountValue ? this.cardCountValue : 5,
+            fallback,
+        });
+
+        const sheet = document.createElement('canvas');
+        sheet.width = SHEET.w;
+        sheet.height = SHEET.h;
+        const g = sheet.getContext('2d');
+        let bg = g.createLinearGradient(0, 0, 0, SHEET.h);
+        bg.addColorStop(0, '#2a1655');
+        bg.addColorStop(1, '#0b0712');
+        g.fillStyle = bg;
+        g.fillRect(0, 0, SHEET.w, SHEET.h);
+        // Cover the WHOLE sheet with the artwork first: some pack faces (the bottom
+        // seal, the sides) have UVs outside the front rect, so without this they'd
+        // show flat violet — the "texture stops before the bottom" look. The crisp
+        // front then goes on top into its exact UV rect.
+        if (hero) {
+            const s = Math.max(SHEET.w / hero.width, SHEET.h / hero.height);
+            const hw = hero.width * s;
+            const hh = hero.height * s;
+            g.drawImage(hero, (SHEET.w - hw) / 2, (SHEET.h - hh) / 2, hw, hh);
+        }
+        g.drawImage(front, FRONT.x, FRONT.y, FRONT.w, FRONT.h);
+
+        const texture = new THREE.CanvasTexture(sheet);
+        texture.flipY = false;
+        texture.colorSpace = THREE.SRGBColorSpace;
+
+        return texture;
+    }
+
+    _loadImage(src) {
+        return new Promise((resolve) => {
+            const img = new Image();
+            img.onload = () => resolve(img);
+            img.onerror = () => resolve(null);
+            img.src = src;
+        });
+    }
+
+    // Enable peeling — fired (via a window event) once the booster has been drawn
+    // server-side, so the wrapper can't be torn before there are cards to reveal.
+    arm() {
+        this.armed = true;
+    }
+
+    // Re-seal for another draw — this pack lives in a data-live-ignore subtree and
+    // persists between openings, so "open another" must reset it to a sealed state.
+    reseal() {
+        this.committed = false;
+        this.armed = false;
+        this.dragging = false;
+        this.targetProgress = 0;
     }
 
     // ------------------------------------------------------------- drag
     dragStart(event) {
-        if (this.committed || !this.renderer) {
+        if (this.committed || !this.armed || !this.renderer) {
             return;
         }
         this.dragging = true;
-        this.startX = event.clientX;
+        this.startX = event.clientX; // peel the top ribbon sideways (packs.com)
         try {
             event.currentTarget.setPointerCapture(event.pointerId);
         } catch {
@@ -132,14 +453,19 @@ export default class extends Controller {
     }
 
     dragMove(event) {
-        const rect = this.element.getBoundingClientRect();
-        this.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
-        this.pointer.y = ((event.clientY - rect.top) / rect.height) * 2 - 1;
-
         if (!this.dragging || this.committed) {
             return;
         }
-        this.targetProgress = Math.max(0, Math.min(1, Math.abs(event.clientX - this.startX) / DRAG_DISTANCE));
+        this.targetProgress = Math.max(0, Math.min(1, Math.abs(event.clientX - this.startX) / this.dragDistance));
+    }
+
+    // lean toward the cursor anywhere on screen, normalised against the pack centre
+    _trackPointer(event) {
+        const rect = this.element.getBoundingClientRect();
+        const centerX = rect.left + rect.width / 2;
+        const centerY = rect.top + rect.height / 2;
+        this.pointer.x = Math.max(-1, Math.min(1, (event.clientX - centerX) / (window.innerWidth / 2)));
+        this.pointer.y = Math.max(-1, Math.min(1, (event.clientY - centerY) / (window.innerHeight / 2)));
     }
 
     dragEnd() {
@@ -156,7 +482,7 @@ export default class extends Controller {
 
     // fallback: click to open in one go
     openAtOnce() {
-        if (this.renderer && !this.committed) {
+        if (this.renderer && this.armed && !this.committed) {
             this._commit();
         }
     }
@@ -175,12 +501,29 @@ export default class extends Controller {
         this.progress += (this.targetProgress - this.progress) * 0.18;
         this._applyProgress(this.progress);
 
-        // lean toward the pointer
-        this.tilt.x += (this.pointer.y * TILT - this.tilt.x) * 0.1;
-        this.tilt.y += (this.pointer.x * TILT - this.tilt.y) * 0.1;
+        // lean toward the pointer — held still mid-tear so the drag reads as a peel
+        // and is never "swallowed" by the pack rotating to follow the cursor
+        if (!this.dragging) {
+            this.tilt.x += (this.pointer.y * TILT - this.tilt.x) * 0.1;
+            this.tilt.y += (this.pointer.x * TILT - this.tilt.y) * 0.1;
+        }
+
+        // idle float — full while sealed & untouched, fades out as you grab or tear
+        const t = this.clock.getElapsedTime();
+        const calm = this.committed ? 0 : (this.dragging ? 0.15 : 1) * (1 - this.progress);
+        const bob = Math.sin(t * IDLE_BOB_SPEED) * IDLE_BOB_AMP * calm;
+        const rock = Math.sin(t * IDLE_ROCK_SPEED) * IDLE_ROCK_AMP * calm;
+
         if (this.pivot) {
-            this.pivot.rotation.x = this.tilt.x;
-            this.pivot.rotation.y = this.tilt.y;
+            this.pivot.rotation.x = BASE_TILT + this.tilt.x;
+            this.pivot.rotation.y = this.tilt.y + rock;
+            this.pivot.position.y = bob;
+        }
+
+        if (this.sparkles) {
+            this.sparkles.material.uniforms.uTime.value = t;
+            this.sparkles.rotation.z = t * 0.02;
+            this.sparkles.position.y = Math.sin(t * 0.3) * 0.15;
         }
 
         this.renderer.render(this.scene, this.camera);
@@ -190,7 +533,13 @@ export default class extends Controller {
         if (!this.mixer) {
             return;
         }
-        this.mixer.setTime((TEAR_START + (1 - TEAR_START) * progress) * this.duration);
+        // Scrub by driving each (paused) action's time directly — mixer.setTime()
+        // does NOT advance paused actions, so the tear would never move with it.
+        const time = progress * this.duration;
+        for (const action of this.actions) {
+            action.time = Math.min(time, action.getClip().duration);
+        }
+        this.mixer.update(0);
     }
 
     _resize() {
@@ -198,10 +547,16 @@ export default class extends Controller {
             return;
         }
         const width = this.element.clientWidth || 360;
-        const height = this.element.clientHeight || 460;
+        const height = this.element.clientHeight || 480;
         this.renderer.setSize(width, height, false);
         this.camera.aspect = width / height;
         this.camera.updateProjectionMatrix();
+        this._updateDragDistance();
+    }
+
+    // full-tear distance as a share of the pack's rendered width (scale-robust)
+    _updateDragDistance() {
+        this.dragDistance = Math.max(DRAG_MIN, (this.element.clientWidth || 420) * DRAG_RATIO);
     }
 
     _teardown() {
@@ -212,6 +567,12 @@ export default class extends Controller {
         if (this._onResize) {
             window.removeEventListener('resize', this._onResize);
         }
+        if (this._onPointerMove) {
+            window.removeEventListener('pointermove', this._onPointerMove);
+        }
+        this.sparkles?.geometry.dispose();
+        this.sparkles?.material.dispose();
+        this.materials?.forEach((material) => material.dispose());
         this.renderer?.dispose();
     }
 }

--- a/assets/controllers/pack_opening_3d_controller.js
+++ b/assets/controllers/pack_opening_3d_controller.js
@@ -1,0 +1,217 @@
+import { Controller } from '@hotwired/stimulus';
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+
+/**
+ * 3D pack opening — packs.com-style progressive enhancement over the 2D swipe.
+ *
+ * Loads a GLTF pack (rigid body + a foil flap carrying a pre-baked cloth-tear as
+ * morph targets) with an unlit material, and **scrubs the GLTF animation with
+ * the drag**: the tear follows your finger forwards and back, snaps back below
+ * the threshold, commits at the top. On commit it hands off to the existing 2D
+ * reveal (`booster-opening` controller) via a bubbling `pack3d:opened` event.
+ *
+ * Strictly additive: if WebGL is unavailable, the model fails to load, or the
+ * user prefers reduced motion, this controller does nothing and the 2D swipe
+ * pack stays in place (CSS only hides it once `is-ready` is set here).
+ */
+
+const DRAG_DISTANCE = 130; // px of drag for a full tear (packs.com threshold)
+const COMMIT_THRESHOLD = 0.98;
+const TEAR_START = 0.4; // the first 40% of the clip settles the body; the tear scrubs 0.4 → 1
+const TILT = 0.18; // how far the pack leans toward the pointer
+
+export default class extends Controller {
+    static targets = ['canvas'];
+
+    static values = {
+        model: String,
+        texture: String,
+    };
+
+    connect() {
+        this.committed = false;
+        this.progress = 0;
+        this.targetProgress = 0;
+        this.tilt = { x: 0, y: 0 };
+        this.pointer = { x: 0, y: 0 };
+
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches || !this._webglAvailable()) {
+            return;
+        }
+
+        this._init().catch(() => this._teardown());
+    }
+
+    disconnect() {
+        this._teardown();
+    }
+
+    // ------------------------------------------------------------- setup
+    _webglAvailable() {
+        try {
+            const canvas = document.createElement('canvas');
+
+            return !!(window.WebGLRenderingContext && (canvas.getContext('webgl2') || canvas.getContext('webgl')));
+        } catch {
+            return false;
+        }
+    }
+
+    async _init() {
+        const gltf = await new GLTFLoader().loadAsync(this.modelValue);
+        if (this.committed === null) {
+            return; // disconnected while loading
+        }
+
+        const width = this.element.clientWidth || 360;
+        const height = this.element.clientHeight || 460;
+
+        this.renderer = new THREE.WebGLRenderer({ canvas: this.canvasTarget, alpha: true, antialias: true });
+        this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+        this.renderer.setSize(width, height, false);
+
+        this.scene = new THREE.Scene();
+        this.camera = new THREE.PerspectiveCamera(35, width / height, 0.1, 100);
+        this.camera.position.set(0, 0, 6);
+
+        // unlit material → swap the texture freely, colours stay pixel-perfect
+        if (this.hasTextureValue && this.textureValue) {
+            const texture = await new THREE.TextureLoader().loadAsync(this.textureValue);
+            texture.flipY = false; // glTF UV convention
+            texture.colorSpace = THREE.SRGBColorSpace;
+            gltf.scene.traverse((node) => {
+                if (node.isMesh && node.material) {
+                    node.material.map = texture;
+                    node.material.needsUpdate = true;
+                }
+            });
+        }
+
+        // centre + frame the pack
+        this.pack = gltf.scene;
+        const box = new THREE.Box3().setFromObject(this.pack);
+        const center = box.getCenter(new THREE.Vector3());
+        const size = box.getSize(new THREE.Vector3());
+        this.pack.position.sub(center);
+        const fit = 3.4 / Math.max(size.x, size.y, size.z);
+        this.pack.scale.setScalar(fit);
+        this.pivot = new THREE.Group();
+        this.pivot.add(this.pack);
+        this.scene.add(this.pivot);
+
+        // pause every clip and drive time by hand
+        this.mixer = new THREE.AnimationMixer(gltf.scene);
+        this.duration = 0;
+        for (const clip of gltf.animations) {
+            const action = this.mixer.clipAction(clip);
+            action.play();
+            action.paused = true;
+            this.duration = Math.max(this.duration, clip.duration);
+        }
+        this._applyProgress(0);
+
+        this.element.classList.add('is-ready'); // CSS hides the 2D fallback pack
+        this._onResize = () => this._resize();
+        window.addEventListener('resize', this._onResize);
+        this._loop();
+    }
+
+    // ------------------------------------------------------------- drag
+    dragStart(event) {
+        if (this.committed || !this.renderer) {
+            return;
+        }
+        this.dragging = true;
+        this.startX = event.clientX;
+        try {
+            event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+            // best effort
+        }
+    }
+
+    dragMove(event) {
+        const rect = this.element.getBoundingClientRect();
+        this.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+        this.pointer.y = ((event.clientY - rect.top) / rect.height) * 2 - 1;
+
+        if (!this.dragging || this.committed) {
+            return;
+        }
+        this.targetProgress = Math.max(0, Math.min(1, Math.abs(event.clientX - this.startX) / DRAG_DISTANCE));
+    }
+
+    dragEnd() {
+        if (!this.dragging) {
+            return;
+        }
+        this.dragging = false;
+        if (this.targetProgress >= COMMIT_THRESHOLD) {
+            this._commit();
+        } else {
+            this.targetProgress = 0; // snap back
+        }
+    }
+
+    // fallback: click to open in one go
+    openAtOnce() {
+        if (this.renderer && !this.committed) {
+            this._commit();
+        }
+    }
+
+    _commit() {
+        this.committed = true;
+        this.targetProgress = 1;
+        this.dispatch('opened', { prefix: 'pack3d', bubbles: true });
+    }
+
+    // ------------------------------------------------------------- render
+    _loop() {
+        this.frame = requestAnimationFrame(() => this._loop());
+
+        // ease the tear toward its target so snap-back and commit feel springy
+        this.progress += (this.targetProgress - this.progress) * 0.18;
+        this._applyProgress(this.progress);
+
+        // lean toward the pointer
+        this.tilt.x += (this.pointer.y * TILT - this.tilt.x) * 0.1;
+        this.tilt.y += (this.pointer.x * TILT - this.tilt.y) * 0.1;
+        if (this.pivot) {
+            this.pivot.rotation.x = this.tilt.x;
+            this.pivot.rotation.y = this.tilt.y;
+        }
+
+        this.renderer.render(this.scene, this.camera);
+    }
+
+    _applyProgress(progress) {
+        if (!this.mixer) {
+            return;
+        }
+        this.mixer.setTime((TEAR_START + (1 - TEAR_START) * progress) * this.duration);
+    }
+
+    _resize() {
+        if (!this.renderer) {
+            return;
+        }
+        const width = this.element.clientWidth || 360;
+        const height = this.element.clientHeight || 460;
+        this.renderer.setSize(width, height, false);
+        this.camera.aspect = width / height;
+        this.camera.updateProjectionMatrix();
+    }
+
+    _teardown() {
+        this.committed = null;
+        if (this.frame) {
+            cancelAnimationFrame(this.frame);
+        }
+        if (this._onResize) {
+            window.removeEventListener('resize', this._onResize);
+        }
+        this.renderer?.dispose();
+    }
+}

--- a/assets/lib/pack_front.js
+++ b/assets/lib/pack_front.js
@@ -1,0 +1,93 @@
+/**
+ * Paints a YOUL pack "front" (artwork + branding) onto a 2D canvas context at a
+ * fixed 840×1300 resolution. Shared by the 3D opening pack (blitted into the
+ * GLTF UV rect) and the boosters grid (drawn straight into a tile canvas) so the
+ * two stay visually identical. Pass already-loaded images (hero/logo) or null.
+ */
+
+export const PACK_FRONT_W = 840;
+export const PACK_FRONT_H = 1300;
+
+export function drawPackFront(c, { hero = null, logo = null, name = 'YOUL', count = 5, fallback = false }) {
+    const fw = PACK_FRONT_W;
+    const fh = PACK_FRONT_H;
+
+    c.fillStyle = '#180a33';
+    c.fillRect(0, 0, fw, fh);
+    if (hero) {
+        // centred cover-fit — fills the whole front incl. the bottom
+        const s = Math.max(fw / hero.width, fh / hero.height);
+        const w = hero.width * s;
+        const h = hero.height * s;
+        c.drawImage(hero, (fw - w) / 2, (fh - h) / 2, w, h);
+    }
+
+    // gentle bottom gradient: keeps the wordmark legible, light enough that the
+    // artwork still reads all the way down
+    const vignette = c.createLinearGradient(0, fh * 0.5, 0, fh);
+    vignette.addColorStop(0, 'rgba(11,7,18,0)');
+    vignette.addColorStop(1, 'rgba(11,7,18,0.6)');
+    c.fillStyle = vignette;
+    c.fillRect(0, 0, fw, fh);
+
+    // subtle holographic sheen
+    c.save();
+    c.globalCompositeOperation = 'screen';
+    c.globalAlpha = 0.1;
+    const sheen = c.createLinearGradient(0, 0, fw, fh);
+    sheen.addColorStop(0, '#ff3db0');
+    sheen.addColorStop(0.5, '#5be4ff');
+    sheen.addColorStop(1, '#a435f0');
+    c.fillStyle = sheen;
+    for (let i = -fh; i < fw; i += 120) {
+        c.fillRect(i, 0, 46, fh);
+    }
+    c.restore();
+
+    // brand logo on the fallback front (no extension artwork)
+    if (fallback && logo) {
+        const lw = fw * 0.74;
+        const lh = lw * (logo.height / logo.width);
+        c.drawImage(logo, (fw - lw) / 2, fh * 0.3, lw, lh);
+    }
+
+    const label = (name || 'YOUL').toUpperCase();
+    c.textAlign = 'center';
+    c.fillStyle = '#fff';
+    c.font = `800 ${label.length > 10 ? 64 : 88}px "Arial Black", system-ui, sans-serif`;
+    c.fillText(label, fw / 2, fh * 0.8);
+    c.fillStyle = '#c9a0ff';
+    c.font = '700 26px monospace';
+    c.fillText('TRADING CARD GAME', fw / 2, fh * 0.845);
+    c.fillStyle = 'rgba(255,255,255,.85)';
+    c.font = '600 20px monospace';
+    c.fillText(`CONTIENT ${count} CARTE${count > 1 ? 'S' : ''}`, fw / 2, fh * 0.93);
+
+    // "N CARTES" badge, top-right
+    c.fillStyle = '#0b0712';
+    roundRect(c, fw - 230, 40, 190, 96, 16);
+    c.fill();
+    c.fillStyle = '#fff';
+    c.textAlign = 'right';
+    c.font = '800 56px "Arial Black", sans-serif';
+    c.fillText(`${count}`, fw - 150, 108);
+    c.font = '700 20px monospace';
+    c.fillText('CARTES', fw - 55, 100);
+    c.textAlign = 'center';
+
+    // chrome border
+    c.strokeStyle = 'rgba(201,160,255,.55)';
+    c.lineWidth = 10;
+    roundRect(c, 5, 5, fw - 10, fh - 10, 28);
+    c.stroke();
+}
+
+function roundRect(c, x, y, w, h, r) {
+    c.beginPath();
+    c.moveTo(x + r, y);
+    c.arcTo(x + w, y, x + w, y + h, r);
+    c.arcTo(x + w, y + h, x, y + h, r);
+    c.arcTo(x, y + h, x, y, r);
+    c.arcTo(x, y, x + w, y, r);
+    c.closePath();
+}

--- a/assets/styles/cards/base.css
+++ b/assets/styles/cards/base.css
@@ -186,7 +186,9 @@
   }
   
   .card__rotator img {
-    /*height: auto;*/
+    /* the box is forced to the card aspect (.card__rotator *), so cover the
+       artwork into it instead of the default `fill` which stretches it */
+    object-fit: cover;
     -webkit-transform: translate3d(0px, 0px, 0.01px);
     transform: translate3d(0px, 0px, 0.01px);
   }

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -70,6 +70,22 @@
 .opening__tearing,
 .opening__reveal { position: relative; z-index: 2; text-align: center; }
 
+/* ============================================= SEALED — 3D pack (enhancement) */
+.opening__3d {
+    display: none; /* shown by the controller once WebGL + model are ready */
+    width: min(78vw, 360px);
+    height: min(64vh, 480px);
+    margin: 0 auto;
+    cursor: grab;
+    touch-action: none;
+}
+.opening__3d.is-ready { display: block; }
+.opening__3d.is-ready:active { cursor: grabbing; }
+.opening__3d canvas { display: block; width: 100%; height: 100%; }
+
+/* once the 3D pack is up, drop the 2D fallback pack */
+.opening__sealed:has(.opening__3d.is-ready) .opening__pack-wrap { display: none; }
+
 /* ====================================================== SEALED — the pack */
 .opening__pack-wrap {
     display: inline-block;

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -1,340 +1,145 @@
 /*
- * Pack opening reveal — sealed → swipe-to-slice → tearing → whiteout → reveal.
+ * Booster opening — dedicated packs.com-style page: the 3D pack on the left,
+ * the extension's card set on the right. The set list fills in real time as the
+ * player peels the pack and the centre showcase reveals each card (rarest last).
  *
  * Driven by assets/controllers/booster_opening_controller.js (no anime.js):
- * the controller sets `data-phase` on `.opening`, a `--tp` (tear progress 0..1)
- * while the pack is being sliced, `--reveal-color` per revealed card, and
- * toggles a handful of state classes. Everything else is CSS.
+ * the controller toggles `is-current`/`is-revealed`/`is-popping`
+ * state classes, sets `--reveal-color` per revealed card, and unhides the
+ * showcase / footer. The 3D pack lives in assets/controllers/pack_opening_3d.
  *
- * CRITICAL: every entrance animation that has a start delay uses
- * `animation-fill-mode: both` — with `forwards` the element would flash its base
- * style during the delay (off-centre bloom/beam). See the design handoff.
+ * CRITICAL: entrance animations with a start delay use `both` fill-mode so the
+ * element never flashes its base style during the delay.
  */
 
 /* ------------------------------------------------------------------ keyframes */
-@keyframes opening-slitOpen   { 0% { transform: scaleY(0); opacity: 0; } 30% { opacity: 1; } 100% { transform: scaleY(1); opacity: 1; } }
-@keyframes opening-flapTearOff{ 0% { transform: translate(0,0) rotate(0); opacity: 1; } 14% { transform: translate(0,-10px) rotate(-3deg); } 55% { opacity: 1; } 100% { transform: translate(560px,-150px) rotate(46deg) scale(.9); opacity: 0; } }
-@keyframes opening-packBurst  { 0% { filter: brightness(1); } 60% { filter: brightness(1.55); } 100% { filter: brightness(2.5) saturate(1.2); opacity: .82; } }
-@keyframes opening-beamRise   { 0% { transform: translate(-50%,0) scaleY(0); opacity: 0; } 25% { opacity: 1; } 100% { transform: translate(-50%,0) scaleY(1); opacity: .9; } }
-@keyframes opening-coreBloom  { 0% { transform: translate(-50%,-50%) scale(.15); opacity: 0; } 20% { opacity: .9; } 100% { transform: translate(-50%,-50%) scale(1.85); opacity: 1; } }
-@keyframes opening-raysSpin   { 0% { transform: translate(-50%,-50%) rotate(0); } 100% { transform: translate(-50%,-50%) rotate(360deg); } }
-@keyframes opening-fadeIn6    { from { opacity: 0; } to { opacity: .6; } }
-@keyframes opening-particlefly{ 0% { transform: translate(-50%,-50%) rotate(var(--ang)) translateX(0); opacity: 1; } 100% { transform: translate(-50%,-50%) rotate(var(--ang)) translateX(var(--dist)); opacity: 0; } }
-@keyframes opening-whiteout   { 0% { opacity: 0; } 45% { opacity: 0; } 78% { opacity: .9; } 100% { opacity: 1; } }
-@keyframes opening-fadeWhite  { 0% { opacity: 1; } 100% { opacity: 0; } }
 @keyframes opening-cardReveal { 0% { transform: translateY(40px) scale(.7) rotateY(90deg); opacity: 0; } 60% { opacity: 1; } 100% { transform: translateY(0) scale(1) rotateY(0); opacity: 1; } }
 @keyframes opening-cardRevealBig { 0% { transform: translateY(60px) scale(.5) rotateY(180deg); opacity: 0; filter: brightness(3); } 40% { opacity: 1; } 70% { transform: translateY(0) scale(1.12) rotateY(0); filter: brightness(1.4); } 100% { transform: translateY(0) scale(1) rotateY(0); filter: brightness(1); } }
-@keyframes opening-auraPulse  { 0% { transform: translate(-50%,-50%) scale(.4); opacity: 0; } 40% { opacity: 1; } 100% { transform: translate(-50%,-50%) scale(1.1); opacity: 1; } }
-@keyframes opening-labelSlam  { 0% { transform: translateX(-50%) scale(2.4); opacity: 0; filter: blur(8px); } 60% { transform: translateX(-50%) scale(.92); opacity: 1; filter: blur(0); } 100% { transform: translateX(-50%) scale(1); opacity: 1; } }
-@keyframes opening-screenShake{ 0%,100% { transform: translate(0,0); } 25% { transform: translate(-6px,3px); } 50% { transform: translate(6px,-3px); } 75% { transform: translate(-4px,-2px); } }
-@keyframes opening-nudgeX     { 0%,100% { transform: translateX(0); } 50% { transform: translateX(7px); } }
-@keyframes opening-summaryIn  { 0% { transform: translateY(14px) scale(.92); opacity: 0; } 100% { transform: translateY(0) scale(1); opacity: 1; } }
+@keyframes opening-auraPulse { 0% { transform: translate(-50%,-50%) scale(.4); opacity: 0; } 40% { opacity: 1; } 100% { transform: translate(-50%,-50%) scale(1.1); opacity: 1; } }
+@keyframes opening-labelSlam { 0% { transform: scale(2.4); opacity: 0; filter: blur(8px); } 60% { transform: scale(.92); opacity: 1; filter: blur(0); } 100% { transform: scale(1); opacity: 1; } }
+@keyframes opening-slotPop { 0% { transform: scale(.82); } 60% { transform: scale(1.06); } 100% { transform: scale(1); } }
+@keyframes opening-nudgeX { 0%,100% { transform: translateX(0); } 50% { transform: translateX(5px); } }
+@keyframes opening-footIn { 0% { transform: translateY(14px); opacity: 0; } 100% { transform: translateY(0); opacity: 1; } }
 
-/* --------------------------------------------------------------------- stage */
-.opening {
+/* ===================================================================== layout */
+.opening--page {
     position: relative;
     display: flex;
     width: 100%;
-    min-height: min(90vh, 760px);
-    align-items: center;
-    justify-content: center;
+    min-height: calc(100vh - 64px);
+    /* ends on the exact body colour (#0b0712) so the page never goes darker than
+     * the site background at its edges — no visible seam against the body */
+    background: radial-gradient(120% 80% at 30% 18%, #1a1030 0%, #0b0712 62%, #0b0712 100%);
     overflow: hidden;
+    /* it's an interactive game screen, not text — clicking/dragging to reveal
+     * cards must never start a text/image selection */
+    user-select: none;
+    -webkit-user-select: none;
+}
+.opening--page img { -webkit-user-drag: none; user-drag: none; }
+.opening--page [hidden] { display: none !important; }
+
+@media (max-width: 900px) {
+    .opening--page { flex-direction: column; }
 }
 
-.opening.is-shake { animation: opening-screenShake .5s; }
-
-/*
- * `[hidden]` (display:none) is a low-priority UA rule — the stages below set an
- * explicit `display` (flex grid, Tailwind `flex`) which would otherwise win and
- * leak every stage at once (the summary showing before the pack is opened).
- */
-.opening [hidden] { display: none !important; }
-
-/* ambient violet glow behind the stage */
-.opening::before {
-    content: "";
-    position: absolute;
-    top: -20%;
-    left: 50%;
-    width: 1000px;
-    height: 700px;
-    transform: translateX(-50%);
-    border-radius: 50%;
-    background: radial-gradient(ellipse, #a435f022 0%, transparent 60%);
-    filter: blur(40px);
-    pointer-events: none;
-}
-
-/* stage visibility is driven by [hidden] toggled from the controller */
-.opening__sealed,
-.opening__tearing,
-.opening__reveal { position: relative; z-index: 2; text-align: center; }
-
-/* ============================================= SEALED — 3D pack (enhancement) */
-.opening__3d {
-    display: none; /* shown by the controller once WebGL + model are ready */
-    width: min(78vw, 360px);
-    height: min(64vh, 480px);
-    margin: 0 auto;
-    cursor: grab;
-    touch-action: none;
-}
-.opening__3d.is-ready { display: block; }
-.opening__3d.is-ready:active { cursor: grabbing; }
-.opening__3d canvas { display: block; width: 100%; height: 100%; }
-
-/* once the 3D pack is up, drop the 2D fallback pack */
-.opening__sealed:has(.opening__3d.is-ready) .opening__pack-wrap { display: none; }
-
-/* ====================================================== SEALED — the pack */
-.opening__pack-wrap {
-    display: inline-block;
-    cursor: grab;
-    touch-action: none;
-    animation: floatY 4s ease-in-out infinite;
-}
-.opening__pack-wrap.is-cutting { cursor: grabbing; animation: none; }
-
-.opening__pack {
+/* ------------------------------------------------------ left: the pack column */
+.opening__pack-col {
     position: relative;
-    width: 300px;
-    height: 430px;
-    filter: drop-shadow(0 30px 50px #000a);
-}
-
-.opening__pack-body {
-    position: absolute;
-    inset: 0;
-    top: 30px;
-    overflow: hidden;
-    border: 1px solid #a435f055;
-    border-radius: 10px;
-    background: linear-gradient(160deg, #2a1356 0%, #14092e 45%, #2a0f44 100%);
-}
-.opening__pack-body img {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    opacity: .85;
-}
-.opening__pack-body::after {
-    content: "";
-    position: absolute;
-    inset: 0;
-    mix-blend-mode: color-dodge;
-    opacity: .5;
-    background: linear-gradient(115deg, transparent 35%, #ff3db077 48%, #00f0ff55 52%, transparent 65%);
-    background-size: 300% 300%;
-    animation: packShimmer 4s linear infinite;
-}
-.opening__pack-banner {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 2;
-    padding: 16px 18px 20px;
-    background: linear-gradient(180deg, transparent, #0b0712 80%);
-    text-align: left;
-}
-.opening__pack-banner .code { font-family: 'JetBrains Mono', monospace; font-size: 10px; font-weight: 700; letter-spacing: .25em; color: #ff3db0; }
-.opening__pack-banner .name { margin-top: 4px; font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 22px; line-height: 1; text-transform: uppercase; letter-spacing: -.02em; color: #fff; }
-
-/* top crimp flap that slides off as you slice (driven by --tp) */
-.opening__pack-flap {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    z-index: 4;
-    height: 50px;
-    transform-origin: left center;
-    transform: translate(calc(var(--tp, 0) * 135px), calc(var(--tp, 0) * -10px)) rotate(calc(var(--tp, 0) * 7deg));
-    transition: transform 70ms linear, opacity 70ms linear;
-    background: linear-gradient(180deg, #2c1758 0%, #170c30 100%);
-    box-shadow: inset 0 2px 0 #ffffff22, inset 0 -3px 7px #00000077;
-    clip-path: polygon(0 0,100% 0,100% 84%,97% 100%,94% 85%,91% 100%,88% 84%,85% 100%,82% 85%,79% 100%,76% 84%,73% 100%,70% 85%,67% 100%,64% 84%,61% 100%,58% 85%,55% 100%,52% 84%,49% 100%,46% 85%,43% 100%,40% 84%,37% 100%,34% 85%,31% 100%,28% 84%,25% 100%,22% 85%,19% 100%,16% 84%,13% 100%,10% 85%,7% 100%,4% 84%,1% 100%,0 88%);
-}
-
-/* light slit opening along the tear line */
-.opening__pack-slit {
-    position: absolute;
-    top: 44px;
-    left: 6px;
-    right: 6px;
-    z-index: 3;
-    height: calc(6px + var(--tp, 0) * 28px);
-    opacity: calc(var(--tp, 0) * 1.4);
-    background: linear-gradient(180deg, #fff, #e9d5ff 50%, transparent);
-    filter: blur(5px);
-    pointer-events: none;
-    transition: height 70ms linear, opacity 70ms linear;
-}
-
-/* glowing torn edge racing left → right with the cut */
-.opening__pack-edge {
-    position: absolute;
-    top: 46px;
-    left: 0;
-    z-index: 5;
-    width: calc(min(100%, var(--tp, 0) * 120%));
-    height: 2px;
-    opacity: .9;
-    background: #fff;
-    box-shadow: 0 0 10px #fff, 0 0 22px #e9d5ff;
-    pointer-events: none;
-    transition: width 70ms linear;
-}
-
-/* perforation guide line — only while untouched */
-.opening__pack-guide {
-    position: absolute;
-    top: 48px;
-    left: 12px;
-    right: 12px;
-    z-index: 5;
-    border-top: 2px dotted #c79bff99;
-    pointer-events: none;
-}
-.is-cutting .opening__pack-guide { display: none; }
-
-/* CUTTER — the bright point of light riding the cut under your finger */
-.opening__pack-cutter {
-    position: absolute;
-    top: 46px;
-    left: calc(min(98%, var(--tp, 0) * 100%));
-    z-index: 6;
-    transform: translate(-50%, -50%);
-    opacity: 0;
-    pointer-events: none;
-    transition: left 60ms linear;
-}
-.is-cutting .opening__pack-cutter { opacity: 1; }
-.opening__pack-cutter .dot {
-    width: 13px;
-    height: 13px;
-    border-radius: 999px;
-    background: #fff;
-    box-shadow: 0 0 14px 5px #fff, 0 0 30px 12px #e9d5ff, 0 0 50px 20px #a435f088;
-}
-.opening__pack-cutter .cross-h,
-.opening__pack-cutter .cross-v {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-}
-.opening__pack-cutter .cross-h { width: 46px; height: 2px; background: linear-gradient(90deg, transparent, #fff 45%, #fff 55%, transparent); }
-.opening__pack-cutter .cross-v { width: 2px; height: 20px; background: linear-gradient(180deg, transparent, #fff, transparent); }
-
-.opening__hint {
-    margin-top: 32px;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 12px;
-    letter-spacing: .15em;
-    color: #b9a8cf;
-}
-.opening__hint .arrow { display: inline-block; animation: opening-nudgeX 1.3s ease-in-out infinite; }
-
-.opening__skip {
-    margin-top: 16px;
-    padding: 14px 28px;
-    border: 1px solid #a435f066;
-    background: transparent;
-    color: #fff;
-    font-family: 'Space Grotesk', sans-serif;
-    font-weight: 700;
-    font-size: 13px;
-    letter-spacing: .15em;
-    text-transform: uppercase;
-    cursor: pointer;
-}
-.opening__skip:hover { border-color: var(--primary); color: var(--primary); }
-
-/* ===================================================== TEARING — burst fx */
-.opening__beam {
-    position: absolute;
-    left: 50%;
-    top: 4%;
-    z-index: 2;
-    width: 150px;
-    height: 480px;
-    transform-origin: 50% 0%;
-    background: linear-gradient(180deg, #fff 0%, #ecd9ff 42%, transparent 92%);
-    filter: blur(11px);
-    mix-blend-mode: screen;
-    pointer-events: none;
-    animation: opening-beamRise .9s .12s cubic-bezier(.2,.8,.2,1) both;
-}
-.opening__rays {
-    position: absolute;
-    left: 50%;
-    top: 44%;
-    z-index: 2;
-    width: 780px;
-    height: 780px;
-    pointer-events: none;
-    background: repeating-conic-gradient(from 0deg, #ffffff44 0deg 4deg, transparent 4deg 16deg);
-    mask-image: radial-gradient(circle, #000 6%, transparent 58%);
-    -webkit-mask-image: radial-gradient(circle, #000 6%, transparent 58%);
-    animation: opening-raysSpin 9s linear infinite, opening-fadeIn6 .6s .15s ease-out backwards;
-}
-.opening__bloom {
-    position: absolute;
-    left: 50%;
-    top: 44%;
-    z-index: 3;
-    width: 540px;
-    height: 540px;
-    border-radius: 50%;
-    mix-blend-mode: screen;
-    pointer-events: none;
-    background: radial-gradient(circle, #fff 0%, #f0ddff 26%, #c9a0ff55 48%, transparent 72%);
-    animation: opening-coreBloom 1.05s .22s ease-out both;
-}
-.opening__particles span {
-    position: absolute;
-    left: 50%;
-    top: 40%;
-    z-index: 4;
-    width: 6px;
-    height: 6px;
-    border-radius: 999px;
-    box-shadow: 0 0 10px currentColor;
-    animation: opening-particlefly 1s ease-out both;
-}
-
-/* ============================================ WHITEOUT / FLASH overlays */
-.opening__whiteout,
-.opening__flash {
-    position: fixed;
-    inset: 0;
-    z-index: 60;
-    opacity: 0;
-    pointer-events: none;
-    background: radial-gradient(circle at 50% 44%, #ffffff, #ead8ff 42%, transparent 82%);
-}
-.opening__whiteout.is-tearing { animation: opening-whiteout 1.15s ease-in forwards; }
-.opening__whiteout.is-bridge  { animation: opening-fadeWhite .6s ease-out forwards; }
-.opening__flash { transition: opacity .5s ease-out; }
-.opening__flash.is-on { opacity: var(--flash, .3); }
-
-/* ================================================= REVEAL — one card at a time */
-.opening__reveal {
+    flex: 1 1 58%;
     display: flex;
-    width: 100%;
     flex-direction: column;
     align-items: center;
-    cursor: pointer;
+    justify-content: center;
+    gap: 18px;
+    padding: 28px 24px 36px;
+    min-width: 0;
 }
-.opening__reveal-fx {
+
+.opening__back {
     position: absolute;
-    inset: 0;
-    z-index: 1;
+    top: 20px;
+    left: 24px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    letter-spacing: .12em;
+    color: #8a7aae;
+    text-decoration: none;
+    transition: color .2s;
+}
+.opening__back:hover { color: var(--primary, #c9a0ff); }
+
+.opening__err {
+    position: absolute;
+    top: 18px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 8px 14px;
+    border: 1px solid #ff3db066;
+    background: #ff3db01a;
+    color: #ff8ac0;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+}
+
+.opening__pack-stage {
+    position: relative;
+    width: min(58vw, 740px);
+    aspect-ratio: .74;
+}
+@media (max-width: 900px) {
+    .opening__pack-stage { width: min(90vw, 540px); }
+}
+
+/* ----------------------------------------------------------- the 3D pack */
+.opening__3d {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+    touch-action: none;
+}
+.opening__3d:active { cursor: grabbing; }
+.opening__3d canvas { position: relative; z-index: 1; display: block; width: 100%; height: 100%; }
+
+/* soft contact shadow grounding the pack (canvas is alpha) */
+.opening__3d::before {
+    content: "";
+    position: absolute;
+    left: 50%;
+    bottom: 4%;
+    z-index: 0;
+    width: 62%;
+    height: 16%;
+    transform: translateX(-50%);
+    border-radius: 50%;
+    background: radial-gradient(ellipse, #000a 0%, transparent 70%);
+    filter: blur(14px);
     pointer-events: none;
 }
+/* soft halo BEHIND the pack so it pops — fades fully to transparent well inside
+ * the stage box, so (unlike a darkening vignette) it never paints a rectangle */
+.opening__3d::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    background: radial-gradient(ellipse 58% 56% at 50% 46%, #9a70e824 0%, transparent 64%);
+    pointer-events: none;
+}
+
+/* ------------------------------------------------- centre showcase (reveal) */
+.opening__showcase {
+    position: absolute;
+    inset: -8% -6%;
+    z-index: 5;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+}
+
 .opening__aura {
     position: absolute;
     top: 50%;
@@ -344,20 +149,18 @@
     transform: translate(-50%, -50%);
     border-radius: 50%;
     opacity: 0;
+    pointer-events: none;
     background: radial-gradient(circle, color-mix(in srgb, var(--reveal-color, #fff) 18%, transparent) 0%, transparent 60%);
 }
 .is-shiny .opening__aura { background: radial-gradient(circle, color-mix(in srgb, var(--reveal-color, #fff) 40%, transparent) 0%, transparent 60%); }
 .opening__aura.is-on { animation: opening-auraPulse 1.6s ease-out forwards; }
 
 .opening__label {
-    position: absolute;
-    top: 4%;
-    left: 50%;
     z-index: 3;
-    transform: translateX(-50%);
+    margin-bottom: 16px;
     font-family: 'Space Grotesk', sans-serif;
     font-weight: 700;
-    font-size: 40px;
+    font-size: clamp(24px, 3.4vw, 38px);
     text-transform: uppercase;
     letter-spacing: -.02em;
     white-space: nowrap;
@@ -371,43 +174,27 @@
 .opening__reveal-cards {
     position: relative;
     z-index: 2;
-    margin-top: 64px;
+    width: clamp(260px, 34vw, 420px);
     display: grid;
     place-items: center;
 }
-/* all reveal cards stacked in the same cell; only the current one shows */
 .opening__reveal-card {
     grid-area: 1 / 1;
+    width: 100%;
     display: none;
-    transform: scale(var(--reveal-card-scale, 1.4));
+    transform: scale(1.05);
     transform-origin: center;
 }
 .opening__reveal-card.is-current { display: block; }
 .opening__reveal-card.is-entering { animation: opening-cardReveal .6s cubic-bezier(.2,.8,.2,1); }
 .opening__reveal-card[data-shiny="1"].is-entering { animation: opening-cardRevealBig .9s cubic-bezier(.2,.8,.2,1); }
 
-.opening__progress {
-    z-index: 2;
-    margin-top: 40px;
-    display: flex;
-    gap: 8px;
-}
-.opening__dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 999px;
-    background: #ffffff22;
-    transition: all .3s;
-}
-.opening__dot.is-done { background: var(--dot-color, #fff); }
-.opening__dot.is-current { width: 28px; background: var(--dot-color, #fff); box-shadow: 0 0 10px var(--dot-color, #fff); }
-
 .opening__next {
     z-index: 2;
-    margin-top: 24px;
+    margin-top: 22px;
     padding: 12px 26px;
     border: 1px solid #a435f066;
-    background: transparent;
+    background: #0b0712aa;
     color: #fff;
     font-family: 'Space Grotesk', sans-serif;
     font-weight: 700;
@@ -419,23 +206,223 @@
 .opening__next:hover { border-color: var(--primary); }
 .opening__counter {
     z-index: 2;
-    margin-top: 14px;
+    margin-top: 12px;
     font-family: 'JetBrains Mono', monospace;
     font-size: 10px;
     letter-spacing: .15em;
     color: #6a5a8a;
 }
 
-/* ===================================================================== SUMMARY */
-.opening__summary { animation: opening-summaryIn .4s ease-out both; }
+/* --------------------------------------------------- CTA / instruction line */
+.opening__cta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    text-align: center;
+}
+.opening__hint {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+    letter-spacing: .14em;
+    color: #b9a8cf;
+}
+.opening__hint .arrow { display: inline-block; animation: opening-nudgeX 1.3s ease-in-out infinite; }
+.opening__skip {
+    padding: 10px 22px;
+    border: 1px solid #a435f066;
+    background: transparent;
+    color: #cdbff0;
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700;
+    font-size: 12px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    text-decoration: none;
+    cursor: pointer;
+}
+.opening__skip:hover { border-color: var(--primary); color: var(--primary); }
 
-/* reveal card scale shrinks a touch on short viewports */
-@media (max-height: 760px) {
-    .opening__reveal-card { --reveal-card-scale: 1.1; }
-    .opening__reveal-cards { margin-top: 48px; }
+/* ------------------------------------------------ right: the set list (aside) */
+.opening__panel {
+    flex: 0 0 42%;
+    display: flex;
+    flex-direction: column;
+    border-left: 1px solid #ffffff14;
+    background: #140a26;
+    max-height: calc(100vh - 64px);
+}
+@media (max-width: 900px) {
+    .opening__panel { flex: 0 0 auto; border-left: none; border-top: 1px solid #ffffff14; max-height: 56vh; }
+}
+.opening__panel-head {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding: 18px 18px 14px;
+    border-bottom: 1px solid #ffffff12;
+    background: #140a26;
+}
+.opening__panel-title {
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700;
+    font-size: 17px;
+    letter-spacing: -.01em;
+    text-transform: uppercase;
+    color: #fff;
+}
+.opening__panel-sub {
+    margin-top: 4px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: .08em;
+    color: #6a5a8a;
+}
+.opening__panel-best {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 9px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: .1em;
+    text-transform: uppercase;
+    color: #6a5a8a;
+}
+.opening__panel-best span { font-weight: 700; color: #fff; font-variant-numeric: tabular-nums; }
+
+.opening__slots {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 18px;
+    display: grid;
+    /* fixed-ish card size that stays sane whether the set has 3 cards or 300 —
+       auto-fill keeps a small set from blowing up to fill the column */
+    grid-template-columns: repeat(auto-fill, minmax(118px, 1fr));
+    gap: 18px 14px;
+    align-content: start;
+    justify-content: start;
+}
+@media (max-width: 560px) { .opening__slots { grid-template-columns: repeat(auto-fill, minmax(96px, 1fr)); } }
+
+/* a card in the set: dimmed until it is drawn & revealed, then lit + framed */
+.opening__slot {
+    opacity: 1;
+    transition: opacity .45s ease;
+}
+.opening__slot.is-popping .opening__slot-img { animation: opening-slotPop .5s ease-out; }
+
+/* mystery slots: cards you don't own (and haven't owned) stay hidden behind a "?"
+ * until you get them — revealed live in this opening, or already in your collection */
+.opening__slot-img img { transition: opacity .4s ease; }
+.opening__slot[data-owned="0"]:not(.is-revealed) .opening__slot-img img { opacity: 0; }
+.opening__slot[data-owned="0"]:not(.is-revealed) .opening__slot-img::after {
+    content: "?";
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 800;
+    font-size: clamp(22px, 3vw, 34px);
+    color: #ffffff1f;
 }
 
+.opening__slot-img {
+    position: relative;
+    aspect-ratio: var(--card-aspect, .718);
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1.5px solid #ffffff14;
+    background: #0c0618;
+}
+.opening__slot.is-revealed .opening__slot-img {
+    border-color: var(--slot-rar, #ffffff33);
+    box-shadow: 0 0 14px -2px var(--slot-rar, transparent), 0 8px 18px #0008;
+}
+.opening__slot-img img { display: block; width: 100%; height: 100%; object-fit: cover; }
+
+/* badges only show once the slot is revealed */
+.opening__slot-holo,
+.opening__slot-qty,
+.opening__slot-new {
+    position: absolute;
+    opacity: 0;
+    transition: opacity .3s ease .2s;
+    font-family: 'JetBrains Mono', monospace;
+    font-weight: 700;
+    letter-spacing: .08em;
+}
+.opening__slot.is-revealed .opening__slot-holo,
+.opening__slot.is-revealed .opening__slot-qty,
+.opening__slot.is-revealed .opening__slot-new { opacity: 1; }
+.opening__slot-holo {
+    top: 5px;
+    right: 5px;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 8px;
+    color: #0b0712;
+    background: linear-gradient(90deg, #ff3db0, #c9a0ff);
+}
+.opening__slot-qty {
+    bottom: 5px;
+    right: 5px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    color: #fff;
+    background: #000a;
+}
+.opening__slot-new {
+    top: 5px;
+    left: 5px;
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 8px;
+    color: #0b0712;
+    background: linear-gradient(90deg, var(--primary, #c9a0ff), #ff3db0);
+}
+.opening__slot-name {
+    margin-top: 6px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9.5px;
+    letter-spacing: .03em;
+    color: #b9a8cf;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* end-of-opening actions, grouped right under the revealed card (inside the
+ * showcase, which is pointer-events:none once done — so re-enable them here) */
+.opening__foot {
+    z-index: 3;
+    margin-top: 22px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    text-align: center;
+    pointer-events: auto;
+    animation: opening-footIn .4s ease-out both;
+}
+
+/* ============================================================= flash overlay */
+.opening__flash {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    opacity: 0;
+    pointer-events: none;
+    background: radial-gradient(circle at 35% 50%, #ffffff, #ead8ff 42%, transparent 82%);
+    transition: opacity .5s ease-out;
+}
+.opening__flash.is-on { opacity: var(--flash, .3); }
+
 @media (prefers-reduced-motion: reduce) {
-    .opening__pack-wrap,
-    .opening__pack-body::after { animation: none; }
+    .opening__slot,
+    .opening__reveal-card { animation: none !important; }
 }

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -53,9 +53,12 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    gap: 18px;
-    padding: 28px 24px 36px;
+    gap: 12px;
+    /* trimmed top padding — the big void above the pack lived here */
+    padding: 12px 24px 20px;
     min-width: 0;
+    /* never grow past the viewport, or the CTA gets pushed below the fold */
+    min-height: 0;
 }
 
 .opening__back {
@@ -86,11 +89,20 @@
 
 .opening__pack-stage {
     position: relative;
-    width: min(58vw, 740px);
+    /* Size from the smallest of width AND height budgets (single dimension, so the
+     * aspect ratio is never distorted). The `58vh * 0.92` term caps the height to
+     * the viewport so the pack + CTA stay on screen on short displays. */
+    width: min(56vw, 700px, calc(58vh * 0.92));
     aspect-ratio: .92;
+    /* lift the optical centre toward ~44% of the view (it sat ~52% — centred below
+     * the 64px header — which read as "hanging low" with a big void on top) */
+    margin-top: clamp(-96px, -7vh, -24px);
 }
 @media (max-width: 900px) {
-    .opening__pack-stage { width: min(90vw, 540px); }
+    .opening__pack-stage {
+        width: min(86vw, 520px, calc(50vh * 0.92));
+        margin-top: -8px;
+    }
 }
 
 /* ----------------------------------------------------------- the 3D pack */
@@ -472,7 +484,12 @@
     z-index: 60;
     opacity: 0;
     pointer-events: none;
-    background: radial-gradient(circle at 35% 50%, #ffffff, #ead8ff 42%, transparent 82%);
+    /* white-hot core fading into the current card's rarity colour, so an epic
+     * (purple) and a legendary (orange) burst read distinctly */
+    background: radial-gradient(circle at 50% 46%,
+        #ffffff 0%,
+        color-mix(in srgb, var(--reveal-color, #ead8ff) 55%, #ffffff) 38%,
+        transparent 82%);
     transition: opacity .5s ease-out;
 }
 .opening__flash.is-on { opacity: var(--flash, .3); }

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -125,6 +125,13 @@
     mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
 }
 
+/* WebGL/model unavailable: the controller falls back to a direct reveal, so
+ * don't leave a dead, grabbable canvas in the middle of the stage */
+.opening__3d.is-unavailable {
+    visibility: hidden;
+    cursor: default;
+}
+
 /* soft halo BEHIND the pack so it pops — fades fully to transparent well inside
  * the stage box, so (unlike a darkening vignette) it never paints a rectangle */
 .opening__3d::after {

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -13,8 +13,10 @@
  */
 
 /* ------------------------------------------------------------------ keyframes */
-@keyframes opening-cardReveal { 0% { transform: translateY(40px) scale(.7) rotateY(90deg); opacity: 0; } 60% { opacity: 1; } 100% { transform: translateY(0) scale(1) rotateY(0); opacity: 1; } }
-@keyframes opening-cardRevealBig { 0% { transform: translateY(60px) scale(.5) rotateY(180deg); opacity: 0; filter: brightness(3); } 40% { opacity: 1; } 70% { transform: translateY(0) scale(1.12) rotateY(0); filter: brightness(1.4); } 100% { transform: translateY(0) scale(1) rotateY(0); filter: brightness(1); } }
+/* face-down card entrance (the flip itself does the rotateY reveal) */
+@keyframes opening-cardEnter { 0% { transform: translateY(34px) scale(.86); opacity: 0; } 100% { transform: translateY(0) scale(1); opacity: 1; } }
+/* payoff "pop" once a shiny / the rarest-last card has flipped face-up */
+@keyframes opening-cardPop { 0% { transform: scale(1); filter: brightness(1); } 35% { transform: scale(1.1); filter: brightness(1.55); } 100% { transform: scale(1); filter: brightness(1); } }
 @keyframes opening-auraPulse { 0% { transform: translate(-50%,-50%) scale(.4); opacity: 0; } 40% { opacity: 1; } 100% { transform: translate(-50%,-50%) scale(1.1); opacity: 1; } }
 @keyframes opening-labelSlam { 0% { transform: scale(2.4); opacity: 0; filter: blur(8px); } 60% { transform: scale(.92); opacity: 1; filter: blur(0); } 100% { transform: scale(1); opacity: 1; } }
 @keyframes opening-slotPop { 0% { transform: scale(.82); } 60% { transform: scale(1.06); } 100% { transform: scale(1); } }
@@ -85,7 +87,7 @@
 .opening__pack-stage {
     position: relative;
     width: min(58vw, 740px);
-    aspect-ratio: .74;
+    aspect-ratio: .92;
 }
 @media (max-width: 900px) {
     .opening__pack-stage { width: min(90vw, 540px); }
@@ -100,23 +102,17 @@
     touch-action: none;
 }
 .opening__3d:active { cursor: grabbing; }
-.opening__3d canvas { position: relative; z-index: 1; display: block; width: 100%; height: 100%; }
-
-/* soft contact shadow grounding the pack (canvas is alpha) */
-.opening__3d::before {
-    content: "";
-    position: absolute;
-    left: 50%;
-    bottom: 4%;
-    z-index: 0;
-    width: 62%;
-    height: 16%;
-    transform: translateX(-50%);
-    border-radius: 50%;
-    background: radial-gradient(ellipse, #000a 0%, transparent 70%);
-    filter: blur(14px);
-    pointer-events: none;
+.opening__3d canvas {
+    position: relative;
+    z-index: 1;
+    display: block;
+    width: 100%;
+    height: 100%;
+    /* fade the bottom so the model's folded seal blends off-frame (packs.com crops it) */
+    -webkit-mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
+    mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
 }
+
 /* soft halo BEHIND the pack so it pops — fades fully to transparent well inside
  * the stage box, so (unlike a darkening vignette) it never paints a rectangle */
 .opening__3d::after {
@@ -157,7 +153,7 @@
 
 .opening__label {
     z-index: 3;
-    margin-bottom: 16px;
+    margin-bottom: 44px;
     font-family: 'Space Grotesk', sans-serif;
     font-weight: 700;
     font-size: clamp(24px, 3.4vw, 38px);
@@ -182,16 +178,70 @@
     grid-area: 1 / 1;
     width: 100%;
     display: none;
-    transform: scale(1.05);
+    perspective: 1500px;
     transform-origin: center;
 }
 .opening__reveal-card.is-current { display: block; }
-.opening__reveal-card.is-entering { animation: opening-cardReveal .6s cubic-bezier(.2,.8,.2,1); }
-.opening__reveal-card[data-shiny="1"].is-entering { animation: opening-cardRevealBig .9s cubic-bezier(.2,.8,.2,1); }
+.opening__reveal-card.is-entering { animation: opening-cardEnter .45s cubic-bezier(.2,.8,.2,1) both; }
+.opening__reveal-card.is-pop { animation: opening-cardPop .6s ease-out; }
+
+/* ---- 3D flip scene: back faces the player, click flips it to the front ---- */
+.opening__flip {
+    position: relative;
+    width: 100%;
+    transform-style: preserve-3d;
+    transform: rotateY(180deg); /* back toward the player until revealed */
+    transition: transform .56s cubic-bezier(.4,.05,.2,1);
+}
+.opening__flip.is-flipped { transform: rotateY(0deg); }
+.opening__flip-face {
+    backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
+}
+.opening__flip-front { position: relative; }
+/* belt-and-suspenders against the nested 3D card bleeding through while face-down:
+ * backface-visibility hides it once flipping, this hides it fully at rest */
+.opening__flip:not(.is-flipped) .opening__flip-front { visibility: hidden; }
+.opening__flip-back {
+    position: absolute;
+    inset: 0;
+    transform: rotateY(180deg);
+    display: grid;
+    place-items: center;
+}
+.opening__flip-back img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    filter: drop-shadow(0 18px 42px #000a);
+}
+
+/* ---- stacked deck of the remaining cards' backs, peeking behind ---- */
+.opening__stack {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 100%;
+    aspect-ratio: var(--card-aspect, .718);
+    transform: translate(-50%, -50%);
+    z-index: -1; /* behind the current card within .opening__reveal-cards */
+    pointer-events: none;
+}
+.opening__stack-layer {
+    position: absolute;
+    inset: 0;
+    border-radius: 5% / 3.6%;
+    background: #140a26 center/cover no-repeat url('/images/card-back.svg');
+    border: 1px solid #ffffff14;
+    box-shadow: 0 10px 30px #0007;
+}
+.opening__stack-layer:nth-child(1) { transform: translate(7px, 9px) scale(.985); opacity: .85; }
+.opening__stack-layer:nth-child(2) { transform: translate(15px, 19px) scale(.97); opacity: .6; }
+.opening__stack-layer:nth-child(3) { transform: translate(23px, 29px) scale(.955); opacity: .4; }
 
 .opening__next {
     z-index: 2;
-    margin-top: 22px;
+    margin-top: 48px;
     padding: 12px 26px;
     border: 1px solid #a435f066;
     background: #0b0712aa;
@@ -215,6 +265,8 @@
 
 /* --------------------------------------------------- CTA / instruction line */
 .opening__cta {
+    /* small pull toward the pack (the stage still has a little empty room below) */
+    margin-top: -16px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -312,21 +364,24 @@
 }
 .opening__slot.is-popping .opening__slot-img { animation: opening-slotPop .5s ease-out; }
 
-/* mystery slots: cards you don't own (and haven't owned) stay hidden behind a "?"
- * until you get them — revealed live in this opening, or already in your collection */
+/* mystery slots: cards you don't own (and haven't owned) sit behind a card back
+ * until you get them — revealed live in this opening, or already in your collection.
+ * On reveal the back fades out and cross-dissolves into the real card art. */
 .opening__slot-img img { transition: opacity .4s ease; }
 .opening__slot[data-owned="0"]:not(.is-revealed) .opening__slot-img img { opacity: 0; }
-.opening__slot[data-owned="0"]:not(.is-revealed) .opening__slot-img::after {
-    content: "?";
+.opening__slot-back {
     position: absolute;
     inset: 0;
-    display: grid;
-    place-items: center;
-    font-family: 'Space Grotesk', sans-serif;
-    font-weight: 800;
-    font-size: clamp(22px, 3vw, 34px);
-    color: #ffffff1f;
+    z-index: 1;
+    background-color: #140a26;
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+    opacity: 0;
+    transition: opacity .4s ease;
+    pointer-events: none;
 }
+.opening__slot[data-owned="0"]:not(.is-revealed) .opening__slot-back { opacity: 1; }
 
 .opening__slot-img {
     position: relative;
@@ -399,7 +454,7 @@
  * showcase, which is pointer-events:none once done — so re-enable them here) */
 .opening__foot {
     z-index: 3;
-    margin-top: 22px;
+    margin-top: 34px;
     display: flex;
     flex-wrap: wrap;
     align-items: center;

--- a/assets/styles/theme.css
+++ b/assets/styles/theme.css
@@ -40,6 +40,7 @@
     background: repeating-linear-gradient(0deg, transparent 0 2px, #00000030 2px 3px);
     opacity: .4;
 }
+.crt-off .scanlines { display: none; }
 
 .glow-ambient {
     position: absolute;

--- a/castor.php
+++ b/castor.php
@@ -28,4 +28,38 @@ function generateJwtKeyPair(): void
     io()->info($output);
 }
 
+/**
+ * Copy the packs.com placeholder pack model into public/models/ (served dir).
+ *
+ * The model lives in the gitignored design handoff and is NEVER committed; this
+ * task makes it available locally so the 3D pack opening works in dev. Without
+ * it the opening gracefully falls back to the 2D swipe pack.
+ */
+#[AsTask('sync-pack-model')]
+function syncPackModel(): void
+{
+    $source = __DIR__ . '/.claude/design_handoff_youl/refs-packs/model';
+    $target = __DIR__ . '/public/models';
+
+    if (!is_dir($source)) {
+        io()->warning('No placeholder model found at ' . $source . ' — skipping (the opening falls back to the 2D pack).');
+
+        return;
+    }
+
+    if (!is_dir($target) && !mkdir($target, 0o775, true) && !is_dir($target)) {
+        io()->error('Could not create ' . $target);
+
+        return;
+    }
+
+    foreach (['pack-wide.gltf', 'pack-wide.bin', 'opening.png', 'fallback.png'] as $file) {
+        if (is_file($source . '/' . $file)) {
+            copy($source . '/' . $file, $target . '/' . $file);
+        }
+    }
+
+    io()->success('Placeholder pack model synced to public/models/.');
+}
+
 import('make/castor_entrypoint.php');

--- a/importmap.php
+++ b/importmap.php
@@ -27,4 +27,10 @@ return [
     '@symfony/ux-live-component' => [
         'path' => './vendor/symfony/ux-live-component/assets/dist/live_controller.js',
     ],
+    'three' => [
+        'version' => '0.184.0',
+    ],
+    'three/addons/loaders/GLTFLoader.js' => [
+        'version' => '0.184.0',
+    ],
 ];

--- a/public/images/card-back.svg
+++ b/public/images/card-back.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 718 1000" width="718" height="1000" role="img" aria-label="Dos de carte YOUL">
+  <defs>
+    <linearGradient id="cb-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1c1038"/>
+      <stop offset="0.55" stop-color="#120a24"/>
+      <stop offset="1" stop-color="#0b0712"/>
+    </linearGradient>
+    <radialGradient id="cb-glow" cx="0.5" cy="0.42" r="0.62">
+      <stop offset="0" stop-color="#a435f0" stop-opacity="0.55"/>
+      <stop offset="0.6" stop-color="#a435f0" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#a435f0" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="cb-emblem" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#e7d4ff"/>
+      <stop offset="0.5" stop-color="#c9a0ff"/>
+      <stop offset="1" stop-color="#ff3db0"/>
+    </linearGradient>
+    <pattern id="cb-lattice" width="84" height="84" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <path d="M0 0H84V84H0Z" fill="none"/>
+      <path d="M42 0V84M0 42H84" stroke="#c9a0ff" stroke-opacity="0.06" stroke-width="2"/>
+      <circle cx="42" cy="42" r="3.2" fill="#c9a0ff" fill-opacity="0.10"/>
+    </pattern>
+  </defs>
+
+  <!-- base -->
+  <rect x="8" y="8" width="702" height="984" rx="44" fill="url(#cb-bg)"/>
+  <!-- lattice texture -->
+  <rect x="8" y="8" width="702" height="984" rx="44" fill="url(#cb-lattice)"/>
+  <!-- central glow -->
+  <rect x="8" y="8" width="702" height="984" rx="44" fill="url(#cb-glow)"/>
+
+  <!-- inner frame -->
+  <rect x="40" y="40" width="638" height="920" rx="30" fill="none" stroke="#c9a0ff" stroke-opacity="0.28" stroke-width="3"/>
+  <rect x="58" y="58" width="602" height="884" rx="22" fill="none" stroke="#ff3db0" stroke-opacity="0.14" stroke-width="2"/>
+
+  <!-- central emblem: a diamond with a Y monogram -->
+  <g transform="translate(359 500)">
+    <g opacity="0.9">
+      <path d="M0 -210 L150 0 L0 210 L-150 0 Z" fill="none" stroke="url(#cb-emblem)" stroke-width="6"/>
+      <path d="M0 -150 L108 0 L0 150 L-108 0 Z" fill="#a435f0" fill-opacity="0.10" stroke="url(#cb-emblem)" stroke-width="3" stroke-opacity="0.6"/>
+    </g>
+    <!-- Y monogram -->
+    <path d="M-52 -78 L0 -6 L52 -78 M0 -6 L0 86"
+          fill="none" stroke="url(#cb-emblem)" stroke-width="20"
+          stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+
+  <!-- wordmark -->
+  <text x="359" y="812" text-anchor="middle"
+        font-family="'Space Grotesk', 'Segoe UI', sans-serif"
+        font-size="58" font-weight="700" letter-spacing="14"
+        fill="#e7d4ff" fill-opacity="0.85">YOUL</text>
+  <text x="359" y="852" text-anchor="middle"
+        font-family="'JetBrains Mono', monospace"
+        font-size="20" letter-spacing="10"
+        fill="#c9a0ff" fill-opacity="0.55">TCG</text>
+</svg>

--- a/src/Controller/BoosterController.php
+++ b/src/Controller/BoosterController.php
@@ -12,6 +12,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
+use Symfony\Component\Uid\Uuid;
 
 class BoosterController extends AbstractController
 {
@@ -28,7 +29,8 @@ class BoosterController extends AbstractController
         CardRepository $cardRepository,
         UserBoosterRepository $userBoosterRepository,
     ): Response {
-        $booster = $boosterRepository->find($id);
+        // A malformed uuid must be a plain 404 instead of a Doctrine conversion error.
+        $booster = Uuid::isValid($id) ? $boosterRepository->find($id) : null;
 
         if (null === $booster) {
             throw $this->createNotFoundException();

--- a/src/Controller/BoosterController.php
+++ b/src/Controller/BoosterController.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\DiscordUser;
+use App\Repository\BoosterRepository;
+use App\Repository\CardRepository;
+use App\Repository\UserBoosterRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+class BoosterController extends AbstractController
+{
+    /**
+     * Dedicated single-booster opening page (packs.com-style): the 3D pack on the
+     * left, the extension's card set on the right. The draw itself happens through
+     * the BoosterOpening live component's `open` action.
+     */
+    #[Route('/boosters/{id}/open', name: 'booster_open')]
+    public function open(
+        string $id,
+        #[CurrentUser] DiscordUser $user,
+        BoosterRepository $boosterRepository,
+        CardRepository $cardRepository,
+        UserBoosterRepository $userBoosterRepository,
+    ): Response {
+        $booster = $boosterRepository->find($id);
+
+        if (null === $booster) {
+            throw $this->createNotFoundException();
+        }
+
+        $drawableExtensionIds = array_flip($cardRepository->findExtensionIdsWithPublishedCards());
+        $userBooster = $userBoosterRepository->findOneBy(['discordUser' => $user, 'booster' => $booster]);
+
+        if (
+            !isset($drawableExtensionIds[(string) $booster->getExtension()->getId()])
+            || null === $userBooster
+            || $userBooster->getQuantity() < 1
+        ) {
+            $this->addFlash('error', "Ce pack n'est pas ouvrable pour le moment.");
+
+            return $this->redirectToRoute('boosters');
+        }
+
+        return $this->render('pages/booster_open.html.twig', ['booster' => $booster]);
+    }
+}

--- a/src/Repository/CardRepository.php
+++ b/src/Repository/CardRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Card;
+use App\Entity\Extension;
 use App\Enum\Entity\CardStatusEnum;
 use App\Enum\Entity\ExtensionStatusEnum;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
@@ -19,6 +20,41 @@ class CardRepository extends ServiceEntityRepository
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, Card::class);
+    }
+
+    /**
+     * Extension ids that have at least one published card, i.e. extensions a
+     * booster can actually draw from.
+     *
+     * @return list<string>
+     */
+    public function findExtensionIdsWithPublishedCards(): array
+    {
+        return array_map(static fn (mixed $id): string => (string) $id, array_values($this->createQueryBuilder('c')
+            ->select('IDENTITY(c.extension) AS extensionId')
+            ->andWhere('c.status = :status')
+            ->setParameter('status', CardStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
+            ->distinct()
+            ->getQuery()
+            ->getSingleColumnResult()));
+    }
+
+    /**
+     * Published cards of an extension — the "set contents" shown in the opening
+     * aside. Ordering by rarity is handled in the component (CardRarityEnum rank).
+     *
+     * @return list<Card>
+     */
+    public function findPublishedByExtension(Extension $extension): array
+    {
+        return array_values($this->createQueryBuilder('c')
+            ->andWhere('c.extension = :extension')
+            ->andWhere('c.status = :status')
+            ->setParameter('extension', $extension)
+            ->setParameter('status', CardStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
+            ->orderBy('c.name', 'ASC')
+            ->getQuery()
+            ->getResult());
     }
 
     /**

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace App\Twig\Components;
 
 use App\Entity\Booster;
-use App\Entity\BoosterOpening;
-use App\Entity\Card;
 use App\Entity\DiscordUser;
-use App\Enum\Entity\CardRarityEnum;
 use App\Exception\Booster\BoosterException;
 use App\Repository\BoosterRepository;
+use App\Repository\CardRepository;
 use App\Repository\UserBoosterRepository;
-use App\Repository\UserCardRepository;
 use App\Service\Booster\BoosterClaimService;
-use App\Service\Booster\BoosterOpeningService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Uid\Uuid;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
@@ -23,34 +19,19 @@ use Symfony\UX\LiveComponent\Attribute\LiveArg;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-/**
- * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
- */
 #[AsLiveComponent]
 final class BoosterHub extends AbstractController
 {
     use DefaultActionTrait;
 
     #[LiveProp]
-    public ?BoosterOpening $opening = null;
-
-    /**
-     * Card ids that the user did not own before the last opening (NOUVEAU badge).
-     *
-     * @var list<string>
-     */
-    #[LiveProp]
-    public array $newCardIds = [];
-
-    #[LiveProp]
     public ?string $error = null;
 
     public function __construct(
         private readonly BoosterRepository $boosterRepository,
+        private readonly CardRepository $cardRepository,
         private readonly UserBoosterRepository $userBoosterRepository,
-        private readonly UserCardRepository $userCardRepository,
         private readonly BoosterClaimService $boosterClaimService,
-        private readonly BoosterOpeningService $boosterOpeningService,
     ) {
     }
 
@@ -82,6 +63,27 @@ final class BoosterHub extends AbstractController
     }
 
     /**
+     * Booster ids whose extension has at least one published card, i.e. the
+     * boosters that can actually be opened. Boosters over an empty extension
+     * are surfaced as "à venir" rather than letting the user hit a draw error.
+     *
+     * @return array<string, true> booster id => true
+     */
+    public function getDrawableBoosterIds(): array
+    {
+        $extensionIds = array_flip($this->cardRepository->findExtensionIdsWithPublishedCards());
+
+        $drawable = [];
+        foreach ($this->getBoosters() as $booster) {
+            if (isset($extensionIds[(string) $booster->getExtension()->getId()])) {
+                $drawable[(string) $booster->getId()] = true;
+            }
+        }
+
+        return $drawable;
+    }
+
+    /**
      * @return array<string, int> booster id => owned quantity
      */
     public function getInventory(): array
@@ -93,66 +95,6 @@ final class BoosterHub extends AbstractController
         }
 
         return $inventory;
-    }
-
-    /**
-     * Per-rarity count of the last opening, ordered from common to legendary.
-     *
-     * @return list<array{rarity: CardRarityEnum, count: int}>
-     */
-    public function getRaritySummary(): array
-    {
-        if (!$this->opening instanceof BoosterOpening) {
-            return [];
-        }
-
-        $counts = [];
-        foreach ($this->opening->getBoosterOpeningCards() as $openingCard) {
-            $rarity = $openingCard->getCard()->getRarity()->value;
-            $counts[$rarity] = ($counts[$rarity] ?? 0) + $openingCard->getQuantity();
-        }
-
-        $summary = [];
-        foreach (CardRarityEnum::ascending() as $rarity) {
-            if (isset($counts[$rarity->value])) {
-                $summary[] = ['rarity' => $rarity, 'count' => $counts[$rarity->value]];
-            }
-        }
-
-        return $summary;
-    }
-
-    /**
-     * Individual drawn cards in reveal order: rarest revealed last (the climax),
-     * holo copies flagged so the CardComponent lights up its holo layers.
-     *
-     * @return list<array{card: Card, holo: bool}>
-     */
-    public function getRevealCards(): array
-    {
-        if (!$this->opening instanceof BoosterOpening) {
-            return [];
-        }
-
-        $rank = array_flip(array_map(
-            static fn (CardRarityEnum $rarity): string => $rarity->value,
-            CardRarityEnum::ascending(),
-        ));
-
-        $cards = [];
-        foreach ($this->opening->getBoosterOpeningCards() as $openingCard) {
-            $card = $openingCard->getCard();
-            for ($copy = 0; $copy < $openingCard->getQuantity(); ++$copy) {
-                $cards[] = ['card' => $card, 'holo' => $copy < $openingCard->getHoloQuantity()];
-            }
-        }
-
-        usort(
-            $cards,
-            static fn (array $a, array $b): int => $rank[$a['card']->getRarity()->value] <=> $rank[$b['card']->getRarity()->value],
-        );
-
-        return $cards;
     }
 
     #[LiveAction]
@@ -173,47 +115,6 @@ final class BoosterHub extends AbstractController
         } catch (BoosterException $exception) {
             $this->error = $exception->getUserMessage();
         }
-    }
-
-    #[LiveAction]
-    public function openBooster(#[LiveArg] string $boosterId): void
-    {
-        $this->error = null;
-
-        $booster = $this->findBooster($boosterId);
-
-        if (!$booster instanceof Booster) {
-            $this->error = 'Booster introuvable.';
-
-            return;
-        }
-
-        $user = $this->getDiscordUser();
-        $ownedBefore = $this->userCardRepository->findOwnedCardIds($user);
-
-        try {
-            $this->opening = $this->boosterOpeningService->open($user, $booster);
-        } catch (BoosterException $exception) {
-            $this->error = $exception->getUserMessage();
-
-            return;
-        }
-
-        $this->newCardIds = [];
-        foreach ($this->opening->getBoosterOpeningCards() as $openingCard) {
-            $cardId = (string) $openingCard->getCard()->getId();
-            if (!\in_array($cardId, $ownedBefore, true)) {
-                $this->newCardIds[] = $cardId;
-            }
-        }
-    }
-
-    #[LiveAction]
-    public function closeModal(): void
-    {
-        $this->opening = null;
-        $this->newCardIds = [];
-        $this->error = null;
     }
 
     /**

--- a/src/Twig/Components/BoosterOpening.php
+++ b/src/Twig/Components/BoosterOpening.php
@@ -183,7 +183,7 @@ final class BoosterOpening extends AbstractController
         try {
             $this->opening = $this->boosterOpeningService->open($user, $this->getBooster());
         } catch (BoosterException $exception) {
-            $this->error = $exception->getMessage();
+            $this->error = $exception->getUserMessage();
 
             return;
         }

--- a/src/Twig/Components/BoosterOpening.php
+++ b/src/Twig/Components/BoosterOpening.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Components;
+
+use App\Entity\Booster;
+use App\Entity\BoosterOpening as BoosterOpeningEntity;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Enum\Entity\CardRarityEnum;
+use App\Exception\Booster\BoosterException;
+use App\Repository\BoosterRepository;
+use App\Repository\CardRepository;
+use App\Repository\UserBoosterRepository;
+use App\Repository\UserCardRepository;
+use App\Service\Booster\BoosterOpeningService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * Single-booster opening (dedicated page, packs.com-style). The pack stands on
+ * the left, the extension's card set on the right; `open()` draws server-side
+ * (one atomic, pessimistic-locked transaction via BoosterOpeningService) and the
+ * client choreographs the reveal as the player peels the 3D pack.
+ *
+ * @SuppressWarnings("PHPMD.CouplingBetweenObjects")
+ */
+#[AsLiveComponent]
+final class BoosterOpening extends AbstractController
+{
+    use DefaultActionTrait;
+
+    #[LiveProp(writable: false)]
+    public string $boosterId = '';
+
+    #[LiveProp]
+    public ?BoosterOpeningEntity $opening = null;
+
+    /**
+     * Card ids the user did not own before this opening (NOUVEAU highlight).
+     *
+     * @var list<string>
+     */
+    #[LiveProp]
+    public array $newCardIds = [];
+
+    #[LiveProp]
+    public ?string $error = null;
+
+    private ?Booster $boosterCache = null;
+
+    public function __construct(
+        private readonly BoosterRepository $boosterRepository,
+        private readonly CardRepository $cardRepository,
+        private readonly UserBoosterRepository $userBoosterRepository,
+        private readonly UserCardRepository $userCardRepository,
+        private readonly BoosterOpeningService $boosterOpeningService,
+    ) {
+    }
+
+    public function getBooster(): Booster
+    {
+        if (!$this->boosterCache instanceof Booster) {
+            $booster = $this->boosterRepository->find($this->boosterId);
+
+            if (null === $booster) {
+                throw $this->createNotFoundException();
+            }
+
+            $this->boosterCache = $booster;
+        }
+
+        return $this->boosterCache;
+    }
+
+    /**
+     * The extension's published cards ("set contents"), rarest last so the aside
+     * reads common → legendary like the reveal order.
+     *
+     * @return list<Card>
+     */
+    public function getExtensionCatalog(): array
+    {
+        $cards = $this->cardRepository->findPublishedByExtension($this->getBooster()->getExtension());
+        $rank = $this->rarityRanks();
+
+        usort(
+            $cards,
+            static fn (Card $a, Card $b): int => [$rank[$a->getRarity()->value], $a->getName()]
+                <=> [$rank[$b->getRarity()->value], $b->getName()],
+        );
+
+        return $cards;
+    }
+
+    /**
+     * Drawn cards in reveal order (rarest revealed last — the climax), holo copies
+     * flagged so the CardComponent lights up its holo layers.
+     *
+     * @return list<array{card: Card, holo: bool}>
+     */
+    public function getRevealCards(): array
+    {
+        if (!$this->opening instanceof BoosterOpeningEntity) {
+            return [];
+        }
+
+        $rank = $this->rarityRanks();
+
+        $cards = [];
+        foreach ($this->opening->getBoosterOpeningCards() as $openingCard) {
+            $card = $openingCard->getCard();
+            for ($copy = 0; $copy < $openingCard->getQuantity(); ++$copy) {
+                $cards[] = ['card' => $card, 'holo' => $copy < $openingCard->getHoloQuantity()];
+            }
+        }
+
+        usort(
+            $cards,
+            static fn (array $a, array $b): int => $rank[$a['card']->getRarity()->value] <=> $rank[$b['card']->getRarity()->value],
+        );
+
+        return $cards;
+    }
+
+    /**
+     * Per-card draw summary keyed by card id, to annotate the catalog slots.
+     *
+     * @return array<string, array{quantity: int, holoQuantity: int, new: bool}>
+     */
+    public function getDrawnByCardId(): array
+    {
+        if (!$this->opening instanceof BoosterOpeningEntity) {
+            return [];
+        }
+
+        $drawn = [];
+        foreach ($this->opening->getBoosterOpeningCards() as $openingCard) {
+            $cardId = (string) $openingCard->getCard()->getId();
+            $drawn[$cardId] = [
+                'quantity' => $openingCard->getQuantity(),
+                'holoQuantity' => $openingCard->getHoloQuantity(),
+                'new' => \in_array($cardId, $this->newCardIds, true),
+            ];
+        }
+
+        return $drawn;
+    }
+
+    /**
+     * Card ids the user owns (or has owned). The set list masks every other card
+     * as "?" so the opening only reveals what the player actually has / gets.
+     *
+     * @return array<string, true> card id => true
+     */
+    public function getOwnedCardIds(): array
+    {
+        return array_fill_keys($this->userCardRepository->findOwnedCardIds($this->getDiscordUser()), true);
+    }
+
+    public function getOwnedCount(): int
+    {
+        $userBooster = $this->userBoosterRepository->findOneBy([
+            'discordUser' => $this->getDiscordUser(),
+            'booster' => $this->getBooster(),
+        ]);
+
+        return null !== $userBooster ? $userBooster->getQuantity() : 0;
+    }
+
+    #[LiveAction]
+    public function open(): void
+    {
+        $this->error = null;
+
+        $user = $this->getDiscordUser();
+        $ownedBefore = $this->userCardRepository->findOwnedCardIds($user);
+
+        try {
+            $this->opening = $this->boosterOpeningService->open($user, $this->getBooster());
+        } catch (BoosterException $exception) {
+            $this->error = $exception->getMessage();
+
+            return;
+        }
+
+        $this->newCardIds = [];
+        foreach ($this->opening->getBoosterOpeningCards() as $openingCard) {
+            $cardId = (string) $openingCard->getCard()->getId();
+            if (!\in_array($cardId, $ownedBefore, true)) {
+                $this->newCardIds[] = $cardId;
+            }
+        }
+    }
+
+    #[LiveAction]
+    public function reset(): void
+    {
+        $this->opening = null;
+        $this->newCardIds = [];
+        $this->error = null;
+    }
+
+    /**
+     * @return array<string, int> rarity value => ascending rank
+     */
+    private function rarityRanks(): array
+    {
+        return array_flip(array_map(
+            static fn (CardRarityEnum $rarity): string => $rarity->value,
+            CardRarityEnum::ascending(),
+        ));
+    }
+
+    private function getDiscordUser(): DiscordUser
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof DiscordUser) {
+            throw $this->createAccessDeniedException();
+        }
+
+        return $user;
+    }
+}

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -55,44 +55,62 @@
                 {% else %}
                     {% set inventory = this.inventory %}
                     {% set remainingClaims = this.remainingClaims %}
-                    <div class="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3" data-testid="boosters-grid">
+                    {% set drawableBoosterIds = this.drawableBoosterIds %}
+                    <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4" data-testid="boosters-grid">
                         {% for booster in this.boosters %}
                             {% set owned = inventory[booster.id]|default(0) %}
-                            <article class="group flex flex-col border border-hairline bg-surface">
-                                <div class="relative aspect-[16/10] overflow-hidden border-b border-hairline bg-bg">
-                                    <img src="{{ booster.imageName ? vich_uploader_asset(booster) : (booster.extension.imageName ? vich_uploader_asset(booster.extension) : asset('images/cards/default_card.png')) }}"
-                                         alt="{{ booster.extension.name }}"
-                                         class="h-full w-full object-cover opacity-80 transition duration-300 group-hover:scale-[1.03] group-hover:opacity-100"
-                                         onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
-                                    <div class="absolute inset-0 bg-gradient-to-t from-bg via-bg/20 to-transparent"></div>
-                                    <span class="chip-mono absolute right-3 top-3 bg-black/80 px-2 py-1 font-bold text-ink-strong">×{{ owned }}</span>
+                            {% set drawable = drawableBoosterIds[booster.id]|default(false) %}
+                            <article class="group relative flex flex-col rounded-2xl border border-hairline bg-surface p-4 transition duration-300 hover:-translate-y-1 hover:border-primary/40">
+                                {# centred eyebrow + set name (packs.com header) #}
+                                <p class="text-center font-mono text-[10px] font-bold uppercase tracking-[.2em] text-ink-dim">Cartes de</p>
+                                <h3 class="mt-1 text-center font-display text-lg font-bold uppercase leading-tight tracking-[-0.02em] text-ink-strong">{{ booster.extension.name }}</h3>
+
+                                {# tilted pack with a trading card peeking out behind it #}
+                                <div class="relative mx-auto mt-4 flex h-60 w-full items-center justify-center">
+                                    {# a trading card peeking out behind the pack #}
+                                    <div class="absolute h-[86%] w-[46%] translate-x-8 rotate-[8deg] rounded-lg border border-white/10 bg-gradient-to-br from-white/15 via-white/5 to-transparent shadow-lg transition duration-300 group-hover:translate-x-10 group-hover:rotate-[11deg]"></div>
+                                    {# the pack front — same composite as the 3D opening pack, drawn into a canvas #}
+                                    <canvas width="840" height="1300"
+                                            data-controller="pack-front"
+                                            data-pack-front-bg-url-value="{{ booster.imageName ? vich_uploader_asset(booster) : (booster.extension.imageName ? vich_uploader_asset(booster.extension) : '') }}"
+                                            data-pack-front-fallback-url-value="{{ asset('images/ytcg_background.png') }}"
+                                            data-pack-front-logo-url-value="{{ asset('images/ytcg_logo.png') }}"
+                                            data-pack-front-name-value="{{ booster.extension.name }}"
+                                            data-pack-front-count-value="{{ booster.cardCount }}"
+                                            class="relative h-full w-auto -rotate-3 rounded-xl shadow-2xl ring-1 ring-white/10 transition duration-300 group-hover:-rotate-1 group-hover:scale-[1.04]"></canvas>
                                 </div>
 
-                                <div class="flex flex-1 flex-col p-5">
-                                    <h3 class="font-display text-xl font-bold uppercase tracking-[-0.02em] text-ink-strong">{{ booster.extension.name }}</h3>
-                                    <p class="chip-mono mt-1 text-ink-dim">{{ booster.cardCount }} cartes</p>
-                                    <p class="mt-2 line-clamp-2 text-sm text-ink-muted">{{ booster.extension.description }}</p>
+                                {# whole-card link to the opening (stays under the footer controls) #}
+                                {% if owned > 0 and drawable %}
+                                    <a href="{{ path('booster_open', {id: booster.id}) }}"
+                                       class="absolute inset-0 z-10 rounded-2xl"
+                                       aria-label="Ouvrir un pack {{ booster.extension.name }}"></a>
+                                {% endif %}
 
-                                    <div class="mt-auto grid grid-cols-2 gap-3 pt-5">
+                                {# footer: claim chip on the left, open / status on the right #}
+                                <div class="relative z-20 mt-4 flex items-center justify-between border-t border-hairline pt-3">
+                                    {% if remainingClaims > 0 %}
                                         <button type="button"
                                                 data-action="live#action"
                                                 data-live-action-param="claimBooster"
                                                 data-live-booster-id-param="{{ booster.id }}"
-                                                class="border border-primary bg-black px-4 py-3 font-display text-xs font-bold uppercase tracking-[.12em] text-primary transition hover:bg-primary hover:text-black disabled:cursor-not-allowed disabled:opacity-40"
-                                                {% if remainingClaims == 0 %}disabled{% endif %}>
-                                            <span data-loading="hide">Récupérer</span>
+                                                class="font-mono text-[11px] font-bold uppercase tracking-[.1em] text-primary transition hover:text-ink-strong">
+                                            <span data-loading="hide">+ Récupérer</span>
                                             <span data-loading="show" class="hidden">···</span>
                                         </button>
-                                        <button type="button"
-                                                data-action="live#action"
-                                                data-live-action-param="openBooster"
-                                                data-live-booster-id-param="{{ booster.id }}"
-                                                class="btn-arcade w-full text-center disabled:cursor-not-allowed disabled:opacity-40"
-                                                {% if owned == 0 %}disabled{% endif %}>
-                                            <span data-loading="hide">Ouvrir ▸</span>
-                                            <span data-loading="show" class="hidden">···</span>
-                                        </button>
-                                    </div>
+                                    {% else %}
+                                        <span class="chip-mono text-ink-dim">×{{ owned }}</span>
+                                    {% endif %}
+
+                                    {% if owned > 0 and drawable %}
+                                        <a href="{{ path('booster_open', {id: booster.id}) }}"
+                                           class="flex items-center gap-1 font-display text-xs font-bold uppercase tracking-[.12em] text-ink-strong transition hover:text-primary">
+                                            Ouvrir <span aria-hidden="true">›</span>
+                                        </a>
+                                    {% elseif not drawable %}
+                                        <span class="font-mono text-[11px] uppercase tracking-[.1em] text-ink-dim"
+                                              title="Cette extension n'a pas encore de carte publiée.">À venir</span>
+                                    {% endif %}
                                 </div>
                             </article>
                         {% endfor %}
@@ -101,168 +119,4 @@
             </div>
         </section>
     </main>
-
-    {# --------------------------------------------- Opening scene (reveal) #}
-    {% if opening %}
-        {% set revealCards = this.revealCards %}
-        {% set rarityLabels = { common: 'Commune', uncommon: 'Peu commune', rare: 'Rare', epic: 'Épique', legendary: 'Légendaire' } %}
-        {% set raritySuffix = { rare: ' !', epic: ' !!', legendary: ' !!!' } %}
-        <div class="fixed inset-0 z-50 overflow-y-auto bg-black/90 backdrop-blur-sm"
-             data-live-id="opening-{{ opening.id }}"
-             data-testid="opening-scene">
-            <div class="opening"
-                 data-controller="booster-opening"
-                 data-booster-opening-count-value="{{ revealCards|length }}"
-                 data-action="pack3d:opened->booster-opening#openAtOnce"
-                 data-live-ignore>
-
-                {# ---------- SEALED — the pack, swipe to slice ---------- #}
-                <div class="opening__sealed" data-booster-opening-target="sealed">
-                    {# 3D pack (progressive enhancement); hides the 2D pack below once ready #}
-                    <div class="opening__3d"
-                         data-controller="pack-opening-3d"
-                         data-pack-opening-3d-model-value="/models/pack-wide.gltf"
-                         data-pack-opening-3d-texture-value="/models/opening.png"
-                         data-action="pointerdown->pack-opening-3d#dragStart pointermove->pack-opening-3d#dragMove pointerup->pack-opening-3d#dragEnd pointercancel->pack-opening-3d#dragEnd">
-                        <canvas data-pack-opening-3d-target="canvas"></canvas>
-                    </div>
-                    <div class="opening__pack-wrap"
-                         data-booster-opening-target="pack"
-                         data-action="pointerdown->booster-opening#dragStart pointermove->booster-opening#dragMove pointerup->booster-opening#dragEnd pointercancel->booster-opening#dragEnd">
-                        <div class="opening__pack">
-                            <div class="opening__pack-flap"></div>
-                            <div class="opening__pack-slit"></div>
-                            <div class="opening__pack-edge"></div>
-                            <div class="opening__pack-guide"></div>
-                            <div class="opening__pack-cutter">
-                                <div class="dot"></div>
-                                <div class="cross-h"></div>
-                                <div class="cross-v"></div>
-                            </div>
-                            <div class="opening__pack-body">
-                                <img src="{{ opening.booster.imageName ? vich_uploader_asset(opening.booster) : (opening.booster.extension.imageName ? vich_uploader_asset(opening.booster.extension) : asset('images/cards/default_card.png')) }}"
-                                     alt="{{ opening.booster.extension.name }}"
-                                     onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
-                            </div>
-                            <div class="opening__pack-banner">
-                                <div class="code">BOOSTER</div>
-                                <div class="name">{{ opening.booster.extension.name }}</div>
-                            </div>
-                        </div>
-                    </div>
-                    <p class="opening__hint">
-                        TIRE LE HAUT DU PACK&nbsp;<span class="arrow">→</span>&nbsp;POUR LE DÉCHIRER
-                    </p>
-                    <button type="button" class="opening__skip" data-action="booster-opening#openAtOnce">
-                        … ou clique pour ouvrir d'un coup
-                    </button>
-                </div>
-
-                {# ---------- TEARING — light burst ---------- #}
-                <div class="opening__tearing" data-booster-opening-target="tearing" hidden>
-                    <div class="opening__beam"></div>
-                    <div class="opening__rays"></div>
-                    <div class="opening__bloom"></div>
-                    <div class="opening__particles">
-                        {% for i in 0..21 %}
-                            <span style="--ang: {{ (i / 22 * 360)|round }}deg; --dist: {{ 140 + (i % 5) * 55 }}px; color: {{ i is odd ? '#ff3db0' : '#d9a8ff' }}; animation-delay: {{ (0.22 + (i % 6) * 0.04) }}s;"></span>
-                        {% endfor %}
-                    </div>
-                </div>
-
-                {# ---------- REVEAL — cards one at a time, rarest last ---------- #}
-                <div class="opening__reveal"
-                     data-booster-opening-target="reveal"
-                     data-action="click->booster-opening#advance"
-                     hidden>
-                    <div class="opening__reveal-fx">
-                        <div class="opening__aura" data-booster-opening-target="aura"></div>
-                    </div>
-                    <div class="opening__label" data-booster-opening-target="label"></div>
-
-                    <div class="opening__reveal-cards">
-                        {% for reveal in revealCards %}
-                            {% set rarity = reveal.card.rarity.value %}
-                            <div class="opening__reveal-card"
-                                 data-booster-opening-target="card"
-                                 data-rarity="{{ rarity }}"
-                                 data-shiny="{{ rarity in ['rare', 'epic', 'legendary'] ? '1' : '0' }}"
-                                 data-label="{{ rarityLabels[rarity]|default(rarity) }}{{ raritySuffix[rarity]|default('') }}">
-                                {{ include('components/CardComponent.html.twig', {
-                                    card: reveal.card,
-                                    holo: reveal.holo,
-                                    id: 'reveal-' ~ loop.index,
-                                }) }}
-                            </div>
-                        {% endfor %}
-                    </div>
-
-                    <div class="opening__progress" data-testid="reveal-progress">
-                        {% for reveal in revealCards %}
-                            <span class="opening__dot" data-booster-opening-target="dot"></span>
-                        {% endfor %}
-                    </div>
-                    <button type="button" class="opening__next" data-booster-opening-target="next" data-action="booster-opening#advance">Carte suivante ▸</button>
-                    <p class="opening__counter" data-booster-opening-target="counter"></p>
-                </div>
-
-                {# ---------- SUMMARY — the loot ---------- #}
-                <div class="opening__summary mx-auto flex min-h-full w-full max-w-5xl flex-col"
-                     data-booster-opening-target="summary"
-                     data-testid="opening-summary"
-                     hidden>
-                    <header class="flex items-center justify-between border-b border-hairline bg-surface px-6 py-5">
-                        <div>
-                            <p class="eyebrow">Ton butin</p>
-                            <h2 class="mt-1 font-display text-2xl font-bold uppercase tracking-[-0.03em] text-ink-strong">
-                                {{ opening.booster.extension.name }}
-                            </h2>
-                        </div>
-                        <button type="button"
-                                data-action="live#action"
-                                data-live-action-param="closeModal"
-                                class="font-mono text-2xl leading-none text-ink-dim transition hover:text-ink-strong"
-                                aria-label="Fermer">×</button>
-                    </header>
-
-                    <div class="flex flex-wrap gap-2 border-b border-hairline px-6 py-4" data-testid="rarity-tally">
-                        {% for tier in this.raritySummary %}
-                            <span class="chip-mono border border-hairline px-2.5 py-1 font-bold"
-                                  style="color: var(--rarity-{{ tier.rarity.value }});">
-                                {{ tier.rarity.value }} · {{ tier.count }}
-                            </span>
-                        {% endfor %}
-                    </div>
-
-                    <div class="grid grid-cols-2 gap-5 px-6 py-6 sm:grid-cols-3 md:grid-cols-4">
-                        {% for openingCard in opening.boosterOpeningCards %}
-                            {% for copy in 1..openingCard.quantity %}
-                                <div class="relative">
-                                    {{ include('components/CardComponent.html.twig', {
-                                        card: openingCard.card,
-                                        holo: copy <= openingCard.holoQuantity,
-                                        id: 'loot-' ~ loop.parent.loop.index ~ '-' ~ copy,
-                                    }) }}
-                                    {% if (openingCard.card.id ~ '') in newCardIds %}
-                                        <span class="chip-mono absolute -left-2 -top-2 z-10 bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">NOUVEAU</span>
-                                    {% endif %}
-                                </div>
-                            {% endfor %}
-                        {% endfor %}
-                    </div>
-
-                    <footer class="mt-auto border-t border-hairline bg-surface px-6 py-5 text-center">
-                        <button type="button"
-                                data-action="live#action"
-                                data-live-action-param="closeModal"
-                                class="btn-arcade">Ajouter à ma collection ▸</button>
-                    </footer>
-                </div>
-
-                {# whiteout bridge + soft flash overlays (controller-driven) #}
-                <div class="opening__whiteout" data-booster-opening-target="whiteout"></div>
-                <div class="opening__flash" data-booster-opening-target="flash"></div>
-            </div>
-        </div>
-    {% endif %}
 </div>

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -113,10 +113,19 @@
             <div class="opening"
                  data-controller="booster-opening"
                  data-booster-opening-count-value="{{ revealCards|length }}"
+                 data-action="pack3d:opened->booster-opening#openAtOnce"
                  data-live-ignore>
 
                 {# ---------- SEALED — the pack, swipe to slice ---------- #}
                 <div class="opening__sealed" data-booster-opening-target="sealed">
+                    {# 3D pack (progressive enhancement); hides the 2D pack below once ready #}
+                    <div class="opening__3d"
+                         data-controller="pack-opening-3d"
+                         data-pack-opening-3d-model-value="/models/pack-wide.gltf"
+                         data-pack-opening-3d-texture-value="/models/opening.png"
+                         data-action="pointerdown->pack-opening-3d#dragStart pointermove->pack-opening-3d#dragMove pointerup->pack-opening-3d#dragEnd pointercancel->pack-opening-3d#dragEnd">
+                        <canvas data-pack-opening-3d-target="canvas"></canvas>
+                    </div>
                     <div class="opening__pack-wrap"
                          data-booster-opening-target="pack"
                          data-action="pointerdown->booster-opening#dragStart pointermove->booster-opening#dragMove pointerup->booster-opening#dragEnd pointercancel->booster-opening#dragEnd">

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -1,0 +1,164 @@
+<div {{ attributes }}>
+    {% set booster = this.booster %}
+    {% set extension = booster.extension %}
+    {% set catalog = this.extensionCatalog %}
+    {% set opening = this.opening %}
+    {% set drawn = this.drawnByCardId %}
+    {% set revealCards = this.revealCards %}
+    {% set ownedCount = this.ownedCount %}
+    {% set ownedCardIds = this.ownedCardIds %}
+    {% set newCardIds = this.newCardIds %}
+    {% set rarityLabels = { common: 'Commune', uncommon: 'Peu commune', rare: 'Rare', epic: 'Épique', legendary: 'Légendaire' } %}
+    {% set raritySuffix = { rare: ' !', epic: ' !!', legendary: ' !!!' } %}
+
+    <div class="opening opening--page"
+         data-controller="booster-opening"
+         {% if opening %}data-booster-opening-count-value="{{ revealCards|length }}"{% endif %}
+         data-action="pack3d:opened->booster-opening#startReveal pack3d:ready->booster-opening#syncPack">
+
+        {# ====================================================== LEFT: the pack #}
+        <section class="opening__pack-col">
+            <a href="{{ path('boosters') }}" class="opening__back">← Tous les packs</a>
+
+            {% if error %}
+                <div class="opening__err" data-testid="opening-error">⚠ {{ error }}</div>
+            {% endif %}
+
+            <div class="opening__pack-stage">
+                {# 3D pack — data-live-ignore so the WebGL context survives the open() re-render #}
+                <div class="opening__3d"
+                     data-live-ignore
+                     data-controller="pack-opening-3d"
+                     data-pack-opening-3d-model-value="/models/pack-wide.gltf"
+                     data-pack-opening-3d-texture-value="composite"
+                     data-pack-opening-3d-bg-url-value="{{ extension.imageName ? vich_uploader_asset(extension) : '' }}"
+                     data-pack-opening-3d-fallback-url-value="{{ asset('images/ytcg_background.png') }}"
+                     data-pack-opening-3d-logo-url-value="{{ asset('images/ytcg_logo.png') }}"
+                     data-pack-opening-3d-extension-name-value="{{ extension.name }}"
+                     data-pack-opening-3d-card-count-value="{{ booster.cardCount }}"
+                     data-action="pointerdown->pack-opening-3d#dragStart pointermove->pack-opening-3d#dragMove pointerup->pack-opening-3d#dragEnd pointercancel->pack-opening-3d#dragEnd pack3d:arm@window->pack-opening-3d#arm pack3d:commit@window->pack-opening-3d#openAtOnce pack3d:reset@window->pack-opening-3d#reseal">
+                    <canvas data-pack-opening-3d-target="canvas"></canvas>
+                </div>
+
+                {# showcase overlay: the big card reveal, one at a time, rarest last #}
+                <div class="opening__showcase" data-booster-opening-target="showcase"
+                     data-action="click->booster-opening#advance" hidden>
+                    <div class="opening__aura" data-booster-opening-target="aura"></div>
+                    <div class="opening__label" data-booster-opening-target="label"></div>
+
+                    <div class="opening__reveal-cards">
+                        {% for reveal in revealCards %}
+                            {% set rarity = reveal.card.rarity.value %}
+                            <div class="opening__reveal-card"
+                                 data-booster-opening-target="card"
+                                 data-card-id="{{ reveal.card.id }}"
+                                 data-rarity="{{ rarity }}"
+                                 data-shiny="{{ rarity in ['rare', 'epic', 'legendary'] ? '1' : '0' }}"
+                                 data-label="{{ rarityLabels[rarity]|default(rarity) }}{{ raritySuffix[rarity]|default('') }}">
+                                {{ include('components/CardComponent.html.twig', {
+                                    card: reveal.card,
+                                    holo: reveal.holo,
+                                    id: 'reveal-' ~ loop.index,
+                                }) }}
+                            </div>
+                        {% endfor %}
+                    </div>
+
+                    <button type="button" class="opening__next" data-booster-opening-target="next"
+                            data-action="booster-opening#advance">Carte suivante ▸</button>
+                    <p class="opening__counter" data-booster-opening-target="counter"></p>
+
+                    {# end-of-opening actions, grouped with the revealed card #}
+                    {% if opening %}
+                        <footer class="opening__foot" data-booster-opening-target="foot" hidden>
+                            {% if ownedCount > 0 %}
+                                <button type="button" data-action="live#action" data-live-action-param="reset" class="btn-arcade">
+                                    Ouvrir un autre ▸
+                                </button>
+                                <a href="{{ path('boosters') }}" class="opening__skip">← Tous les packs</a>
+                            {% else %}
+                                <a href="{{ path('boosters') }}" class="btn-arcade">Retour aux packs ▸</a>
+                            {% endif %}
+                        </footer>
+                    {% endif %}
+                </div>
+            </div>
+
+            {# state-driven CTA / instruction #}
+            <div class="opening__cta" data-booster-opening-target="cta">
+                {% if opening is null %}
+                    {% if ownedCount > 0 %}
+                        <button type="button" data-action="live#action" data-live-action-param="open"
+                                class="btn-arcade" data-testid="open-pack">
+                            <span data-loading="hide">Ouvrir ce pack ▸</span>
+                            <span data-loading="show" class="hidden">···</span>
+                        </button>
+                        <p class="opening__hint">Tu possèdes {{ ownedCount }} pack{{ ownedCount > 1 ? 's' }} de cette extension.</p>
+                    {% else %}
+                        <p class="opening__hint">Tu ne possèdes plus de pack de cette extension.</p>
+                        <a href="{{ path('boosters') }}" class="opening__skip">← Retour aux packs</a>
+                    {% endif %}
+                {% else %}
+                    <p class="opening__hint" data-booster-opening-target="hint">
+                        TIRE LE RUBAN VERS LA DROITE&nbsp;<span class="arrow">→</span>&nbsp;POUR DÉCHIRER
+                    </p>
+                    <button type="button" class="opening__skip" data-action="booster-opening#forceOpen">
+                        … ou clique pour ouvrir d'un coup
+                    </button>
+                {% endif %}
+            </div>
+
+        </section>
+
+        {# ============================================ RIGHT: the set contents #}
+        <aside class="opening__panel" data-testid="opening-aside">
+            <header class="opening__panel-head">
+                <p class="opening__panel-title">{{ extension.name }}</p>
+                <p class="opening__panel-sub">
+                    {{ booster.cardCount }} cartes / pack · {{ catalog|length }} dans l'extension
+                </p>
+                <p class="opening__panel-best">
+                    Meilleure trouvaille
+                    <span data-booster-opening-target="best">—</span>
+                </p>
+                {% if opening %}
+                    <p class="opening__panel-best">
+                        Révélé
+                        <span><span data-booster-opening-target="revealedCount">0</span> / {{ revealCards|length }}</span>
+                    </p>
+                {% endif %}
+            </header>
+
+            <div class="opening__slots" data-testid="opening-slots">
+                {% for card in catalog %}
+                    {% set info = drawn[card.id ~ '']|default(null) %}
+                    {# "owned" for masking = had it BEFORE this opening (so freshly drawn
+                       cards stay a mystery until the reveal lights them up) #}
+                    {% set isOwned = (ownedCardIds[card.id ~ ''] is defined) and (card.id ~ '' not in newCardIds) %}
+                    <div class="opening__slot"
+                         data-booster-opening-target="slot"
+                         data-card-id="{{ card.id }}"
+                         data-card-name="{{ card.name }}"
+                         data-rarity="{{ card.rarity.value }}"
+                         data-drawn="{{ info ? '1' : '0' }}"
+                         data-owned="{{ isOwned ? '1' : '0' }}"
+                         style="--slot-rar: var(--rarity-{{ card.rarity.value }});">
+                        <div class="opening__slot-img">
+                            <img src="{{ vich_uploader_asset(card) }}" alt="{{ isOwned ? card.name : '' }}"
+                                 onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
+                            {% if info %}
+                                {% if info.holoQuantity > 0 %}<span class="opening__slot-holo">HOLO</span>{% endif %}
+                                {% if info.quantity > 1 %}<span class="opening__slot-qty">×{{ info.quantity }}</span>{% endif %}
+                                {% if info.new %}<span class="opening__slot-new">NOUVEAU</span>{% endif %}
+                            {% endif %}
+                        </div>
+                        <p class="opening__slot-name">{{ isOwned ? card.name : '???' }}</p>
+                    </div>
+                {% endfor %}
+            </div>
+
+        </aside>
+
+        <div class="opening__flash" data-booster-opening-target="flash"></div>
+    </div>
+</div>

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -42,11 +42,18 @@
 
                 {# showcase overlay: the big card reveal, one at a time, rarest last #}
                 <div class="opening__showcase" data-booster-opening-target="showcase"
-                     data-action="click->booster-opening#advance" hidden>
+                     data-action="click->booster-opening#tap" hidden>
                     <div class="opening__aura" data-booster-opening-target="aura"></div>
                     <div class="opening__label" data-booster-opening-target="label"></div>
 
                     <div class="opening__reveal-cards">
+                        {# physical stack of the remaining cards' backs, peeking behind the current one #}
+                        <div class="opening__stack" data-booster-opening-target="stack" aria-hidden="true">
+                            <span class="opening__stack-layer"></span>
+                            <span class="opening__stack-layer"></span>
+                            <span class="opening__stack-layer"></span>
+                        </div>
+
                         {% for reveal in revealCards %}
                             {% set rarity = reveal.card.rarity.value %}
                             <div class="opening__reveal-card"
@@ -55,17 +62,25 @@
                                  data-rarity="{{ rarity }}"
                                  data-shiny="{{ rarity in ['rare', 'epic', 'legendary'] ? '1' : '0' }}"
                                  data-label="{{ rarityLabels[rarity]|default(rarity) }}{{ raritySuffix[rarity]|default('') }}">
-                                {{ include('components/CardComponent.html.twig', {
-                                    card: reveal.card,
-                                    holo: reveal.holo,
-                                    id: 'reveal-' ~ loop.index,
-                                }) }}
+                                {# flip scene: back faces the player until they click to reveal the front #}
+                                <div class="opening__flip" data-booster-opening-target="flip">
+                                    <div class="opening__flip-face opening__flip-front">
+                                        {{ include('components/CardComponent.html.twig', {
+                                            card: reveal.card,
+                                            holo: reveal.holo,
+                                            id: 'reveal-' ~ loop.index,
+                                        }) }}
+                                    </div>
+                                    <div class="opening__flip-face opening__flip-back">
+                                        <img src="{{ asset('images/card-back.svg') }}" alt="" draggable="false">
+                                    </div>
+                                </div>
                             </div>
                         {% endfor %}
                     </div>
 
                     <button type="button" class="opening__next" data-booster-opening-target="next"
-                            data-action="booster-opening#advance">Carte suivante ▸</button>
+                            data-action="booster-opening#advance" hidden>Carte suivante ▸</button>
                     <p class="opening__counter" data-booster-opening-target="counter"></p>
 
                     {# end-of-opening actions, grouped with the revealed card #}
@@ -144,6 +159,8 @@
                          data-owned="{{ isOwned ? '1' : '0' }}"
                          style="--slot-rar: var(--rarity-{{ card.rarity.value }});">
                         <div class="opening__slot-img">
+                            <span class="opening__slot-back" aria-hidden="true"
+                                  style="background-image: url('{{ asset('images/card-back.svg') }}');"></span>
                             <img src="{{ vich_uploader_asset(card) }}" alt="{{ isOwned ? card.name : '' }}"
                                  onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
                             {% if info %}
@@ -152,7 +169,7 @@
                                 {% if info.new %}<span class="opening__slot-new">NOUVEAU</span>{% endif %}
                             {% endif %}
                         </div>
-                        <p class="opening__slot-name">{{ isOwned ? card.name : '???' }}</p>
+                        <p class="opening__slot-name">{{ isOwned ? card.name : 'Non révélée' }}</p>
                     </div>
                 {% endfor %}
             </div>

--- a/templates/pages/booster_open.html.twig
+++ b/templates/pages/booster_open.html.twig
@@ -1,0 +1,14 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    YOUL TCG — Ouvrir un pack
+{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('styles/opening.css') }}">
+{% endblock %}
+
+{% block body %}
+    {{ component('BoosterOpening', { boosterId: booster.id }) }}
+{% endblock %}

--- a/templates/parts/_footer.html.twig
+++ b/templates/parts/_footer.html.twig
@@ -4,5 +4,14 @@
         <img src="{{ asset('images/ytcg_logo.png') }}" alt="" class="h-8 w-8 object-contain">
         <span>YOUL · YOULS TRADING CARD GAME · {{ 'now'|date('Y') }}</span>
     </div>
-    <span>fan-made · non-officiel</span>
+    <div class="flex items-center gap-5" data-controller="crt-toggle">
+        <label class="flex cursor-pointer select-none items-center gap-2 transition hover:text-ink">
+            <input type="checkbox" checked
+                   data-crt-toggle-target="checkbox"
+                   data-action="change->crt-toggle#toggle"
+                   style="accent-color: #a435f0;">
+            CRT
+        </label>
+        <span>fan-made · non-officiel</span>
+    </div>
 </footer>

--- a/tests/Functional/BoosterHubComponentTest.php
+++ b/tests/Functional/BoosterHubComponentTest.php
@@ -5,13 +5,10 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use App\Entity\UserBooster;
-use App\Entity\UserCard;
-use App\Enum\Entity\CardRarityEnum;
 use App\Repository\BoosterRepository;
 use App\Twig\Components\BoosterHub;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\DomCrawler\Crawler;
 use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
 
 final class BoosterHubComponentTest extends WebTestCase
@@ -41,36 +38,6 @@ final class BoosterHubComponentTest extends WebTestCase
         $this->assertNull($component->component()->error);
     }
 
-    public function testOpeningAClaimedBoosterFillsTheCollectionAndTheSummary(): void
-    {
-        $client = static::createClient();
-        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
-        $booster = $this->firstPublishedBooster();
-
-        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
-        $component->call('claimBooster', ['boosterId' => (string) $booster->getId()]);
-        $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
-
-        $hub = $component->component();
-        $this->assertNull($hub->error);
-        $this->assertNotNull($hub->opening);
-
-        $rendered = (string) $component->render();
-        $this->assertStringContainsString('Ton butin', $rendered);
-        // Every drawn card was new for this empty-inventory user.
-        $this->assertStringContainsString('NOUVEAU', $rendered);
-
-        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
-
-        $userBooster = $entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $user, 'booster' => $booster]);
-        $this->assertNotNull($userBooster);
-        $this->assertSame(0, $userBooster->getQuantity());
-
-        $userCards = $entityManager->getRepository(UserCard::class)->findBy(['discordUser' => $user]);
-        $totalCards = array_sum(array_map(static fn (UserCard $userCard): int => $userCard->getQuantity(), $userCards));
-        $this->assertSame($booster->getCardCount(), $totalCards);
-    }
-
     public function testClaimBoosterWithMalformedIdReportsNotFoundInsteadOfCrashing(): void
     {
         $client = static::createClient();
@@ -82,19 +49,7 @@ final class BoosterHubComponentTest extends WebTestCase
         $this->assertSame('Booster introuvable.', $component->component()->error);
     }
 
-    public function testErrorsAreReportedInFrench(): void
-    {
-        $client = static::createClient();
-        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
-        $booster = $this->firstPublishedBooster();
-
-        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
-        $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
-
-        $this->assertSame('Tu ne possèdes pas ce booster.', $component->component()->error);
-    }
-
-    public function testRevealRendersCardsOrderedRarestLast(): void
+    public function testOwnedDrawableBoosterRendersAnOpenLink(): void
     {
         $client = static::createClient();
         $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
@@ -102,43 +57,40 @@ final class BoosterHubComponentTest extends WebTestCase
 
         $component = $this->createLiveComponent(BoosterHub::class, client: $client);
         $component->call('claimBooster', ['boosterId' => (string) $booster->getId()]);
-        $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
 
         $rendered = (string) $component->render();
-        // 3D pack enhancement is wired in (falls back to the 2D swipe client-side).
-        $this->assertStringContainsString('pack-opening-3d', $rendered);
-        $this->assertStringContainsString('/models/pack-wide.gltf', $rendered);
-
-        $crawler = new Crawler($rendered);
-        $rarities = $crawler->filter('.opening__reveal-card')->each(
-            static fn (Crawler $node): string => (string) $node->attr('data-rarity'),
-        );
-
-        $this->assertCount($booster->getCardCount(), $rarities);
-
-        $rank = array_flip(array_map(
-            static fn (CardRarityEnum $rarity): string => $rarity->value,
-            CardRarityEnum::ascending(),
-        ));
-        $ranks = array_map(static fn (string $rarity): int => $rank[$rarity], $rarities);
-        $sortedRanks = $ranks;
-        sort($sortedRanks);
-
-        $this->assertSame($sortedRanks, $ranks, 'Reveal cards must be ordered from common to rarest (climax last).');
+        // The "Ouvrir" control is now a link to the dedicated opening page.
+        $this->assertStringContainsString('/boosters/' . $booster->getId() . '/open', $rendered);
     }
 
-    public function testOpeningWithoutInventoryReportsAnError(): void
+    public function testBoosterOverExtensionWithoutPublishedCardsIsNotDrawable(): void
     {
         $client = static::createClient();
         $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
-        $booster = $this->firstPublishedBooster();
 
         $component = $this->createLiveComponent(BoosterHub::class, client: $client);
-        $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
+        $drawable = $component->component()->getDrawableBoosterIds();
 
-        $hub = $component->component();
-        $this->assertNull($hub->opening);
-        $this->assertNotNull($hub->error);
+        $cyberpunk = null;
+        $bleach = null;
+        foreach (static::getContainer()->get(BoosterRepository::class)->findPublished() as $booster) {
+            if (str_starts_with($booster->getExtension()->getName(), 'Cyberpunk')) {
+                $cyberpunk = $booster;
+            }
+            if (str_starts_with($booster->getExtension()->getName(), 'Bleach')) {
+                $bleach = $booster;
+            }
+        }
+
+        $this->assertNotNull($cyberpunk, 'Cyberpunk booster fixture missing.');
+        $this->assertNotNull($bleach, 'Bleach booster fixture missing.');
+        // Cyberpunk has published cards → drawable; Bleach has none → "à venir".
+        $this->assertArrayHasKey((string) $cyberpunk->getId(), $drawable);
+        $this->assertArrayNotHasKey((string) $bleach->getId(), $drawable);
+
+        // The rendered "Ouvrir" control for Bleach is disabled, no scary error needed.
+        $rendered = (string) $component->render();
+        $this->assertStringContainsString('À venir', $rendered);
     }
 
     private function firstPublishedBooster(): \App\Entity\Booster

--- a/tests/Functional/BoosterHubComponentTest.php
+++ b/tests/Functional/BoosterHubComponentTest.php
@@ -104,7 +104,12 @@ final class BoosterHubComponentTest extends WebTestCase
         $component->call('claimBooster', ['boosterId' => (string) $booster->getId()]);
         $component->call('openBooster', ['boosterId' => (string) $booster->getId()]);
 
-        $crawler = new Crawler((string) $component->render());
+        $rendered = (string) $component->render();
+        // 3D pack enhancement is wired in (falls back to the 2D swipe client-side).
+        $this->assertStringContainsString('pack-opening-3d', $rendered);
+        $this->assertStringContainsString('/models/pack-wide.gltf', $rendered);
+
+        $crawler = new Crawler($rendered);
         $rarities = $crawler->filter('.opening__reveal-card')->each(
             static fn (Crawler $node): string => (string) $node->attr('data-rarity'),
         );

--- a/tests/Functional/BoosterOpenPageTest.php
+++ b/tests/Functional/BoosterOpenPageTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Booster;
+use App\Repository\BoosterRepository;
+use App\Service\Booster\BoosterClaimService;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class BoosterOpenPageTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private const string USER_WITHOUT_INVENTORY = '195659530363731968';
+
+    public function testRequiresAuthentication(): void
+    {
+        $client = static::createClient();
+        $booster = $this->firstPublishedBooster();
+
+        $client->request('GET', '/boosters/' . $booster->getId() . '/open');
+
+        $this->assertContains($client->getResponse()->getStatusCode(), [302, 307]);
+    }
+
+    public function testRedirectsToTheGridWhenUserDoesNotOwnThePack(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+
+        $client->request('GET', '/boosters/' . $booster->getId() . '/open');
+
+        $this->assertResponseRedirects('/boosters');
+    }
+
+    public function testRendersTheOpeningPageWhenOwned(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+        static::getContainer()->get(BoosterClaimService::class)->claim($user, $booster);
+
+        $client->request('GET', '/boosters/' . $booster->getId() . '/open');
+
+        $this->assertResponseIsSuccessful();
+        $content = (string) $client->getResponse()->getContent();
+        $this->assertStringContainsString('pack-opening-3d', $content);
+        $this->assertStringContainsString('/models/pack-wide.gltf', $content);
+        $this->assertStringContainsString($booster->getExtension()->getName(), $content);
+        $this->assertStringContainsString('data-testid="open-pack"', $content);
+        $this->assertStringContainsString('data-testid="opening-slots"', $content);
+    }
+
+    private function firstPublishedBooster(): Booster
+    {
+        foreach (static::getContainer()->get(BoosterRepository::class)->findPublished() as $booster) {
+            if (str_starts_with($booster->getExtension()->getName(), 'Cyberpunk')) {
+                return $booster;
+            }
+        }
+
+        $this->fail('Fixture booster for the Cyberpunk extension not found, load the alice fixtures first.');
+    }
+}

--- a/tests/Functional/BoosterOpenPageTest.php
+++ b/tests/Functional/BoosterOpenPageTest.php
@@ -36,6 +36,16 @@ final class BoosterOpenPageTest extends WebTestCase
         $this->assertResponseRedirects('/boosters');
     }
 
+    public function testMalformedBoosterIdIsAPlainNotFound(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+
+        $client->request('GET', '/boosters/not-a-uuid/open');
+
+        $this->assertResponseStatusCodeSame(404);
+    }
+
     public function testRendersTheOpeningPageWhenOwned(): void
     {
         $client = static::createClient();

--- a/tests/Functional/BoosterOpeningComponentTest.php
+++ b/tests/Functional/BoosterOpeningComponentTest.php
@@ -109,7 +109,8 @@ final class BoosterOpeningComponentTest extends WebTestCase
 
         $opening = $component->component();
         $this->assertNull($opening->opening);
-        $this->assertNotNull($opening->error);
+        // The player-facing message is French, not the technical exception message.
+        $this->assertSame('Tu ne possèdes pas ce booster.', $opening->error);
     }
 
     public function testResetAllowsOpeningAnotherPack(): void

--- a/tests/Functional/BoosterOpeningComponentTest.php
+++ b/tests/Functional/BoosterOpeningComponentTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Booster;
+use App\Entity\DiscordUser;
+use App\Entity\UserBooster;
+use App\Entity\UserCard;
+use App\Enum\Entity\CardRarityEnum;
+use App\Repository\BoosterRepository;
+use App\Service\Booster\BoosterClaimService;
+use App\Twig\Components\BoosterOpening;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
+
+final class BoosterOpeningComponentTest extends WebTestCase
+{
+    use InteractsWithLiveComponents;
+    use JwtAuthTrait;
+
+    private const string USER_WITHOUT_INVENTORY = '195659530363731968';
+
+    public function testOpenDrawsCardsDebitsInventoryAndFlagsNewCards(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+        $this->claim($user, $booster);
+
+        $component = $this->createLiveComponent(
+            BoosterOpening::class,
+            data: ['boosterId' => (string) $booster->getId()],
+            client: $client,
+        );
+        $component->call('open');
+
+        $opening = $component->component();
+        $this->assertNull($opening->error);
+        $this->assertNotNull($opening->opening);
+
+        $rendered = (string) $component->render();
+        // Empty-inventory user → every drawn card is new.
+        $this->assertStringContainsString('NOUVEAU', $rendered);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $userBooster = $entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $user, 'booster' => $booster]);
+        $this->assertNotNull($userBooster);
+        $this->assertSame(0, $userBooster->getQuantity());
+
+        $userCards = $entityManager->getRepository(UserCard::class)->findBy(['discordUser' => $user]);
+        $totalCards = array_sum(array_map(static fn (UserCard $userCard): int => $userCard->getQuantity(), $userCards));
+        $this->assertSame($booster->getCardCount(), $totalCards);
+    }
+
+    public function testRevealRendersCardsOrderedRarestLast(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+        $this->claim($user, $booster);
+
+        $component = $this->createLiveComponent(
+            BoosterOpening::class,
+            data: ['boosterId' => (string) $booster->getId()],
+            client: $client,
+        );
+        $component->call('open');
+
+        $rendered = (string) $component->render();
+        // 3D pack is wired into the page.
+        $this->assertStringContainsString('pack-opening-3d', $rendered);
+        $this->assertStringContainsString('/models/pack-wide.gltf', $rendered);
+
+        $crawler = new Crawler($rendered);
+        $rarities = $crawler->filter('.opening__reveal-card')->each(
+            static fn (Crawler $node): string => (string) $node->attr('data-rarity'),
+        );
+
+        $this->assertCount($booster->getCardCount(), $rarities);
+
+        $rank = array_flip(array_map(
+            static fn (CardRarityEnum $rarity): string => $rarity->value,
+            CardRarityEnum::ascending(),
+        ));
+        $ranks = array_map(static fn (string $rarity): int => $rank[$rarity], $rarities);
+        $sortedRanks = $ranks;
+        sort($sortedRanks);
+
+        $this->assertSame($sortedRanks, $ranks, 'Reveal cards must be ordered from common to rarest (climax last).');
+    }
+
+    public function testOpeningWithoutInventoryReportsAnError(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+
+        $component = $this->createLiveComponent(
+            BoosterOpening::class,
+            data: ['boosterId' => (string) $booster->getId()],
+            client: $client,
+        );
+        $component->call('open');
+
+        $opening = $component->component();
+        $this->assertNull($opening->opening);
+        $this->assertNotNull($opening->error);
+    }
+
+    public function testResetAllowsOpeningAnotherPack(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+        $this->claim($user, $booster);
+        $this->claim($user, $booster);
+
+        $component = $this->createLiveComponent(
+            BoosterOpening::class,
+            data: ['boosterId' => (string) $booster->getId()],
+            client: $client,
+        );
+
+        $component->call('open');
+        $this->assertNotNull($component->component()->opening, 'first open');
+
+        $component->call('reset');
+        $this->assertNull($component->component()->opening, 'reset clears the opening');
+
+        $component->call('open');
+        $secondOpening = $component->component();
+        $this->assertNull($secondOpening->error, 'second open must not error');
+        $this->assertNotNull($secondOpening->opening, 'second open');
+    }
+
+    private function claim(DiscordUser $user, Booster $booster): void
+    {
+        static::getContainer()->get(BoosterClaimService::class)->claim($user, $booster);
+    }
+
+    private function firstPublishedBooster(): Booster
+    {
+        foreach (static::getContainer()->get(BoosterRepository::class)->findPublished() as $booster) {
+            if (str_starts_with($booster->getExtension()->getName(), 'Cyberpunk')) {
+                return $booster;
+            }
+        }
+
+        $this->fail('Fixture booster for the Cyberpunk extension not found, load the alice fixtures first.');
+    }
+}


### PR DESCRIPTION
## Phase 3d — Pack 3D (three.js, façon packs.com)

> ⚠️ **Stack sur #43 (3c)** → #42 → #41. Base = `feat/phase-3c-opening-reveal`. Re-target en cascade après merges.

Pose la **3D du pack** par-dessus le reveal de la 3c, en *progressive enhancement* : on déchire le pack en 3D (le modèle récupéré de packs.com sert de placeholder, comme convenu), puis handoff vers le reveal DOM existant.

### Contenu
- **`pack_opening_3d_controller.js`** (Stimulus + three.js, sans React) : monte un `<canvas>`, charge le GLTF (corps rigide + opercule portant la **déchirure cloth-sim pré-bakée en 126 morph targets**), matériau **unlit** (`KHR_materials_unlit`) + texture UV. Le drag **scrub l'animation GLTF** (la déchirure suit le doigt et revient), seuil 130 px, snap-back, tilt au pointeur, mapping `0.4 + 0.6·p`. À 100 % → `pack3d:opened` → le controller `booster-opening` enchaîne whiteout + reveal rarest-last.
- **Strictement additif** : pas de WebGL / échec de chargement / `prefers-reduced-motion` → le **swipe 2D** de la 3c reste en place (la CSS ne masque le pack 2D qu'une fois la 3D prête, via `:has()`).
- `three` + `GLTFLoader` épinglés dans l'importmap.

### Assets (placeholder, hors repo)
- Le modèle packs.com (`pack-wide.gltf/.bin`, `opening.png`) est **dev-only et gitignoré** (`/public/models/`), conformément à ce qu'on avait acté (récup comme base/placeholder, texture refaite chez nous ensuite).
- **`castor sync-pack-model`** le copie depuis le handoff design vers `public/models/`. Sur une machine sans le modèle, l'ouverture retombe proprement sur le pack 2D.
- À venir (art, hors scope code) : notre **texture Violet Arcade** depuis le gabarit UV + notre **modèle via script `bpy`** pour sortir du placeholder. Cf. `refs-packs/RAPPORT-OUVERTURE-3D.md`.

### Tests / qualité
- `make quality` + **67 tests** verts (PHPStan niveau 8 sans baseline). Test : le markup du controller 3D + le chemin du modèle sont rendus dans la scène.
- ⚠️ **Le rendu WebGL lui-même n'a pas pu être vérifié en headless** — à valider visuellement sur `/boosters` (`castor sync-pack-model` d'abord).