### PR TITLE
feat(booster): Phase 3e — aside d'ouverture 2 zones + finitions reveal/rendu 3D

### DIFF
--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -14,9 +14,11 @@ import { Controller } from '@hotwired/stimulus';
  * `pack3d:opened` → `startReveal()`, which presents the drawn cards one at a time
  * in the centre showcase, each face-DOWN with the remaining cards stacked behind
  * it (packs.com style). Clicking the card flips it (3D rotateY) to reveal the
- * face — per-card state machine 'back' → 'flipping' → 'face' — which lights up the
- * matching card in the right-hand set list. Cards run common → rarest (climax
- * last); when the last one is up it surfaces the "open another / back" footer.
+ * face — per-card state machine 'back' → 'flipping' → 'face' — which flips the
+ * matching tile in the right-hand reveal tracker (zone 1 of the aside) from its
+ * back to the real card. Cards run common → rarest (climax last); when the last
+ * one is up it surfaces the "open another / back" footer. The lower aside zone
+ * (set contents: search/sort) is a separate `set-contents` controller.
  *
  * No anime.js: plain `setTimeout` timelines + CSS animations.
  */
@@ -44,7 +46,7 @@ const FLIP_MS = 560;
 export default class extends Controller {
     static targets = [
         'showcase', 'aura', 'label', 'card', 'flip', 'stack', 'next', 'counter',
-        'slot', 'best', 'revealedCount', 'flash', 'foot', 'cta',
+        'track', 'best', 'revealedCount', 'flash', 'foot', 'cta',
     ];
 
     static values = {
@@ -106,6 +108,14 @@ export default class extends Controller {
         // every card face-down again, nothing current
         this.cardTargets?.forEach((node) => node.classList.remove('is-current', 'is-pop'));
         this.flipTargets?.forEach((flip) => flip.classList.remove('is-flipped'));
+        // reveal tracker back to all-mystery
+        this.trackTargets?.forEach((tile) => {
+            tile.classList.remove('is-revealed', 'is-popping');
+            const name = tile.querySelector('.opening__track-name');
+            if (name) {
+                name.textContent = 'Non révélée';
+            }
+        });
         if (this.hasLabelTarget) {
             this.labelTarget.textContent = '';
             this.labelTarget.classList.remove('is-on');
@@ -241,7 +251,7 @@ export default class extends Controller {
         const index = this.revealIndex;
         const isLast = index === this.lastIndex;
         const card = this.cardTargets[index];
-        const { rarity, cardId } = card.dataset;
+        const { rarity } = card.dataset;
         const color = RARITY_COLOR[rarity] || '#ffffff';
         const shiny = SHINY.has(rarity);
 
@@ -270,7 +280,7 @@ export default class extends Controller {
             this._flash(0.24, 140);
         }
 
-        this._lightSlot(cardId);
+        this._revealTrack(index);
         this._bumpBest(rarity);
         this._updateRevealedCount(index + 1);
         this._updateStack(this.lastIndex - index);
@@ -325,8 +335,8 @@ export default class extends Controller {
         this.cardState = 'face';
         this.flipTargets.forEach((flip) => flip.classList.add('is-flipped'));
         this._updateStack(0);
-        this.cardTargets.forEach((card) => {
-            this._lightSlot(card.dataset.cardId);
+        this.cardTargets.forEach((card, index) => {
+            this._revealTrack(index);
             this._bumpBest(card.dataset.rarity);
         });
         this._updateRevealedCount(this.countValue);
@@ -344,19 +354,20 @@ export default class extends Controller {
         }
     }
 
-    // ----------------------------------------------------- set list (aside)
-    _lightSlot(cardId) {
-        const slot = this.slotTargets.find((node) => node.dataset.cardId === cardId);
-        if (!slot) {
+    // -------------------------------------------- reveal tracker (zone 1 aside)
+    // flip the matching tile in the top "Révélé x/N" grid from its back to the
+    // real card, in sync with the centre flip
+    _revealTrack(index) {
+        const tile = this.trackTargets[index];
+        if (!tile) {
             return;
         }
-        slot.classList.add('is-revealed');
-        // reveal the real name (masked as "???" until owned / revealed)
-        const nameEl = slot.querySelector('.opening__slot-name');
-        if (nameEl && slot.dataset.cardName) {
-            nameEl.textContent = slot.dataset.cardName;
+        tile.classList.add('is-revealed');
+        const nameEl = tile.querySelector('.opening__track-name');
+        if (nameEl && nameEl.dataset.name) {
+            nameEl.textContent = nameEl.dataset.name;
         }
-        this._retrigger(slot, 'is-popping');
+        this._retrigger(tile, 'is-popping');
     }
 
     _bumpBest(rarity) {

--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -124,12 +124,14 @@ export default class extends Controller {
         if (this.hasFootTarget) {
             this.footTarget.hidden = true;
         }
-        // the "carte suivante" button only surfaces once a card has been flipped
+        // The "carte suivante" button and counter keep their slot in the flow at all
+        // times — we only fade them (is-shown / is-hidden), never display:none them,
+        // so the centred showcase height stays constant and the card never jumps.
         if (this.hasNextTarget) {
-            this.nextTarget.hidden = true;
+            this.nextTarget.classList.remove('is-shown');
         }
         if (this.hasCounterTarget) {
-            this.counterTarget.hidden = false;
+            this.counterTarget.classList.remove('is-hidden');
             this.counterTarget.textContent = '';
         }
         // restore the tear CTA that _end() hides
@@ -225,7 +227,7 @@ export default class extends Controller {
         this.element.classList.remove('is-shiny');
 
         if (this.hasNextTarget) {
-            this.nextTarget.hidden = true;
+            this.nextTarget.classList.remove('is-shown');
         }
         // cards still waiting behind this one
         this._updateStack(this.lastIndex - index);
@@ -289,7 +291,7 @@ export default class extends Controller {
             // rarest card is last: it stays on screen and the loot/actions surface
             this._end();
         } else if (this.hasNextTarget) {
-            this.nextTarget.hidden = false;
+            this.nextTarget.classList.add('is-shown');
             if (this.hasCounterTarget) {
                 this.counterTarget.textContent = `${index + 1} / ${this.countValue} · CLIQUE POUR CONTINUER`;
             }
@@ -311,10 +313,10 @@ export default class extends Controller {
         // keep the last card on screen; retire the in-showcase prompt + tear CTA
         // and surface the back / open-another actions under the booster
         if (this.hasNextTarget) {
-            this.nextTarget.hidden = true;
+            this.nextTarget.classList.remove('is-shown');
         }
         if (this.hasCounterTarget) {
-            this.counterTarget.hidden = true;
+            this.counterTarget.classList.add('is-hidden');
         }
         if (this.hasCtaTarget) {
             this.ctaTarget.hidden = true;

--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -283,6 +283,7 @@ export default class extends Controller {
         }
 
         this._revealTrack(index);
+        this._unmaskSetTile(card.dataset.cardId);
         this._bumpBest(rarity);
         this._updateRevealedCount(index + 1);
         this._updateStack(this.lastIndex - index);
@@ -339,6 +340,7 @@ export default class extends Controller {
         this._updateStack(0);
         this.cardTargets.forEach((card, index) => {
             this._revealTrack(index);
+            this._unmaskSetTile(card.dataset.cardId);
             this._bumpBest(card.dataset.rarity);
         });
         this._updateRevealedCount(this.countValue);
@@ -370,6 +372,39 @@ export default class extends Controller {
             nameEl.textContent = nameEl.dataset.name;
         }
         this._retrigger(tile, 'is-popping');
+    }
+
+    // -------------------------------------------- set contents (zone 2 aside)
+    // A card FIRST won by this opening is server-rendered masked (`is-pending`,
+    // full data carried in data-* attributes) so the set list cannot spoil the
+    // showcase; flip by flip we promote its tile to the regular owned rendering.
+    _unmaskSetTile(cardId) {
+        if (!cardId) {
+            return;
+        }
+        this.element.querySelectorAll(`.opening__card-tile.is-pending[data-card-id="${cardId}"]`).forEach((tile) => {
+            tile.classList.remove('is-masked', 'is-pending');
+            tile.dataset.name = tile.dataset.pendingName || '';
+            tile.dataset.rarity = tile.dataset.pendingRarity || '';
+            if (tile.dataset.rarity) {
+                tile.style.setProperty('--tile-rar', `var(--rarity-${tile.dataset.rarity})`);
+            }
+            tile.querySelector('.opening__card-back')?.remove();
+            const img = tile.querySelector('img');
+            if (img) {
+                img.hidden = false;
+            }
+            const name = tile.querySelector('.opening__card-name');
+            if (name && name.dataset.revealName) {
+                name.textContent = name.dataset.revealName;
+            }
+            const tier = tile.querySelector('.opening__card-tier');
+            if (tier && tier.dataset.revealTier) {
+                tier.textContent = tier.dataset.revealTier;
+                tier.hidden = false;
+            }
+            this._retrigger(tile, 'is-popping');
+        });
     }
 
     _bumpBest(rarity) {

--- a/assets/controllers/pack_opening_3d_controller.js
+++ b/assets/controllers/pack_opening_3d_controller.js
@@ -183,10 +183,11 @@ export default class extends Controller {
         const center = box.getCenter(new THREE.Vector3());
         const size = box.getSize(new THREE.Vector3());
         this.pack.position.sub(center);
-        // fill most of the frame (packs.com immersion); headroom kept for the peel
-        // flap + idle bob so the pack never clips at the canvas edges
-        const fit = 4.6 / Math.max(size.x, size.y, size.z);
+        // packs.com framing: zoom in and drop the pack so its top stays in frame
+        // while the (less pretty) folded bottom seal falls off the bottom edge
+        const fit = 6 / Math.max(size.x, size.y, size.z);
         this.pack.scale.setScalar(fit);
+        this.pack.position.y -= 1.2; // sink it so the top fills the frame and the bottom seal runs off-canvas
         this.pivot = new THREE.Group();
         this.pivot.add(this.pack);
         this.scene.add(this.pivot);
@@ -227,6 +228,7 @@ export default class extends Controller {
             const texture = await new THREE.TextureLoader().loadAsync(value);
             texture.flipY = false; // glTF UV convention
             texture.colorSpace = THREE.SRGBColorSpace;
+            texture.anisotropy = this.renderer.capabilities.getMaxAnisotropy();
 
             return texture;
         }
@@ -286,8 +288,12 @@ export default class extends Controller {
                 for (let x = 0; x < w; x++) {
                     // x-derivative of gentle vertical creases → R channel
                     const crease = Math.sin((x / w) * Math.PI * 26) * 32;
-                    // dense crimp ridges near the very top edge → extra wobble
-                    const crimp = y < 24 ? Math.sin((x / w) * Math.PI * 80) * 70 : 0;
+                    // Faint crimp ridges fading in toward the very top edge. Kept
+                    // subtle and feathered (no hard cutoff) so the tear band blends
+                    // with the body instead of catching a bright specular rim — the
+                    // old amplitude (70) + sharp y<24 cutoff lit a pale line along it.
+                    const crimpFalloff = Math.max(0, 1 - y / 28); // 1 at the top → 0 by ~28px
+                    const crimp = Math.sin((x / w) * Math.PI * 80) * 16 * crimpFalloff;
                     const i = (y * w + x) * 4;
                     data[i] = Math.max(0, Math.min(255, 128 + crease + crimp));
                     data[i + 1] = 128; // flat in Y
@@ -385,15 +391,19 @@ export default class extends Controller {
             ? await this._loadImage(this.logoUrlValue)
             : null;
 
+        // render the front at 3× — it gets stretched into a tall UV rect, so the
+        // extra resolution keeps the wordmark/logo/art from looking pixelated
+        const scale = 3;
         const front = document.createElement('canvas');
-        front.width = PACK_FRONT_W;
-        front.height = PACK_FRONT_H;
+        front.width = PACK_FRONT_W * scale;
+        front.height = PACK_FRONT_H * scale;
         drawPackFront(front.getContext('2d'), {
             hero,
             logo,
             name: this.hasExtensionNameValue ? this.extensionNameValue : '',
             count: this.hasCardCountValue && this.cardCountValue ? this.cardCountValue : 5,
             fallback,
+            scale,
         });
 
         const sheet = document.createElement('canvas');
@@ -420,6 +430,9 @@ export default class extends Controller {
         const texture = new THREE.CanvasTexture(sheet);
         texture.flipY = false;
         texture.colorSpace = THREE.SRGBColorSpace;
+        // the pack is always tilted in 3D — without anisotropy the angled surface
+        // samples the texture poorly and looks pixelated/aliased even at high res
+        texture.anisotropy = this.renderer.capabilities.getMaxAnisotropy();
 
         return texture;
     }
@@ -486,11 +499,23 @@ export default class extends Controller {
 
     // lean toward the cursor anywhere on screen, normalised against the pack centre
     _trackPointer(event) {
-        const rect = this.element.getBoundingClientRect();
+        const zone = this._zoneEl || (this._zoneEl = this.element.closest('.opening__pack-col') || this.element);
+        const rect = zone.getBoundingClientRect();
+        // only react to the cursor inside the opening zone (left column) — hovering
+        // the set list on the right must not tilt the pack
+        if (
+            event.clientX < rect.left || event.clientX > rect.right
+            || event.clientY < rect.top || event.clientY > rect.bottom
+        ) {
+            this.pointer.x = 0;
+            this.pointer.y = 0;
+
+            return;
+        }
         const centerX = rect.left + rect.width / 2;
         const centerY = rect.top + rect.height / 2;
-        this.pointer.x = Math.max(-1, Math.min(1, (event.clientX - centerX) / (window.innerWidth / 2)));
-        this.pointer.y = Math.max(-1, Math.min(1, (event.clientY - centerY) / (window.innerHeight / 2)));
+        this.pointer.x = Math.max(-1, Math.min(1, (event.clientX - centerX) / (rect.width / 2)));
+        this.pointer.y = Math.max(-1, Math.min(1, (event.clientY - centerY) / (rect.height / 2)));
     }
 
     dragEnd() {

--- a/assets/controllers/pack_opening_3d_controller.js
+++ b/assets/controllers/pack_opening_3d_controller.js
@@ -142,14 +142,14 @@ export default class extends Controller {
         // glossy plastic-film reflections + a key/rim rig. The env hotspot lives
         // top-left, so tilting the pack sweeps a specular highlight across it.
         this.scene.environment = this._buildEnvironment();
-        // Key light kept more frontal (lower Y) so it no longer rakes across the top
-        // tear band and lights it as a bright edge. Rim light dimmed for the same
-        // reason — it was the main source of the pale fringe along the seam.
-        const key = new THREE.DirectionalLight(0xffffff, 1.8);
-        key.position.set(-2.5, 1.6, 5);
+        // glossy foil rig. Key kept slightly more frontal (Y 3.5→2.4) so it doesn't
+        // rake the top edge as hard, but otherwise the punchy original values — the
+        // pale rim that looked like a "border" came from the texture frame, not here.
+        const key = new THREE.DirectionalLight(0xffffff, 2.2);
+        key.position.set(-2.5, 2.4, 4.5);
         this.scene.add(key);
-        const rim = new THREE.DirectionalLight(0xc9a0ff, 0.5);
-        rim.position.set(3, 0.6, -2);
+        const rim = new THREE.DirectionalLight(0xc9a0ff, 1.2);
+        rim.position.set(3, 1.2, -2);
         this.scene.add(rim);
         this.scene.add(new THREE.AmbientLight(0xffffff, 0.3));
 
@@ -171,11 +171,11 @@ export default class extends Controller {
                 emissive: 0xffffff,
                 emissiveMap: texture,
                 emissiveIntensity: 1,
-                metalness: 0.5,
-                roughness: 0.32,
-                clearcoat: 0.7,
-                clearcoatRoughness: 0.38,
-                envMapIntensity: 1.1,
+                metalness: 0.6,
+                roughness: 0.28,
+                clearcoat: 1,
+                clearcoatRoughness: 0.22,
+                envMapIntensity: 1.4,
                 side: THREE.DoubleSide,
             });
             if (normalMap) {
@@ -418,6 +418,7 @@ export default class extends Controller {
             count: this.hasCardCountValue && this.cardCountValue ? this.cardCountValue : 5,
             fallback,
             scale,
+            border: false, // the chrome frame becomes a parasitic light rim on the 3D pack
         });
 
         const sheet = document.createElement('canvas');

--- a/assets/controllers/pack_opening_3d_controller.js
+++ b/assets/controllers/pack_opening_3d_controller.js
@@ -46,6 +46,12 @@ const IDLE_ROCK_AMP = 0.1; // gentle yaw rock (rad)
 const IDLE_ROCK_SPEED = 0.55;
 const BASE_TILT = 0.1; // slight resting lean so the pack never reads flat
 
+// framing: scaled pack height (world units) and the gap kept above the tear band.
+// The view is ~3.78 units tall (camera z=6, fov 35°), so a height of 5.2 fills the
+// frame and overflows the bottom (the seal), which the CSS mask fades out.
+const PACK_FILL_HEIGHT = 5.2;
+const PACK_TOP_MARGIN = 0.15;
+
 // Front-face UV rect baked into the GLTF (U 0.111..0.896, V 0.085..0.996),
 // in pixels on the 1618×6672 sheet with flipY=false → pixelY = (1-V)·H.
 const SHEET = { w: 1618, h: 6672 };
@@ -136,11 +142,14 @@ export default class extends Controller {
         // glossy plastic-film reflections + a key/rim rig. The env hotspot lives
         // top-left, so tilting the pack sweeps a specular highlight across it.
         this.scene.environment = this._buildEnvironment();
-        const key = new THREE.DirectionalLight(0xffffff, 2.2);
-        key.position.set(-2.5, 3.5, 4);
+        // Key light kept more frontal (lower Y) so it no longer rakes across the top
+        // tear band and lights it as a bright edge. Rim light dimmed for the same
+        // reason — it was the main source of the pale fringe along the seam.
+        const key = new THREE.DirectionalLight(0xffffff, 1.8);
+        key.position.set(-2.5, 1.6, 5);
         this.scene.add(key);
-        const rim = new THREE.DirectionalLight(0xc9a0ff, 1.3);
-        rim.position.set(3, 1.5, -2);
+        const rim = new THREE.DirectionalLight(0xc9a0ff, 0.5);
+        rim.position.set(3, 0.6, -2);
         this.scene.add(rim);
         this.scene.add(new THREE.AmbientLight(0xffffff, 0.3));
 
@@ -162,11 +171,11 @@ export default class extends Controller {
                 emissive: 0xffffff,
                 emissiveMap: texture,
                 emissiveIntensity: 1,
-                metalness: 0.6,
-                roughness: 0.28,
-                clearcoat: 1,
-                clearcoatRoughness: 0.18,
-                envMapIntensity: 1.4,
+                metalness: 0.5,
+                roughness: 0.32,
+                clearcoat: 0.7,
+                clearcoatRoughness: 0.38,
+                envMapIntensity: 1.1,
                 side: THREE.DoubleSide,
             });
             if (normalMap) {
@@ -183,11 +192,16 @@ export default class extends Controller {
         const center = box.getCenter(new THREE.Vector3());
         const size = box.getSize(new THREE.Vector3());
         this.pack.position.sub(center);
-        // packs.com framing: zoom in and drop the pack so its top stays in frame
-        // while the (less pretty) folded bottom seal falls off the bottom edge
-        const fit = 6 / Math.max(size.x, size.y, size.z);
+        // packs.com framing: scale on the pack's HEIGHT so the body fills the frame,
+        // then TOP-ALIGN it — the top (pretty tear band) sits just inside the frame
+        // and the taller body runs off the bottom edge, where the folded seal is
+        // masked out in CSS. Computing the sink from the camera frustum keeps the
+        // pack glued to the top whatever the screen/canvas size (no magic offset).
+        const fit = PACK_FILL_HEIGHT / size.y;
         this.pack.scale.setScalar(fit);
-        this.pack.position.y -= 1.2; // sink it so the top fills the frame and the bottom seal runs off-canvas
+        const halfPack = (size.y * fit) / 2;
+        const halfView = this.camera.position.z * Math.tan((this.camera.fov * Math.PI / 180) / 2);
+        this.pack.position.y -= halfPack - (halfView - PACK_TOP_MARGIN);
         this.pivot = new THREE.Group();
         this.pivot.add(this.pack);
         this.scene.add(this.pivot);

--- a/assets/controllers/set_contents_controller.js
+++ b/assets/controllers/set_contents_controller.js
@@ -8,7 +8,6 @@ import { Controller } from '@hotwired/stimulus';
  * hides the existing tiles.
  */
 
-const RANK = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 };
 const DEBOUNCE_MS = 150;
 const SCROLL_TOP_AT = 240; // px scrolled before the "back to top" button shows
 
@@ -74,13 +73,9 @@ export default class extends Controller {
             case 'name-desc':
                 ordered = this.tileTargets.slice().sort((a, b) => b.dataset.name.localeCompare(a.dataset.name));
                 break;
-            case 'rarity':
-                // rarest first, ties broken by name for a stable, readable order
-                ordered = this.tileTargets.slice().sort((a, b) =>
-                    (RANK[b.dataset.rarity] ?? 0) - (RANK[a.dataset.rarity] ?? 0)
-                    || a.dataset.name.localeCompare(b.dataset.name));
-                break;
             default:
+                // "Rareté" — the server already renders the catalog rarest-first, so
+                // the original DOM order captured at connect IS the rarity order
                 ordered = this.defaultOrder;
         }
 

--- a/assets/controllers/set_contents_controller.js
+++ b/assets/controllers/set_contents_controller.js
@@ -1,0 +1,101 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * "Set Contents" — the lower, independently-scrolling zone of the opening aside.
+ * Pure client-side reference catalogue of the whole extension: live search
+ * (debounced), client-side sort, and a scroll-to-top affordance. It owns no
+ * server state — the cards are rendered once and this controller only reorders /
+ * hides the existing tiles.
+ */
+
+const RANK = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 };
+const DEBOUNCE_MS = 150;
+const SCROLL_TOP_AT = 240; // px scrolled before the "back to top" button shows
+
+export default class extends Controller {
+    static targets = ['search', 'clear', 'sort', 'grid', 'tile', 'count', 'empty', 'scroll', 'top'];
+
+    connect() {
+        this.total = this.tileTargets.length;
+        // DOM order at load == the "Numéro" / default order, captured for resets
+        this.defaultOrder = this.tileTargets.slice();
+    }
+
+    disconnect() {
+        clearTimeout(this.debounce);
+    }
+
+    // ----------------------------------------------------------- search
+    filter() {
+        // toggle the clear (✕) button immediately, debounce the actual filtering
+        if (this.hasClearTarget) {
+            this.clearTarget.hidden = this.searchTarget.value.trim() === '';
+        }
+        clearTimeout(this.debounce);
+        this.debounce = setTimeout(() => this._applyFilter(), DEBOUNCE_MS);
+    }
+
+    clear() {
+        this.searchTarget.value = '';
+        if (this.hasClearTarget) {
+            this.clearTarget.hidden = true;
+        }
+        this._applyFilter();
+        this.searchTarget.focus();
+    }
+
+    _applyFilter() {
+        const query = this.searchTarget.value.trim().toLowerCase();
+        let visible = 0;
+        this.tileTargets.forEach((tile) => {
+            const match = query === '' || tile.dataset.name.includes(query);
+            tile.hidden = !match;
+            if (match) {
+                visible++;
+            }
+        });
+        if (this.hasCountTarget) {
+            this.countTarget.textContent = `${visible}`;
+        }
+        if (this.hasEmptyTarget) {
+            this.emptyTarget.hidden = visible !== 0;
+        }
+    }
+
+    // ----------------------------------------------------------- sort
+    sort() {
+        const mode = this.hasSortTarget ? this.sortTarget.value : 'default';
+        let ordered;
+
+        switch (mode) {
+            case 'name-asc':
+                ordered = this.tileTargets.slice().sort((a, b) => a.dataset.name.localeCompare(b.dataset.name));
+                break;
+            case 'name-desc':
+                ordered = this.tileTargets.slice().sort((a, b) => b.dataset.name.localeCompare(a.dataset.name));
+                break;
+            case 'rarity':
+                // rarest first, ties broken by name for a stable, readable order
+                ordered = this.tileTargets.slice().sort((a, b) =>
+                    (RANK[b.dataset.rarity] ?? 0) - (RANK[a.dataset.rarity] ?? 0)
+                    || a.dataset.name.localeCompare(b.dataset.name));
+                break;
+            default:
+                ordered = this.defaultOrder;
+        }
+
+        // re-append in the new order (appendChild moves nodes, no clones)
+        ordered.forEach((tile) => this.gridTarget.appendChild(tile));
+    }
+
+    // ----------------------------------------------------- scroll to top
+    onScroll() {
+        if (this.hasTopTarget && this.hasScrollTarget) {
+            this.topTarget.hidden = this.scrollTarget.scrollTop < SCROLL_TOP_AT;
+        }
+    }
+
+    scrollTop() {
+        this.scrollTarget?.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+}

--- a/assets/lib/pack_front.js
+++ b/assets/lib/pack_front.js
@@ -8,9 +8,14 @@
 export const PACK_FRONT_W = 840;
 export const PACK_FRONT_H = 1300;
 
-export function drawPackFront(c, { hero = null, logo = null, name = 'YOUL', count = 5, fallback = false }) {
+export function drawPackFront(c, { hero = null, logo = null, name = 'YOUL', count = 5, fallback = false, scale = 1 }) {
     const fw = PACK_FRONT_W;
     const fh = PACK_FRONT_H;
+
+    // draw at base 840×1300 coords; `scale` lets the caller render at a higher
+    // resolution (the 3D pack stretches this into a tall UV rect, so it needs the
+    // extra pixels to stay crisp) while the grid tiles draw at 1× and downscale
+    c.scale(scale, scale);
 
     c.fillStyle = '#180a33';
     c.fillRect(0, 0, fw, fh);
@@ -29,20 +34,6 @@ export function drawPackFront(c, { hero = null, logo = null, name = 'YOUL', coun
     vignette.addColorStop(1, 'rgba(11,7,18,0.6)');
     c.fillStyle = vignette;
     c.fillRect(0, 0, fw, fh);
-
-    // subtle holographic sheen
-    c.save();
-    c.globalCompositeOperation = 'screen';
-    c.globalAlpha = 0.1;
-    const sheen = c.createLinearGradient(0, 0, fw, fh);
-    sheen.addColorStop(0, '#ff3db0');
-    sheen.addColorStop(0.5, '#5be4ff');
-    sheen.addColorStop(1, '#a435f0');
-    c.fillStyle = sheen;
-    for (let i = -fh; i < fw; i += 120) {
-        c.fillRect(i, 0, 46, fh);
-    }
-    c.restore();
 
     // brand logo on the fallback front (no extension artwork)
     if (fallback && logo) {

--- a/assets/lib/pack_front.js
+++ b/assets/lib/pack_front.js
@@ -8,7 +8,7 @@
 export const PACK_FRONT_W = 840;
 export const PACK_FRONT_H = 1300;
 
-export function drawPackFront(c, { hero = null, logo = null, name = 'YOUL', count = 5, fallback = false, scale = 1 }) {
+export function drawPackFront(c, { hero = null, logo = null, name = 'YOUL', count = 5, fallback = false, scale = 1, border = true }) {
     const fw = PACK_FRONT_W;
     const fh = PACK_FRONT_H;
 
@@ -66,11 +66,15 @@ export function drawPackFront(c, { hero = null, logo = null, name = 'YOUL', coun
     c.fillText('CARTES', fw - 55, 100);
     c.textAlign = 'center';
 
-    // chrome border
-    c.strokeStyle = 'rgba(201,160,255,.55)';
-    c.lineWidth = 10;
-    roundRect(c, 5, 5, fw - 10, fh - 10, 28);
-    c.stroke();
+    // chrome border — subtle frame on the small grid tiles, but on the big 3D pack
+    // it reads as a parasitic light rim around the artwork, so callers there pass
+    // border:false (the real pack edge comes from the 3D mesh, not the texture)
+    if (border) {
+        c.strokeStyle = 'rgba(201,160,255,.55)';
+        c.lineWidth = 10;
+        roundRect(c, 5, 5, fw - 10, fh - 10, 28);
+        c.stroke();
+    }
 }
 
 function roundRect(c, x, y, w, h, r) {

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -569,6 +569,13 @@
     box-shadow: 0 0 16px -4px var(--tile-rar, transparent), 0 8px 18px #0007;
 }
 .opening__card-art img { display: block; width: 100%; height: 100%; object-fit: cover; }
+/* masked (unowned) tile: card back, no halo, muted label */
+.opening__card-back {
+    position: absolute;
+    inset: 0;
+    background: #140a26 center/cover no-repeat;
+}
+.opening__card-tile.is-masked .opening__card-name { color: #6a5a8a; }
 .opening__card-name {
     margin-top: 6px;
     font-family: 'Space Grotesk', sans-serif;

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -90,18 +90,20 @@
 .opening__pack-stage {
     position: relative;
     /* Size from the smallest of width AND height budgets (single dimension, so the
-     * aspect ratio is never distorted). The `58vh * 0.92` term caps the height to
-     * the viewport so the pack + CTA stay on screen on short displays. */
-    width: min(56vw, 700px, calc(58vh * 0.92));
+     * aspect ratio is never distorted). The `78vh * 0.92` term caps the height to
+     * the viewport so the pack + CTA stay on screen; the height budget is what
+     * usually wins on a desktop, giving a packs.com-sized canvas (~900-1100px on a
+     * tall screen) instead of the cramped ~640px the old 58vh/700px cap produced. */
+    width: min(54vw, 1180px, calc(78vh * 0.92));
     aspect-ratio: .92;
     /* lift the optical centre toward ~44% of the view (it sat ~52% — centred below
-     * the 64px header — which read as "hanging low" with a big void on top) */
-    margin-top: clamp(-96px, -7vh, -24px);
+     * the 64px header); gentler now that the stage is much taller */
+    margin-top: clamp(-64px, -3.5vh, -12px);
 }
 @media (max-width: 900px) {
     .opening__pack-stage {
-        width: min(86vw, 520px, calc(50vh * 0.92));
-        margin-top: -8px;
+        width: min(92vw, 640px, calc(56vh * 0.92));
+        margin-top: -6px;
     }
 }
 
@@ -120,7 +122,11 @@
     display: block;
     width: 100%;
     height: 100%;
-    /* fade the bottom so the model's folded seal blends off-frame (packs.com crops it) */
+    /* Fade the bottom so the model's folded seal blends off-frame (packs.com crops
+     * it). The cut is a PROPORTION of the canvas height: since the stage keeps a
+     * fixed .92 aspect, enlarging it scales the canvas uniformly and this fade
+     * stays pinned to the same spot on the model — no need to retune when the pack
+     * grows. (The mesh is also sunk in JS so the seal mostly runs off-canvas.) */
     -webkit-mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
     mask-image: linear-gradient(to bottom, #000 80%, transparent 100%);
 }

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -566,6 +566,8 @@
     background: #140a26 center/cover no-repeat;
 }
 .opening__card-tile.is-masked .opening__card-name { color: #6a5a8a; }
+/* freshly-won tile promoted by the reveal controller: same pop as the tracker */
+.opening__card-tile.is-popping .opening__card-art { animation: opening-slotPop .5s ease-out; }
 .opening__card-name {
     margin-top: 6px;
     font-family: 'Space Grotesk', sans-serif;

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -182,6 +182,10 @@
     font-family: 'Space Grotesk', sans-serif;
     font-weight: 700;
     font-size: clamp(24px, 3.4vw, 38px);
+    line-height: 1.1;
+    /* reserve one line even while empty (face-down) so the rarity label appearing
+     * on reveal doesn't grow the showcase and shove the card up */
+    min-height: 1.1em;
     text-transform: uppercase;
     letter-spacing: -.02em;
     white-space: nowrap;
@@ -277,7 +281,13 @@
     letter-spacing: .15em;
     text-transform: uppercase;
     cursor: pointer;
+    /* always keep its slot in the flow — fade only, never display:none, so the
+     * centred showcase height stays constant and the card doesn't jump up */
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity .2s ease;
 }
+.opening__next.is-shown { visibility: visible; opacity: 1; }
 .opening__next:hover { border-color: var(--primary); }
 .opening__counter {
     z-index: 2;
@@ -286,7 +296,10 @@
     font-size: 10px;
     letter-spacing: .15em;
     color: #6a5a8a;
+    transition: opacity .2s ease;
 }
+/* hidden at the end of the opening, but its slot stays reserved (no layout shift) */
+.opening__counter.is-hidden { visibility: hidden; opacity: 0; }
 
 /* --------------------------------------------------- CTA / instruction line */
 .opening__cta {

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -548,35 +548,6 @@
 @media (max-width: 560px) { .opening__set-grid { grid-template-columns: repeat(auto-fill, minmax(96px, 1fr)); } }
 
 .opening__card-tile { position: relative; min-width: 0; }
-.opening__card-no {
-    position: absolute;
-    top: 6px;
-    left: 6px;
-    z-index: 2;
-    padding: 1px 5px;
-    border-radius: 3px;
-    background: #000a;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 8px;
-    letter-spacing: .06em;
-    color: #cdbff0;
-    font-variant-numeric: tabular-nums;
-}
-.opening__card-owned {
-    position: absolute;
-    top: 6px;
-    right: 6px;
-    z-index: 2;
-    width: 16px;
-    height: 16px;
-    display: grid;
-    place-items: center;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #5be584, #54a8ff);
-    color: #06210f;
-    font-size: 9px;
-    font-weight: 800;
-}
 .opening__card-art {
     position: relative;
     aspect-ratio: var(--card-aspect, .718);

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -314,95 +314,52 @@
 }
 .opening__skip:hover { border-color: var(--primary); color: var(--primary); }
 
-/* ------------------------------------------------ right: the set list (aside) */
+/* ============================ right: reveal tracker + set contents (aside) */
 .opening__panel {
     flex: 0 0 42%;
     display: flex;
     flex-direction: column;
     border-left: 1px solid #ffffff14;
     background: #140a26;
-    max-height: calc(100vh - 64px);
+    /* fixed so zone 2 can own its own scroll without growing the page */
+    height: calc(100vh - 64px);
+    min-height: 0;
 }
 @media (max-width: 900px) {
-    .opening__panel { flex: 0 0 auto; border-left: none; border-top: 1px solid #ffffff14; max-height: 56vh; }
+    .opening__panel { flex: 0 0 auto; border-left: none; border-top: 1px solid #ffffff14; height: auto; max-height: 72vh; }
 }
-.opening__panel-head {
-    position: sticky;
-    top: 0;
-    z-index: 1;
-    padding: 18px 18px 14px;
-    border-bottom: 1px solid #ffffff12;
-    background: #140a26;
+
+/* ----------------------------------------- zone 1: reveal tracker (pinned) */
+.opening__track {
+    flex: 0 0 auto;
+    padding: 16px 18px;
+    border-bottom: 1px solid #ffffff14;
+    background: #160c29;
 }
-.opening__panel-title {
-    font-family: 'Space Grotesk', sans-serif;
-    font-weight: 700;
-    font-size: 17px;
-    letter-spacing: -.01em;
-    text-transform: uppercase;
-    color: #fff;
-}
-.opening__panel-sub {
-    margin-top: 4px;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 10px;
-    letter-spacing: .08em;
-    color: #6a5a8a;
-}
-.opening__panel-best {
+.opening__track-head {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     justify-content: space-between;
-    margin-top: 9px;
+    gap: 12px;
+    margin-bottom: 12px;
     font-family: 'JetBrains Mono', monospace;
     font-size: 10px;
     letter-spacing: .1em;
     text-transform: uppercase;
     color: #6a5a8a;
 }
-.opening__panel-best span { font-weight: 700; color: #fff; font-variant-numeric: tabular-nums; }
+.opening__track-count b { color: #fff; font-variant-numeric: tabular-nums; }
+.opening__track-count span { color: #b9a8cf; }
+.opening__track-best { text-align: right; }
+.opening__track-best span { display: block; margin-top: 3px; font-weight: 700; color: #fff; }
 
-.opening__slots {
-    flex: 1 1 auto;
-    overflow-y: auto;
-    padding: 18px;
+.opening__track-grid {
     display: grid;
-    /* fixed-ish card size that stays sane whether the set has 3 cards or 300 —
-       auto-fill keeps a small set from blowing up to fill the column */
-    grid-template-columns: repeat(auto-fill, minmax(118px, 1fr));
-    gap: 18px 14px;
-    align-content: start;
-    justify-content: start;
+    grid-template-columns: repeat(var(--track-count, 3), minmax(0, 1fr));
+    gap: 10px;
 }
-@media (max-width: 560px) { .opening__slots { grid-template-columns: repeat(auto-fill, minmax(96px, 1fr)); } }
-
-/* a card in the set: dimmed until it is drawn & revealed, then lit + framed */
-.opening__slot {
-    opacity: 1;
-    transition: opacity .45s ease;
-}
-.opening__slot.is-popping .opening__slot-img { animation: opening-slotPop .5s ease-out; }
-
-/* mystery slots: cards you don't own (and haven't owned) sit behind a card back
- * until you get them — revealed live in this opening, or already in your collection.
- * On reveal the back fades out and cross-dissolves into the real card art. */
-.opening__slot-img img { transition: opacity .4s ease; }
-.opening__slot[data-owned="0"]:not(.is-revealed) .opening__slot-img img { opacity: 0; }
-.opening__slot-back {
-    position: absolute;
-    inset: 0;
-    z-index: 1;
-    background-color: #140a26;
-    background-position: center;
-    background-size: cover;
-    background-repeat: no-repeat;
-    opacity: 0;
-    transition: opacity .4s ease;
-    pointer-events: none;
-}
-.opening__slot[data-owned="0"]:not(.is-revealed) .opening__slot-back { opacity: 1; }
-
-.opening__slot-img {
+.opening__track-tile { min-width: 0; }
+.opening__track-img {
     position: relative;
     aspect-ratio: var(--card-aspect, .718);
     border-radius: 8px;
@@ -410,54 +367,51 @@
     border: 1.5px solid #ffffff14;
     background: #0c0618;
 }
-.opening__slot.is-revealed .opening__slot-img {
+.opening__track-tile.is-revealed .opening__track-img {
     border-color: var(--slot-rar, #ffffff33);
     box-shadow: 0 0 14px -2px var(--slot-rar, transparent), 0 8px 18px #0008;
 }
-.opening__slot-img img { display: block; width: 100%; height: 100%; object-fit: cover; }
-
-/* badges only show once the slot is revealed */
-.opening__slot-holo,
-.opening__slot-qty,
-.opening__slot-new {
+.opening__track-tile.is-popping .opening__track-img { animation: opening-slotPop .5s ease-out; }
+.opening__track-img img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0;
+    transition: opacity .4s ease;
+}
+.opening__track-tile.is-revealed .opening__track-img img { opacity: 1; }
+.opening__track-back {
     position: absolute;
+    inset: 0;
+    z-index: 1;
+    background: #140a26 center/cover no-repeat;
+    opacity: 1;
+    transition: opacity .4s ease;
+    pointer-events: none;
+}
+.opening__track-tile.is-revealed .opening__track-back { opacity: 0; }
+
+.opening__track-holo,
+.opening__track-new {
+    position: absolute;
+    z-index: 2;
     opacity: 0;
     transition: opacity .3s ease .2s;
+    padding: 1px 5px;
+    border-radius: 3px;
     font-family: 'JetBrains Mono', monospace;
     font-weight: 700;
     letter-spacing: .08em;
-}
-.opening__slot.is-revealed .opening__slot-holo,
-.opening__slot.is-revealed .opening__slot-qty,
-.opening__slot.is-revealed .opening__slot-new { opacity: 1; }
-.opening__slot-holo {
-    top: 5px;
-    right: 5px;
-    padding: 1px 5px;
-    border-radius: 3px;
     font-size: 8px;
     color: #0b0712;
-    background: linear-gradient(90deg, #ff3db0, #c9a0ff);
 }
-.opening__slot-qty {
-    bottom: 5px;
-    right: 5px;
-    padding: 1px 6px;
-    border-radius: 3px;
-    font-size: 10px;
-    color: #fff;
-    background: #000a;
-}
-.opening__slot-new {
-    top: 5px;
-    left: 5px;
-    padding: 1px 5px;
-    border-radius: 3px;
-    font-size: 8px;
-    color: #0b0712;
-    background: linear-gradient(90deg, var(--primary, #c9a0ff), #ff3db0);
-}
-.opening__slot-name {
+.opening__track-tile.is-revealed .opening__track-holo,
+.opening__track-tile.is-revealed .opening__track-new { opacity: 1; }
+.opening__track-holo { top: 5px; right: 5px; background: linear-gradient(90deg, #ff3db0, #c9a0ff); }
+.opening__track-new { top: 5px; left: 5px; background: linear-gradient(90deg, var(--primary, #c9a0ff), #ff3db0); }
+
+.opening__track-name {
     margin-top: 6px;
     font-family: 'JetBrains Mono', monospace;
     font-size: 9.5px;
@@ -468,6 +422,199 @@
     overflow: hidden;
     text-overflow: ellipsis;
 }
+
+/* ------------------------------------ zone 2: set contents (own scroll) */
+.opening__set {
+    position: relative;
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+.opening__set-head {
+    flex: 0 0 auto;
+    padding: 14px 18px 12px;
+    border-bottom: 1px solid #ffffff12;
+    background: #140a26;
+}
+.opening__set-titleline {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+.opening__set-title {
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700;
+    font-size: 15px;
+    letter-spacing: -.01em;
+    text-transform: uppercase;
+    color: #fff;
+}
+.opening__set-meta {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px;
+    letter-spacing: .06em;
+    color: #6a5a8a;
+    text-align: right;
+}
+.opening__set-meta span { color: #b9a8cf; font-weight: 700; }
+
+.opening__set-controls { display: flex; gap: 8px; }
+.opening__search { position: relative; flex: 1 1 auto; }
+.opening__search-icon {
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #6a5a8a;
+    font-size: 14px;
+    pointer-events: none;
+}
+.opening__search-input {
+    width: 100%;
+    padding: 8px 30px 8px 28px;
+    background: #0c0618;
+    border: 1px solid #ffffff1f;
+    border-radius: 8px;
+    color: #fff;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 12px;
+}
+.opening__search-input::placeholder { color: #6a5a8a; }
+.opening__search-input:focus { outline: none; border-color: var(--primary, #c9a0ff); }
+.opening__search-input::-webkit-search-cancel-button { display: none; }
+.opening__search-clear {
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 20px;
+    height: 20px;
+    display: grid;
+    place-items: center;
+    background: transparent;
+    border: none;
+    color: #8a7aae;
+    cursor: pointer;
+    font-size: 11px;
+}
+.opening__search-clear:hover { color: #fff; }
+.opening__sort {
+    flex: 0 0 auto;
+    padding: 8px 10px;
+    background: #0c0618;
+    border: 1px solid #ffffff1f;
+    border-radius: 8px;
+    color: #cdbff0;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    cursor: pointer;
+}
+.opening__sort:focus { outline: none; border-color: var(--primary, #c9a0ff); }
+
+.opening__set-scroll {
+    flex: 1 1 auto;
+    overflow-y: auto;
+    padding: 16px 18px 24px;
+    min-height: 0;
+}
+.opening__set-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 16px 12px;
+    align-content: start;
+}
+@media (max-width: 560px) { .opening__set-grid { grid-template-columns: repeat(auto-fill, minmax(96px, 1fr)); } }
+
+.opening__card-tile { position: relative; min-width: 0; }
+.opening__card-no {
+    position: absolute;
+    top: 6px;
+    left: 6px;
+    z-index: 2;
+    padding: 1px 5px;
+    border-radius: 3px;
+    background: #000a;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 8px;
+    letter-spacing: .06em;
+    color: #cdbff0;
+    font-variant-numeric: tabular-nums;
+}
+.opening__card-owned {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    z-index: 2;
+    width: 16px;
+    height: 16px;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #5be584, #54a8ff);
+    color: #06210f;
+    font-size: 9px;
+    font-weight: 800;
+}
+.opening__card-art {
+    position: relative;
+    aspect-ratio: var(--card-aspect, .718);
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1.5px solid var(--tile-rar, #ffffff1f);
+    background: #0c0618;
+    /* rarity halo */
+    box-shadow: 0 0 16px -4px var(--tile-rar, transparent), 0 8px 18px #0007;
+}
+.opening__card-art img { display: block; width: 100%; height: 100%; object-fit: cover; }
+.opening__card-name {
+    margin-top: 6px;
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    color: #e7d8ff;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.opening__card-tier {
+    margin-top: 1px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9px;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+    color: var(--tile-rar, #6a5a8a);
+}
+
+.opening__set-empty {
+    padding: 24px 8px;
+    text-align: center;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    letter-spacing: .06em;
+    color: #6a5a8a;
+}
+
+.opening__set-top {
+    position: absolute;
+    right: 16px;
+    bottom: 16px;
+    z-index: 4;
+    padding: 8px 12px;
+    border-radius: 999px;
+    border: 1px solid #a435f066;
+    background: #1a0f30ee;
+    color: #cdbff0;
+    font-family: 'Space Grotesk', sans-serif;
+    font-weight: 700;
+    font-size: 11px;
+    letter-spacing: .06em;
+    cursor: pointer;
+    box-shadow: 0 6px 18px #0008;
+}
+.opening__set-top:hover { border-color: var(--primary); color: #fff; }
 
 /* end-of-opening actions, grouped right under the revealed card (inside the
  * showcase, which is pointer-events:none once done — so re-enable them here) */
@@ -502,6 +649,7 @@
 .opening__flash.is-on { opacity: var(--flash, .3); }
 
 @media (prefers-reduced-motion: reduce) {
-    .opening__slot,
+    .opening__track-tile,
     .opening__reveal-card { animation: none !important; }
+    .opening__flip { transition: none !important; }
 }

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -96,9 +96,9 @@
      * tall screen) instead of the cramped ~640px the old 58vh/700px cap produced. */
     width: min(54vw, 1180px, calc(78vh * 0.92));
     aspect-ratio: .92;
-    /* lift the optical centre toward ~44% of the view (it sat ~52% — centred below
-     * the 64px header); gentler now that the stage is much taller */
-    margin-top: clamp(-64px, -3.5vh, -12px);
+    /* small upward bias; the pack is now top-aligned inside the canvas (JS), so the
+     * heavy lifting is done there and we only nudge the stage up a touch */
+    margin-top: clamp(-48px, -2.5vh, -8px);
 }
 @media (max-width: 900px) {
     .opening__pack-stage {

--- a/src/Twig/Components/BoosterOpening.php
+++ b/src/Twig/Components/BoosterOpening.php
@@ -155,11 +155,22 @@ final class BoosterOpening extends AbstractController
      * Card ids the user owns (or has owned). The set list masks every other card
      * as "?" so the opening only reveals what the player actually has / gets.
      *
+     * Cards FIRST acquired by the ongoing opening are excluded on purpose: the
+     * inventory is already credited when the component re-renders, and listing
+     * them would spoil the showcase before a single flip. They render as
+     * `is-pending` tiles that the reveal controller unmasks flip by flip.
+     *
      * @return array<string, true> card id => true
      */
     public function getOwnedCardIds(): array
     {
-        return array_fill_keys($this->userCardRepository->findOwnedCardIds($this->getDiscordUser()), true);
+        $owned = array_fill_keys($this->userCardRepository->findOwnedCardIds($this->getDiscordUser()), true);
+
+        foreach ($this->newCardIds as $cardId) {
+            unset($owned[$cardId]);
+        }
+
+        return $owned;
     }
 
     public function getOwnedCount(): int

--- a/src/Twig/Components/BoosterOpening.php
+++ b/src/Twig/Components/BoosterOpening.php
@@ -78,8 +78,8 @@ final class BoosterOpening extends AbstractController
     }
 
     /**
-     * The extension's published cards ("set contents"), rarest last so the aside
-     * reads common → legendary like the reveal order.
+     * The extension's published cards ("set contents"), rarest FIRST then name —
+     * this is also the catalog order the aside numbers the cards by (n°1 = rarest).
      *
      * @return list<Card>
      */
@@ -90,8 +90,8 @@ final class BoosterOpening extends AbstractController
 
         usort(
             $cards,
-            static fn (Card $a, Card $b): int => [$rank[$a->getRarity()->value], $a->getName()]
-                <=> [$rank[$b->getRarity()->value], $b->getName()],
+            static fn (Card $a, Card $b): int => ($rank[$b->getRarity()->value] <=> $rank[$a->getRarity()->value])
+                ?: $a->getName() <=> $b->getName(),
         );
 
         return $cards;

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -80,7 +80,7 @@
                     </div>
 
                     <button type="button" class="opening__next" data-booster-opening-target="next"
-                            data-action="booster-opening#advance" hidden>Carte suivante ▸</button>
+                            data-action="booster-opening#advance">Carte suivante ▸</button>
                     <p class="opening__counter" data-booster-opening-target="counter"></p>
 
                     {# end-of-opening actions, grouped with the revealed card #}

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -196,10 +196,9 @@
                         </div>
                         <select class="opening__sort" aria-label="Trier"
                                 data-set-contents-target="sort" data-action="set-contents#sort">
-                            <option value="default">Numéro</option>
+                            <option value="default">Rareté</option>
                             <option value="name-asc">Nom (A→Z)</option>
                             <option value="name-desc">Nom (Z→A)</option>
-                            <option value="rarity">Rareté</option>
                         </select>
                     </div>
                 </header>
@@ -212,16 +211,11 @@
                             {% set isOwned = ownedCardIds[card.id ~ ''] is defined %}
                             {# cards the user doesn't own stay hidden behind a card back
                                (no art, no name, no rarity hint) — pure checklist mystery #}
-                            <article class="opening__card-tile{{ isOwned ? ' is-owned' : ' is-masked' }}"
+                            <article class="opening__card-tile{{ isOwned ? '' : ' is-masked' }}"
                                      data-set-contents-target="tile"
                                      data-name="{{ isOwned ? card.name|lower : '' }}"
-                                     data-number="{{ loop.index }}"
                                      data-rarity="{{ isOwned ? rarity : '' }}"
                                      {% if isOwned %}style="--tile-rar: var(--rarity-{{ rarity }});"{% endif %}>
-                                <span class="opening__card-no">{{ loop.index }}/{{ catalog|length }}</span>
-                                {% if isOwned %}
-                                    <span class="opening__card-owned" title="Dans ta collection">✓</span>
-                                {% endif %}
                                 <div class="opening__card-art">
                                     {% if isOwned %}
                                         <img loading="lazy" src="{{ vich_uploader_asset(card) }}" alt="{{ card.name }}"

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -125,54 +125,117 @@
 
         </section>
 
-        {# ============================================ RIGHT: the set contents #}
+        {# ===================================== RIGHT: reveal tracker + set contents #}
         <aside class="opening__panel" data-testid="opening-aside">
-            <header class="opening__panel-head">
-                <p class="opening__panel-title">{{ extension.name }}</p>
-                <p class="opening__panel-sub">
-                    {{ booster.cardCount }} cartes / pack · {{ catalog|length }} dans l'extension
-                </p>
-                <p class="opening__panel-best">
-                    Meilleure trouvaille
-                    <span data-booster-opening-target="best">—</span>
-                </p>
-                {% if opening %}
-                    <p class="opening__panel-best">
-                        Révélé
-                        <span><span data-booster-opening-target="revealedCount">0</span> / {{ revealCards|length }}</span>
-                    </p>
-                {% endif %}
-            </header>
 
-            <div class="opening__slots" data-testid="opening-slots">
-                {% for card in catalog %}
-                    {% set info = drawn[card.id ~ '']|default(null) %}
-                    {# "owned" for masking = had it BEFORE this opening (so freshly drawn
-                       cards stay a mystery until the reveal lights them up) #}
-                    {% set isOwned = (ownedCardIds[card.id ~ ''] is defined) and (card.id ~ '' not in newCardIds) %}
-                    <div class="opening__slot"
-                         data-booster-opening-target="slot"
-                         data-card-id="{{ card.id }}"
-                         data-card-name="{{ card.name }}"
-                         data-rarity="{{ card.rarity.value }}"
-                         data-drawn="{{ info ? '1' : '0' }}"
-                         data-owned="{{ isOwned ? '1' : '0' }}"
-                         style="--slot-rar: var(--rarity-{{ card.rarity.value }});">
-                        <div class="opening__slot-img">
-                            <span class="opening__slot-back" aria-hidden="true"
-                                  style="background-image: url('{{ asset('images/card-back.svg') }}');"></span>
-                            <img src="{{ vich_uploader_asset(card) }}" alt="{{ isOwned ? card.name : '' }}"
-                                 onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
-                            {% if info %}
-                                {% if info.holoQuantity > 0 %}<span class="opening__slot-holo">HOLO</span>{% endif %}
-                                {% if info.quantity > 1 %}<span class="opening__slot-qty">×{{ info.quantity }}</span>{% endif %}
-                                {% if info.new %}<span class="opening__slot-new">NOUVEAU</span>{% endif %}
-                            {% endif %}
-                        </div>
-                        <p class="opening__slot-name">{{ isOwned ? card.name : 'Non révélée' }}</p>
+            {# ---- Zone 1: reveal tracker (pinned, the pack being opened) ---- #}
+            <section class="opening__track" data-testid="opening-track">
+                <header class="opening__track-head">
+                    <p class="opening__track-count">
+                        Révélé
+                        <span><b data-booster-opening-target="revealedCount">0</b> / {{ booster.cardCount }} cartes</span>
+                    </p>
+                    <p class="opening__track-best">
+                        Meilleure trouvaille
+                        <span data-booster-opening-target="best">—</span>
+                    </p>
+                </header>
+
+                <div class="opening__track-grid" style="--track-count: {{ booster.cardCount }};">
+                    {% if opening %}
+                        {% for reveal in revealCards %}
+                            {% set rarity = reveal.card.rarity.value %}
+                            <div class="opening__track-tile"
+                                 data-booster-opening-target="track"
+                                 data-reveal-index="{{ loop.index0 }}"
+                                 style="--slot-rar: var(--rarity-{{ rarity }});">
+                                <div class="opening__track-img">
+                                    <span class="opening__track-back" aria-hidden="true"
+                                          style="background-image: url('{{ asset('images/card-back.svg') }}');"></span>
+                                    <img loading="lazy" src="{{ vich_uploader_asset(reveal.card) }}" alt=""
+                                         onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
+                                    {% if reveal.holo %}<span class="opening__track-holo">HOLO</span>{% endif %}
+                                    {% if reveal.card.id ~ '' in newCardIds %}<span class="opening__track-new">NOUVEAU</span>{% endif %}
+                                </div>
+                                <p class="opening__track-name" data-name="{{ reveal.card.name }}">Non révélée</p>
+                            </div>
+                        {% endfor %}
+                    {% else %}
+                        {% for i in 1..booster.cardCount %}
+                            <div class="opening__track-tile is-empty">
+                                <div class="opening__track-img">
+                                    <span class="opening__track-back" aria-hidden="true"
+                                          style="background-image: url('{{ asset('images/card-back.svg') }}');"></span>
+                                </div>
+                                <p class="opening__track-name">Non révélée</p>
+                            </div>
+                        {% endfor %}
+                    {% endif %}
+                </div>
+            </section>
+
+            {# ---- Zone 2: full set contents (search + sort, scrolls on its own) ---- #}
+            <section class="opening__set" data-controller="set-contents">
+                <header class="opening__set-head">
+                    <div class="opening__set-titleline">
+                        <p class="opening__set-title">Contenu du set</p>
+                        <p class="opening__set-meta">
+                            <span data-set-contents-target="count">{{ catalog|length }}</span> cartes · {{ extension.name }}
+                        </p>
                     </div>
-                {% endfor %}
-            </div>
+                    <div class="opening__set-controls">
+                        <div class="opening__search">
+                            <span class="opening__search-icon" aria-hidden="true">⌕</span>
+                            <input type="search" class="opening__search-input"
+                                   placeholder="Rechercher des cartes…"
+                                   data-set-contents-target="search"
+                                   data-action="input->set-contents#filter">
+                            <button type="button" class="opening__search-clear" hidden
+                                    data-set-contents-target="clear"
+                                    data-action="set-contents#clear" aria-label="Effacer la recherche">✕</button>
+                        </div>
+                        <select class="opening__sort" aria-label="Trier"
+                                data-set-contents-target="sort" data-action="set-contents#sort">
+                            <option value="default">Numéro</option>
+                            <option value="name-asc">Nom (A→Z)</option>
+                            <option value="name-desc">Nom (Z→A)</option>
+                            <option value="rarity">Rareté</option>
+                        </select>
+                    </div>
+                </header>
+
+                <div class="opening__set-scroll" data-set-contents-target="scroll"
+                     data-action="scroll->set-contents#onScroll">
+                    <div class="opening__set-grid" data-set-contents-target="grid" data-testid="opening-slots">
+                        {% for card in catalog %}
+                            {% set rarity = card.rarity.value %}
+                            {% set isOwned = ownedCardIds[card.id ~ ''] is defined %}
+                            <article class="opening__card-tile{{ isOwned ? ' is-owned' }}"
+                                     data-set-contents-target="tile"
+                                     data-name="{{ card.name|lower }}"
+                                     data-number="{{ loop.index }}"
+                                     data-rarity="{{ rarity }}"
+                                     style="--tile-rar: var(--rarity-{{ rarity }});">
+                                <span class="opening__card-no">{{ loop.index }}/{{ catalog|length }}</span>
+                                {% if isOwned %}<span class="opening__card-owned" title="Dans ta collection">✓</span>{% endif %}
+                                <div class="opening__card-art">
+                                    <img loading="lazy" src="{{ vich_uploader_asset(card) }}" alt="{{ card.name }}"
+                                         onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
+                                </div>
+                                <p class="opening__card-name">{{ card.name }}</p>
+                                <p class="opening__card-tier">{{ rarityLabels[rarity]|default(rarity) }}</p>
+                            </article>
+                        {% endfor %}
+                    </div>
+                    <p class="opening__set-empty" data-set-contents-target="empty" hidden>
+                        Aucune carte ne correspond à ta recherche.
+                    </p>
+                </div>
+
+                <button type="button" class="opening__set-top" hidden
+                        data-set-contents-target="top" data-action="set-contents#scrollTop"
+                        aria-label="Remonter en haut de la liste">↑ Haut</button>
+            </section>
 
         </aside>
 

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -208,26 +208,36 @@
                     <div class="opening__set-grid" data-set-contents-target="grid" data-testid="opening-slots">
                         {% for card in catalog %}
                             {% set rarity = card.rarity.value %}
-                            {% set isOwned = ownedCardIds[card.id ~ ''] is defined %}
+                            {% set cardId = card.id ~ '' %}
+                            {% set isOwned = ownedCardIds[cardId] is defined %}
+                            {% set isPending = not isOwned and cardId in newCardIds %}
                             {# cards the user doesn't own stay hidden behind a card back
-                               (no art, no name, no rarity hint) — pure checklist mystery #}
-                            <article class="opening__card-tile{{ isOwned ? '' : ' is-masked' }}"
+                               (no art, no name, no rarity hint) — pure checklist mystery.
+                               Cards FIRST won by the ongoing opening are masked too
+                               (is-pending) and unmasked flip by flip by the reveal
+                               controller, so this list never spoils the showcase. #}
+                            <article class="opening__card-tile{{ isOwned ? '' : ' is-masked' }}{{ isPending ? ' is-pending' }}"
                                      data-set-contents-target="tile"
                                      data-name="{{ isOwned ? card.name|lower : '' }}"
                                      data-rarity="{{ isOwned ? rarity : '' }}"
+                                     {% if isPending %}data-card-id="{{ cardId }}" data-pending-name="{{ card.name|lower }}" data-pending-rarity="{{ rarity }}"{% endif %}
                                      {% if isOwned %}style="--tile-rar: var(--rarity-{{ rarity }});"{% endif %}>
                                 <div class="opening__card-art">
-                                    {% if isOwned %}
-                                        <img loading="lazy" src="{{ vich_uploader_asset(card) }}" alt="{{ card.name }}"
+                                    {% if isOwned or isPending %}
+                                        <img loading="lazy" src="{{ vich_uploader_asset(card) }}" alt="{{ isOwned ? card.name : '' }}"
+                                             {% if isPending %}hidden{% endif %}
                                              onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
-                                    {% else %}
+                                    {% endif %}
+                                    {% if not isOwned %}
                                         <span class="opening__card-back" aria-hidden="true"
                                               style="background-image: url('{{ asset('images/card-back.svg') }}');"></span>
                                     {% endif %}
                                 </div>
-                                <p class="opening__card-name">{{ isOwned ? card.name : 'Non révélée' }}</p>
+                                <p class="opening__card-name"{% if isPending %} data-reveal-name="{{ card.name }}"{% endif %}>{{ isOwned ? card.name : 'Non révélée' }}</p>
                                 {% if isOwned %}
                                     <p class="opening__card-tier">{{ rarityLabels[rarity]|default(rarity) }}</p>
+                                {% elseif isPending %}
+                                    <p class="opening__card-tier" hidden data-reveal-tier="{{ rarityLabels[rarity]|default(rarity) }}"></p>
                                 {% endif %}
                             </article>
                         {% endfor %}

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -210,20 +210,31 @@
                         {% for card in catalog %}
                             {% set rarity = card.rarity.value %}
                             {% set isOwned = ownedCardIds[card.id ~ ''] is defined %}
-                            <article class="opening__card-tile{{ isOwned ? ' is-owned' }}"
+                            {# cards the user doesn't own stay hidden behind a card back
+                               (no art, no name, no rarity hint) — pure checklist mystery #}
+                            <article class="opening__card-tile{{ isOwned ? ' is-owned' : ' is-masked' }}"
                                      data-set-contents-target="tile"
-                                     data-name="{{ card.name|lower }}"
+                                     data-name="{{ isOwned ? card.name|lower : '' }}"
                                      data-number="{{ loop.index }}"
-                                     data-rarity="{{ rarity }}"
-                                     style="--tile-rar: var(--rarity-{{ rarity }});">
+                                     data-rarity="{{ isOwned ? rarity : '' }}"
+                                     {% if isOwned %}style="--tile-rar: var(--rarity-{{ rarity }});"{% endif %}>
                                 <span class="opening__card-no">{{ loop.index }}/{{ catalog|length }}</span>
-                                {% if isOwned %}<span class="opening__card-owned" title="Dans ta collection">✓</span>{% endif %}
+                                {% if isOwned %}
+                                    <span class="opening__card-owned" title="Dans ta collection">✓</span>
+                                {% endif %}
                                 <div class="opening__card-art">
-                                    <img loading="lazy" src="{{ vich_uploader_asset(card) }}" alt="{{ card.name }}"
-                                         onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
+                                    {% if isOwned %}
+                                        <img loading="lazy" src="{{ vich_uploader_asset(card) }}" alt="{{ card.name }}"
+                                             onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
+                                    {% else %}
+                                        <span class="opening__card-back" aria-hidden="true"
+                                              style="background-image: url('{{ asset('images/card-back.svg') }}');"></span>
+                                    {% endif %}
                                 </div>
-                                <p class="opening__card-name">{{ card.name }}</p>
-                                <p class="opening__card-tier">{{ rarityLabels[rarity]|default(rarity) }}</p>
+                                <p class="opening__card-name">{{ isOwned ? card.name : 'Non révélée' }}</p>
+                                {% if isOwned %}
+                                    <p class="opening__card-tier">{{ rarityLabels[rarity]|default(rarity) }}</p>
+                                {% endif %}
                             </article>
                         {% endfor %}
                     </div>

--- a/tests/Functional/BoosterOpeningComponentTest.php
+++ b/tests/Functional/BoosterOpeningComponentTest.php
@@ -57,6 +57,71 @@ final class BoosterOpeningComponentTest extends WebTestCase
         $this->assertSame($booster->getCardCount(), $totalCards);
     }
 
+    public function testSetContentsMasksUnownedCardsWithoutLeakingThem(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+
+        $component = $this->createLiveComponent(
+            BoosterOpening::class,
+            data: ['boosterId' => (string) $booster->getId()],
+            client: $client,
+        );
+
+        $crawler = new Crawler((string) $component->render());
+        $tiles = $crawler->filter('.opening__card-tile');
+        $this->assertGreaterThan(0, $tiles->count());
+
+        // Empty inventory, nothing opened yet: every tile is masked and carries
+        // no name, rarity, artwork url or unmask payload in the DOM.
+        $tiles->each(function (Crawler $tile): void {
+            $this->assertStringContainsString('is-masked', (string) $tile->attr('class'));
+            $this->assertSame('', (string) $tile->attr('data-name'));
+            $this->assertSame('', (string) $tile->attr('data-rarity'));
+            $this->assertNull($tile->attr('data-card-id'));
+            $this->assertSame('Non révélée', trim($tile->filter('.opening__card-name')->text()));
+            $this->assertCount(0, $tile->filter('img'));
+        });
+    }
+
+    public function testFreshlyDrawnCardsStayMaskedAsPendingUntilTheFlip(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+        $this->claim($user, $booster);
+
+        $component = $this->createLiveComponent(
+            BoosterOpening::class,
+            data: ['boosterId' => (string) $booster->getId()],
+            client: $client,
+        );
+        $component->call('open');
+
+        $crawler = new Crawler((string) $component->render());
+
+        // Empty inventory before the opening: every drawn card is new, so the set
+        // list must not unmask a single tile server-side — the reveal controller
+        // promotes the is-pending tiles flip by flip.
+        $this->assertCount(0, $crawler->filter('.opening__card-tile:not(.is-masked)'));
+
+        $pending = $crawler->filter('.opening__card-tile.is-pending');
+        $newCardIds = $component->component()->newCardIds;
+        $this->assertCount(\count($newCardIds), $pending);
+
+        $pending->each(function (Crawler $tile) use ($newCardIds): void {
+            // masked presentation…
+            $this->assertSame('', (string) $tile->attr('data-name'));
+            $this->assertSame('Non révélée', trim($tile->filter('.opening__card-name')->text()));
+            // …but the unmask payload is on board for the flip
+            $this->assertContains((string) $tile->attr('data-card-id'), $newCardIds);
+            $this->assertNotSame('', (string) $tile->attr('data-pending-name'));
+            $this->assertNotSame('', (string) $tile->attr('data-pending-rarity'));
+            $this->assertNotNull($tile->filter('img')->attr('hidden'), 'Pending artwork must stay hidden until the flip.');
+        });
+    }
+
     public function testRevealRendersCardsOrderedRarestLast(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
Suite de la phase 3d (stackée dessus). Refonte du panneau latéral d'ouverture façon packs.com + finitions.

## Aside à deux zones
- Zone 1 (épinglée) : suivi du reveal — dos « Non révélée » qui se retournent en synchro au flip de chaque carte (badges HOLO/NOUVEAU), compteur « Révélé x/N » + meilleure trouvaille.
- Zone 2 (scroll indépendant) : contenu complet du set — recherche live (debounce) + clear, tri (Rareté / Nom A→Z / Z→A), bouton « remonter en haut », lazy-loading. Cartes non possédées masquées par un dos.
- Tri du set par rareté décroissante (rarest first) ; numéro de carte et pastille « possédée » retirés (non pertinents).

## Finitions reveal / rendu 3D du pack (arrivées pendant cette phase)
- Pack plus grand dans le canvas + calage top-align (fini le « pend trop bas ») ; masque du bas conservé.
- Suppression du liseré clair sur la bande (c'était la bordure chrome du front + lumières) ; foil d'origine restauré.
- Plus de saut de la carte à l'apparition de « Carte suivante » (espace réservé).

Tests fonctionnels mis à jour, suite verte.