### PR TITLE
feat(collection): Phase 3f — slug d'extension (route param) + tri par rareté

### DIFF
--- a/config/packages/stof_doctrine_extensions.yaml
+++ b/config/packages/stof_doctrine_extensions.yaml
@@ -5,3 +5,4 @@ stof_doctrine_extensions:
     orm:
         default:
             timestampable: true
+            sluggable: true

--- a/migrations/Version20260617120000.php
+++ b/migrations/Version20260617120000.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds extension.slug (Gedmo-backed, unique) used as a clean route param for the
+ * collection / extension pages instead of the raw UUID. Existing rows are
+ * backfilled from their name (deduplicated) before the NOT NULL + unique index.
+ */
+final class Version20260617120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add unique extension.slug, backfilled from the name';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // existing extensions to backfill (column does not exist yet → read name only)
+        $extensions = $this->connection->fetchAllAssociative('SELECT id, name FROM extension');
+
+        $this->addSql('ALTER TABLE extension ADD slug VARCHAR(255) DEFAULT NULL');
+
+        $slugify = static function (string $text): string {
+            $text = strtolower(trim($text));
+            $ascii = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $text);
+            $text = false !== $ascii ? $ascii : $text;
+            $text = preg_replace('/[^a-z0-9]+/', '-', $text) ?? '';
+
+            return trim($text, '-');
+        };
+
+        $seen = [];
+        foreach ($extensions as $extension) {
+            $base = $slugify((string) $extension['name']);
+            if ('' === $base) {
+                $base = 'extension';
+            }
+
+            $slug = $base;
+            $suffix = 2;
+            while (isset($seen[$slug])) {
+                $slug = $base . '-' . $suffix++;
+            }
+            $seen[$slug] = true;
+
+            $this->addSql('UPDATE extension SET slug = ? WHERE id = ?', [$slug, $extension['id']]);
+        }
+
+        $this->addSql('ALTER TABLE extension ALTER COLUMN slug SET NOT NULL');
+        $this->addSql('CREATE UNIQUE INDEX uniq_extension_slug ON extension (slug)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_extension_slug');
+        $this->addSql('ALTER TABLE extension DROP slug');
+    }
+}

--- a/src/Controller/CollectionController.php
+++ b/src/Controller/CollectionController.php
@@ -10,14 +10,16 @@ use App\Repository\ExtensionRepository;
 use App\Repository\UserCardRepository;
 use App\Service\Booster\BoosterClaimQuotaInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 class CollectionController extends AbstractController
 {
-    #[Route('/collection/{slug}', name: 'collection', defaults: ['slug' => null], requirements: ['slug' => '[a-z0-9-]+'])]
+    #[Route('/collection/{slug}', name: 'collection', requirements: ['slug' => '[a-z0-9-]+'], defaults: ['slug' => null])]
     public function __invoke(
+        Request $request,
         #[CurrentUser] DiscordUser $user,
         UserCardRepository $userCardRepository,
         ExtensionRepository $extensionRepository,
@@ -25,6 +27,19 @@ class CollectionController extends AbstractController
         ?string $slug = null,
     ): Response {
         $extensions = $extensionRepository->findPublishedWithPublishedCardCount();
+
+        // Legacy pre-slug urls (/collection?extension=<uuid>): redirect to the slug
+        // route instead of silently ignoring the filter; unknown id stays a 404,
+        // the contract the query-param version already had.
+        $legacyId = $request->query->getString('extension');
+        if (null === $slug && '' !== $legacyId) {
+            return $this->redirectToRoute(
+                'collection',
+                ['slug' => $this->resolveLegacyExtensionId($legacyId, $extensions)->getSlug()],
+                Response::HTTP_MOVED_PERMANENTLY,
+            );
+        }
+
         $currentExtension = $this->resolveExtensionFilter($slug, $extensions);
 
         $ownedByExtension = $userCardRepository->countOwnedGroupedByExtension($user);
@@ -54,6 +69,20 @@ class CollectionController extends AbstractController
             'remainingClaims' => $boosterClaimQuota->getRemainingClaims($user),
             'dailyLimit' => BoosterClaimQuotaInterface::DAILY_LIMIT,
         ]);
+    }
+
+    /**
+     * @param list<array{extension: Extension, cardCount: int}> $extensions
+     */
+    private function resolveLegacyExtensionId(string $id, array $extensions): Extension
+    {
+        foreach ($extensions as $item) {
+            if (((string) $item['extension']->getId()) === $id) {
+                return $item['extension'];
+            }
+        }
+
+        throw $this->createNotFoundException(\sprintf('Unknown extension "%s".', $id));
     }
 
     /**

--- a/src/Controller/CollectionController.php
+++ b/src/Controller/CollectionController.php
@@ -10,23 +10,22 @@ use App\Repository\ExtensionRepository;
 use App\Repository\UserCardRepository;
 use App\Service\Booster\BoosterClaimQuotaInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 class CollectionController extends AbstractController
 {
-    #[Route('/collection', name: 'collection')]
+    #[Route('/collection/{slug}', name: 'collection', defaults: ['slug' => null], requirements: ['slug' => '[a-z0-9-]+'])]
     public function __invoke(
-        Request $request,
         #[CurrentUser] DiscordUser $user,
         UserCardRepository $userCardRepository,
         ExtensionRepository $extensionRepository,
         BoosterClaimQuotaInterface $boosterClaimQuota,
+        ?string $slug = null,
     ): Response {
         $extensions = $extensionRepository->findPublishedWithPublishedCardCount();
-        $currentExtension = $this->resolveExtensionFilter($request, $extensions);
+        $currentExtension = $this->resolveExtensionFilter($slug, $extensions);
 
         $ownedByExtension = $userCardRepository->countOwnedGroupedByExtension($user);
 
@@ -58,26 +57,23 @@ class CollectionController extends AbstractController
     }
 
     /**
-     * Resolves the ?extension= query parameter against the published
-     * extensions already loaded: no Doctrine lookup, so a malformed uuid is
-     * a plain 404 instead of a conversion error.
+     * Resolves the {slug} route parameter against the published extensions already
+     * loaded: no extra Doctrine lookup, and an unknown slug is a plain 404.
      *
      * @param list<array{extension: Extension, cardCount: int}> $extensions
      */
-    private function resolveExtensionFilter(Request $request, array $extensions): ?Extension
+    private function resolveExtensionFilter(?string $slug, array $extensions): ?Extension
     {
-        $extensionId = $request->query->getString('extension');
-
-        if ('' === $extensionId) {
+        if (null === $slug || '' === $slug) {
             return null;
         }
 
         foreach ($extensions as $item) {
-            if ((string) $item['extension']->getId() === $extensionId) {
+            if ($item['extension']->getSlug() === $slug) {
                 return $item['extension'];
             }
         }
 
-        throw $this->createNotFoundException(\sprintf('Unknown extension "%s".', $extensionId));
+        throw $this->createNotFoundException(\sprintf('Unknown extension "%s".', $slug));
     }
 }

--- a/src/Entity/Extension.php
+++ b/src/Entity/Extension.php
@@ -12,6 +12,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -19,6 +20,7 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
 #[Vich\Uploadable]
 #[ORM\Entity(repositoryClass: ExtensionRepository::class)]
+#[ORM\UniqueConstraint(name: 'uniq_extension_slug', columns: ['slug'])]
 class Extension implements \Stringable
 {
     use IdUuidTrait;
@@ -27,6 +29,14 @@ class Extension implements \Stringable
     #[Assert\Length(max: 255)]
     #[ORM\Column(length: 255)]
     private string $name;
+
+    /**
+     * URL-friendly slug generated from the name (Gedmo), used as a clean route
+     * param for the collection / extension pages instead of the raw UUID.
+     */
+    #[Gedmo\Slug(fields: ['name'])]
+    #[ORM\Column(length: 255)]
+    private string $slug;
 
     #[ORM\Column(type: 'text')]
     private string $description;
@@ -103,6 +113,11 @@ class Extension implements \Stringable
         $this->name = $name;
 
         return $this;
+    }
+
+    public function getSlug(): string
+    {
+        return $this->slug;
     }
 
     public function getDescription(): string

--- a/src/Repository/UserCardRepository.php
+++ b/src/Repository/UserCardRepository.php
@@ -7,6 +7,7 @@ namespace App\Repository;
 use App\Entity\DiscordUser;
 use App\Entity\Extension;
 use App\Entity\UserCard;
+use App\Enum\Entity\CardRarityEnum;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -21,8 +22,8 @@ class UserCardRepository extends ServiceEntityRepository
     }
 
     /**
-     * Owned inventory entries (most recently obtained first), with the card
-     * and its extension eagerly hydrated for the collection grid.
+     * Owned inventory entries with the card and its extension eagerly hydrated for
+     * the collection grid, sorted by rarity (rarest first) then name.
      *
      * @return list<UserCard>
      */
@@ -36,7 +37,6 @@ class UserCardRepository extends ServiceEntityRepository
             ->andWhere('uc.discordUser = :user')
             ->andWhere('uc.quantity > 0 OR uc.holoQuantity > 0')
             ->setParameter('user', $discordUser)
-            ->orderBy('uc.updatedAt', 'DESC')
         ;
 
         if ($extension instanceof Extension) {
@@ -46,8 +46,22 @@ class UserCardRepository extends ServiceEntityRepository
             ;
         }
 
-        /** @var list<UserCard> */
-        return $queryBuilder->getQuery()->getResult();
+        /** @var list<UserCard> $cards */
+        $cards = $queryBuilder->getQuery()->getResult();
+
+        // Rarity is a string-backed enum (alphabetical ≠ rarity order), so rank it
+        // in PHP: rarest first, ties broken by name. The owned set is small.
+        $rank = array_flip(array_map(
+            static fn (CardRarityEnum $rarity): string => $rarity->value,
+            CardRarityEnum::ascending(),
+        ));
+        usort(
+            $cards,
+            static fn (UserCard $a, UserCard $b): int => ($rank[$b->getCard()->getRarity()->value] <=> $rank[$a->getCard()->getRarity()->value])
+                ?: $a->getCard()->getName() <=> $b->getCard()->getName(),
+        );
+
+        return $cards;
     }
 
     /**

--- a/templates/pages/collection.html.twig
+++ b/templates/pages/collection.html.twig
@@ -74,14 +74,14 @@
                     {{ _self.filter_tab(path('collection'), 'Tout', ownedTotalDistinct, currentExtension is null) }}
                     {% for universe in universes %}
                         {{ _self.filter_tab(
-                            path('collection', { extension: universe.extension.id }),
+                            path('collection', { slug: universe.extension.slug }),
                             universe.extension.name,
                             universe.owned,
                             currentExtension is not null and currentExtension.id == universe.extension.id,
                         ) }}
                     {% endfor %}
                 </nav>
-                <span class="font-mono text-[11px] tracking-[.15em] text-ink-dim">TRI: RÉCENTS ↓</span>
+                <span class="font-mono text-[11px] tracking-[.15em] text-ink-dim">TRI: RARETÉ ↓</span>
             </div>
         </section>
 

--- a/tests/Functional/CollectionControllerTest.php
+++ b/tests/Functional/CollectionControllerTest.php
@@ -14,7 +14,6 @@ use App\Enum\Entity\ExtensionStatusEnum;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
-use Symfony\Component\Uid\Uuid;
 
 final class CollectionControllerTest extends WebTestCase
 {
@@ -97,7 +96,7 @@ final class CollectionControllerTest extends WebTestCase
 
     public function testExtensionFilterOnlyShowsItsCards(): void
     {
-        $crawler = $this->client->request('GET', '/collection?extension=' . $this->extensionA->getId());
+        $crawler = $this->client->request('GET', '/collection/' . $this->extensionA->getSlug());
 
         self::assertResponseIsSuccessful();
         $grid = $crawler->filter('[data-testid="collection-grid"]');
@@ -113,7 +112,7 @@ final class CollectionControllerTest extends WebTestCase
 
     public function testEmptyStateWhenNoCardOwnedInExtension(): void
     {
-        $crawler = $this->client->request('GET', '/collection?extension=' . $this->extensionB->getId());
+        $crawler = $this->client->request('GET', '/collection/' . $this->extensionB->getSlug());
 
         self::assertResponseIsSuccessful();
         $this->assertCount(0, $crawler->filter('[data-testid="collection-grid"]'));
@@ -122,14 +121,16 @@ final class CollectionControllerTest extends WebTestCase
 
     public function testUnknownExtensionIsNotFound(): void
     {
-        $this->client->request('GET', '/collection?extension=' . Uuid::v4());
+        // a well-formed but non-existent slug → controller 404
+        $this->client->request('GET', '/collection/this-extension-does-not-exist');
 
         self::assertResponseStatusCodeSame(404);
     }
 
-    public function testMalformedExtensionIsNotFound(): void
+    public function testMalformedSlugIsNotFound(): void
     {
-        $this->client->request('GET', '/collection?extension=not-a-uuid');
+        // chars outside the [a-z0-9-] route requirement → no route matches → 404
+        $this->client->request('GET', '/collection/Invalid_Slug');
 
         self::assertResponseStatusCodeSame(404);
     }

--- a/tests/Functional/CollectionControllerTest.php
+++ b/tests/Functional/CollectionControllerTest.php
@@ -135,6 +135,40 @@ final class CollectionControllerTest extends WebTestCase
         self::assertResponseStatusCodeSame(404);
     }
 
+    public function testLegacyExtensionQueryParamRedirectsToTheSlugRoute(): void
+    {
+        $this->client->request('GET', '/collection?extension=' . $this->extensionA->getId());
+
+        self::assertResponseRedirects('/collection/' . $this->extensionA->getSlug(), 301);
+    }
+
+    public function testLegacyExtensionQueryParamWithUnknownIdIsNotFound(): void
+    {
+        // the query-param filter 404ed on unknown values — the redirect keeps that contract
+        $this->client->request('GET', '/collection?extension=00000000-0000-0000-0000-000000000000');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testGridOrdersOwnedCardsRarestFirst(): void
+    {
+        // a legendary and a rare on top of the owned commons — the grid must lead with them
+        $legendary = $this->createCard($this->extensionA, 'Rarity test legendary ' . uniqid(), rarity: CardRarityEnum::LEGENDARY);
+        $rare = $this->createCard($this->extensionA, 'Rarity test rare ' . uniqid(), rarity: CardRarityEnum::RARE);
+        $this->createUserCard($legendary, quantity: 1);
+        $this->createUserCard($rare, quantity: 1);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/collection');
+
+        self::assertResponseIsSuccessful();
+        $names = $crawler->filter('[data-testid="collection-grid"] img[alt]')->extract(['alt']);
+        $names = array_values(array_filter($names, static fn (string $name): bool => '' !== $name));
+
+        $this->assertSame($legendary->getName(), $names[0] ?? null, 'Rarest card must come first.');
+        $this->assertSame($rare->getName(), $names[1] ?? null, 'Then the rare, before the commons.');
+    }
+
     /**
      * Extension A: 4 published cards (+1 draft) — the user owns 2 of them
      * (one ×3 with 1 holo, one ×1) plus a zero-quantity leftover row.
@@ -173,13 +207,13 @@ final class CollectionControllerTest extends WebTestCase
         return $extension;
     }
 
-    private function createCard(Extension $extension, string $name, CardStatusEnum $status = CardStatusEnum::PUBLISHED): Card
+    private function createCard(Extension $extension, string $name, CardStatusEnum $status = CardStatusEnum::PUBLISHED, CardRarityEnum $rarity = CardRarityEnum::COMMON): Card
     {
         $card = new Card()
             ->setName($name)
             ->setDescription('Test card')
             ->setStatus($status)
-            ->setRarity(CardRarityEnum::COMMON)
+            ->setRarity($rarity)
             ->setExtension($extension)
         ;
         $card->setImageName('default_card.png');


### PR DESCRIPTION
Stackée sur 3e.

- **Slug d'extension** (Gedmo Sluggable depuis le nom, unique) + migration qui backfill les lignes existantes (slugify accents + dédup) avant NOT NULL + index unique.
- `/collection` passe d'un query param `?extension=<uuid>` à un **route param propre `/collection/{slug}`** (« Tout » = `/collection`) ; 404 sur slug inconnu/malformé.
- Tri du listing **par rareté décroissante** par défaut (collection + vue par extension).

Tests `CollectionControllerTest` adaptés au route param. Migration appliquée test + dev, schéma en phase.