### PR TITLE
feat(phase-3i): échelle de rareté à 4 paliers (suppression d'epic)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 
 **Core Entities:**
 - **Card**: Trading cards with multi-image support (main image, mask, foil)
-  - Fields: name, description, status (DRAFT/PUBLISHED), rarity (CardRarityEnum: common/uncommon/rare/epic/legendary — white/green/blue/purple/orange glows), uniqueFlag, alwaysHolo (forces holo whatever the slot's holoChance), visualConfigOverride (JSON, per-card override of the extension's visualConfig)
+  - Fields: name, description, status (DRAFT/PUBLISHED), rarity (CardRarityEnum: common/uncommon/rare/legendary — 4 tiers since the epic removal, grey/green/blue/orange glows), uniqueFlag, alwaysHolo (forces holo whatever the slot's holoChance), visualConfigOverride (JSON, per-card override of the extension's visualConfig)
   - No "type" field: visual customization is the extension→card VisualConfig cascade (see below)
   - Uses VichUploaderBundle for file uploads
   - ManyToOne with Extension

--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -27,18 +27,16 @@ const RARITY_COLOR = {
     common: '#9aa3b2',
     uncommon: '#5be584',
     rare: '#54a8ff',
-    epic: '#a435f0',
     legendary: '#ff8a2b',
 };
 const RARITY_LABEL = {
     common: 'Commune',
     uncommon: 'Peu commune',
     rare: 'Rare',
-    epic: 'Épique',
     legendary: 'Légendaire',
 };
-const RARITY_RANK = { common: 0, uncommon: 1, rare: 2, epic: 3, legendary: 4 };
-const SHINY = new Set(['rare', 'epic', 'legendary']);
+const RARITY_RANK = { common: 0, uncommon: 1, rare: 2, legendary: 3 };
+const SHINY = new Set(['rare', 'legendary']);
 
 // must match the .opening__flip CSS transition duration
 const FLIP_MS = 560;
@@ -269,13 +267,11 @@ export default class extends Controller {
         this.labelTarget.textContent = card.dataset.label;
         this._retrigger(this.labelTarget, 'is-on');
 
-        // Burst on EVERY epic / legendary, whatever its slot — not just the last
-        // card. Legendary gets the strongest hit; the climax still pops if it
-        // happens to be a lesser rarity. The burst is tinted by --reveal-color.
+        // Burst on EVERY legendary, whatever its slot — not just the last card.
+        // Legendary gets the strongest hit; the climax still pops if it happens
+        // to be a lesser rarity. The burst is tinted by --reveal-color.
         if (rarity === 'legendary') {
             this._flash(0.62, 240);
-        } else if (rarity === 'epic') {
-            this._flash(0.44, 190);
         } else if (isLast) {
             this._flash(0.5, 200);
         } else if (rarity === 'rare') {

--- a/assets/lib/card_tilt.js
+++ b/assets/lib/card_tilt.js
@@ -8,7 +8,7 @@
  *
  * Public contract (the "API" the CSS reads):
  *   Required markup (any rarity via data-rarity on the root):
- *     <div class="card interactive" data-rarity="epic">
+ *     <div class="card interactive" data-rarity="legendary">
  *       <div class="card__translater"><div class="card__rotator">
  *         <div class="card__front">
  *           <img src="…">

--- a/assets/styles/cards/holo.css
+++ b/assets/styles/cards/holo.css
@@ -32,8 +32,8 @@
 
 /*
  * Rarities differ by SATURATION and GLITTER density, not by brightness/intensity
- * escalation — an epic must stay as readable as an uncommon, just more chatoyant
- * (poke-holo principle). Intensity is kept low and flat across the high tiers.
+ * escalation — a legendary must stay as readable as an uncommon, just more
+ * chatoyant (poke-holo principle). Intensity is kept low and flat on the top tier.
  */
 /* --rarity-* come from the host theme; the fallbacks keep this file self-contained
  * (the effect works even if you copy it into an app without the project tokens). */
@@ -56,15 +56,8 @@
     --card-glow: var(--rarity-rare, #54a8ff);
 }
 
-/* epic & legendary keep the SAME (low) saturation — they only differ by glitter
- * density, never by saturation/brightness (so they stay as readable as a rare) */
-.card[data-rarity="epic"] {
-    --holo-intensity: .46;
-    --holo-saturation: .9;
-    --holo-glitter: .35;
-    --card-glow: var(--rarity-epic, #a435f0);
-}
-
+/* legendary keeps the SAME (low) saturation as rare — it only differs by glitter
+ * density, never by saturation/brightness (so it stays as readable as a rare) */
 .card[data-rarity="legendary"] {
     --holo-intensity: .52;
     --holo-saturation: .95;
@@ -111,10 +104,9 @@
     );
 }
 
-/* ------------------- rare / epic / legendary : sunpillars + radial foil */
+/* ------------------- rare / legendary : sunpillars + radial foil */
 
 .card[data-rarity="rare"] .card__shine,
-.card[data-rarity="epic"] .card__shine,
 .card[data-rarity="legendary"] .card__shine {
     background-image:
         var(--foil, linear-gradient(transparent, transparent)),
@@ -151,9 +143,8 @@
     opacity: calc(var(--card-opacity) * var(--holo-intensity));
 }
 
-/* epic / legendary : arc-en-ciel conique accroché au pointeur */
+/* legendary : arc-en-ciel conique accroché au pointeur */
 
-.card[data-rarity="epic"] .card__shine::before,
 .card[data-rarity="legendary"] .card__shine::before {
     content: '';
     background-image: conic-gradient(
@@ -173,11 +164,10 @@
     opacity: calc(var(--card-opacity) * var(--holo-intensity) * .15);
 }
 
-/* epic / legendary : glitter en trame croisée (densité = --holo-glitter) + glare */
+/* legendary : glitter en trame croisée (densité = --holo-glitter) + glare */
 /* overlay (pas color-dodge) : ça pétille sans cramer, et la densité différencie
  * les raretés sans toucher au brightness. */
 
-.card[data-rarity="epic"] .card__shine::after,
 .card[data-rarity="legendary"] .card__shine::after {
     content: '';
     background-image:

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -637,8 +637,8 @@
     z-index: 60;
     opacity: 0;
     pointer-events: none;
-    /* white-hot core fading into the current card's rarity colour, so an epic
-     * (purple) and a legendary (orange) burst read distinctly */
+    /* white-hot core fading into the current card's rarity colour, so a rare
+     * (blue) and a legendary (orange) burst read distinctly */
     background: radial-gradient(circle at 50% 46%,
         #ffffff 0%,
         color-mix(in srgb, var(--reveal-color, #ead8ff) 55%, #ffffff) 38%,

--- a/assets/styles/theme.css
+++ b/assets/styles/theme.css
@@ -22,11 +22,10 @@
     --live: #5be584;
     --soon: #ffd24a;
 
-    /* Raretés — 5 tiers (mythic/secret du design remappés sur epic/legendary) */
+    /* Raretés — 4 paliers (common → legendary ; « unique » est un flag, pas un palier) */
     --rarity-common: #9aa3b2;
     --rarity-uncommon: #5be584;
     --rarity-rare: #54a8ff;
-    --rarity-epic: #a435f0;
     --rarity-legendary: #ff8a2b;
 }
 

--- a/docs/card-effect.md
+++ b/docs/card-effect.md
@@ -20,7 +20,7 @@ self-contained.
 ## Markup
 
 ```html
-<div class="card interactive" data-rarity="epic"
+<div class="card interactive" data-rarity="rare"
      style="--foil: url('/foils/my-foil.png')">  <!-- optional foil texture -->
   <div class="card__translater">
     <div class="card__rotator">
@@ -34,7 +34,7 @@ self-contained.
 </div>
 ```
 
-- `data-rarity` ∈ `common | uncommon | rare | epic | legendary` selects the
+- `data-rarity` ∈ `common | uncommon | rare | legendary` selects the
   fallback recipe (used only when no `holo--<preset>` class is present).
 - By default the holo only shows **on hover** (and while zoomed). Add `holo` to
   the class list for a card that should keep a soft holo veil **at rest** too
@@ -152,15 +152,15 @@ inline** (inline always wins):
 |----------|-------|--------|
 | `--holo-intensity` | 0–1 | overall foil opacity |
 | `--holo-saturation` | 0–3 | rainbow vividness (keep ≤ 1 for a subtle, artwork-first look) |
-| `--holo-glitter` | 0–2 | sparkle density (epic / legendary) — the recommended way to differentiate rarities |
+| `--holo-glitter` | 0–2 | sparkle density (rare / legendary) — the recommended way to differentiate rarities |
 
 ```html
-<div class="card interactive" data-rarity="epic"
+<div class="card interactive" data-rarity="rare"
      style="--holo-intensity:.5; --holo-saturation:.9; --holo-glitter:.4"> … </div>
 ```
 
 Design rule baked into the defaults: rarities differ by **glitter density**, never by
-saturation/brightness — an epic stays as readable as a rare, just more sparkly. The
+saturation/brightness — a legendary stays as readable as a rare, just more sparkly. The
 `brightness()` on the foil is kept **below 1** on purpose: `color-dodge` is additive
 and would otherwise blow bright artwork out to white.
 

--- a/docs/card-setup-guide.md
+++ b/docs/card-setup-guide.md
@@ -187,7 +187,7 @@ Pour l'implémenter proprement il faudrait :
 
 **Les cartes rares et légendaires ont-elles un effet par défaut ?**
 Oui. Sans preset (`holoEffect` vide), c'est la **recette par rareté** de `holo.css`
-qui s'applique : `common`/`uncommon` = simple balayage ; `rare`/`epic`/`legendary`
+qui s'applique : `common`/`uncommon` = simple balayage ; `rare`/`legendary`
 = foil sunpillar + radial (de plus en plus pailleté). Un preset (`holo--*`) **prend
 le dessus** sur cette recette.
 

--- a/fixtures/Booster.yaml
+++ b/fixtures/Booster.yaml
@@ -5,7 +5,7 @@ App\Entity\Booster:
         rarityRates:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 100 }, holoChance: 5 }
-            - { rarities: { common: 55, rare: 25, epic: 15, legendary: 5 }, holoChance: 35 }
+            - { rarities: { common: 55, rare: 40, legendary: 5 }, holoChance: 35 }
     booster_bleach:
         extension: '@extension_bleach'
         imageName: 'default_card.png'

--- a/fixtures/Card.yaml
+++ b/fixtures/Card.yaml
@@ -38,7 +38,7 @@ App\Entity\Card:
         unique: true
         imageName: 'default_card.png'
         status: 2
-        rarity: 'epic'
+        rarity: 'rare'
     card_magic_king_julian:
         name: 'Magic King Julian'
         extension: '@extension_magic'

--- a/migrations/Version20260618120000.php
+++ b/migrations/Version20260618120000.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Drops the "epic" rarity tier (the scale is now 4 tiers: common → legendary;
+ * one-of-one cards are carried by Card.uniqueFlag, not a rarity). Pure data
+ * migration — `rarity` is a plain varchar, so there is no DB enum to alter:
+ *  - every Card with rarity "epic" becomes "rare";
+ *  - in every Booster.rarityRates slot, the "epic" weight is folded into "rare".
+ *
+ * Irreversible: the merge loses which rows/weights were originally epic.
+ */
+final class Version20260618120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Remove the "epic" rarity tier (merge into "rare")';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE card SET rarity = 'rare' WHERE rarity = 'epic'");
+
+        $boosters = $this->connection->fetchAllAssociative('SELECT id, rarity_rates FROM booster');
+        foreach ($boosters as $booster) {
+            $slots = json_decode((string) $booster['rarity_rates'], true);
+            if (!is_array($slots)) {
+                continue;
+            }
+
+            $changed = false;
+            foreach ($slots as &$slot) {
+                if (!isset($slot['rarities']) || !is_array($slot['rarities']) || !isset($slot['rarities']['epic'])) {
+                    continue;
+                }
+                $slot['rarities']['rare'] = ($slot['rarities']['rare'] ?? 0) + $slot['rarities']['epic'];
+                unset($slot['rarities']['epic']);
+                $changed = true;
+            }
+            unset($slot);
+
+            if ($changed) {
+                $this->addSql(
+                    'UPDATE booster SET rarity_rates = ? WHERE id = ?',
+                    [json_encode($slots, JSON_THROW_ON_ERROR), $booster['id']],
+                );
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->throwIrreversibleMigration('Merging the "epic" tier into "rare" cannot be reversed.');
+    }
+}

--- a/src/Controller/Dev/CardEffectsDemoController.php
+++ b/src/Controller/Dev/CardEffectsDemoController.php
@@ -23,7 +23,7 @@ use Symfony\Component\Uid\Uuid;
  *    --holo-* knobs, selects for the holo preset + rarity, foil/mask toggles)
  *    wired by the card_playground Stimulus controller;
  *  - a gallery rendering every CardEffectEnum preset side by side;
- *  - the five rarity tiers (pure data-rarity defaults).
+ *  - the four rarity tiers (pure data-rarity defaults).
  *
  * The service only exists in the dev container (#[When]) and the route is
  * declared in config/routes.yaml under when@dev (a #[Route] attribute would

--- a/src/Enum/Entity/CardRarityEnum.php
+++ b/src/Enum/Entity/CardRarityEnum.php
@@ -9,7 +9,6 @@ enum CardRarityEnum: string
     case COMMON = 'common';
     case UNCOMMON = 'uncommon';
     case RARE = 'rare';
-    case EPIC = 'epic';
     case LEGENDARY = 'legendary';
 
     /**
@@ -17,6 +16,6 @@ enum CardRarityEnum: string
      */
     public static function ascending(): array
     {
-        return [self::COMMON, self::UNCOMMON, self::RARE, self::EPIC, self::LEGENDARY];
+        return [self::COMMON, self::UNCOMMON, self::RARE, self::LEGENDARY];
     }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,6 @@ module.exports = {
           common: '#9aa3b2',
           uncommon: '#5be584',
           rare: '#54a8ff',
-          epic: '#a435f0',
           legendary: '#ff8a2b',
         },
       },

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -8,8 +8,8 @@
     {% set ownedCount = this.ownedCount %}
     {% set ownedCardIds = this.ownedCardIds %}
     {% set newCardIds = this.newCardIds %}
-    {% set rarityLabels = { common: 'Commune', uncommon: 'Peu commune', rare: 'Rare', epic: 'Épique', legendary: 'Légendaire' } %}
-    {% set raritySuffix = { rare: ' !', epic: ' !!', legendary: ' !!!' } %}
+    {% set rarityLabels = { common: 'Commune', uncommon: 'Peu commune', rare: 'Rare', legendary: 'Légendaire' } %}
+    {% set raritySuffix = { rare: ' !', legendary: ' !!!' } %}
 
     <div class="opening opening--page"
          data-controller="booster-opening"
@@ -60,7 +60,7 @@
                                  data-booster-opening-target="card"
                                  data-card-id="{{ reveal.card.id }}"
                                  data-rarity="{{ rarity }}"
-                                 data-shiny="{{ rarity in ['rare', 'epic', 'legendary'] ? '1' : '0' }}"
+                                 data-shiny="{{ rarity in ['rare', 'legendary'] ? '1' : '0' }}"
                                  data-label="{{ rarityLabels[rarity]|default(rarity) }}{{ raritySuffix[rarity]|default('') }}">
                                 {# flip scene: back faces the player until they click to reveal the front #}
                                 <div class="opening__flip" data-booster-opening-target="flip">

--- a/templates/dev/card_effects.html.twig
+++ b/templates/dev/card_effects.html.twig
@@ -58,7 +58,7 @@
             </p>
             <p class="mt-2 max-w-3xl text-xs text-amber-300/80">
                 ⚠️ Les molettes <code>--holo-intensity / saturation / glitter</code> ne pilotent plus que la recette
-                <em>par rareté</em> (section « 5 paliers » sans preset). Les presets pokeholo les ignorent (rendu fidèle, pleine intensité).
+                <em>par rareté</em> (section « 4 paliers » sans preset). Les presets pokeholo les ignorent (rendu fidèle, pleine intensité).
             </p>
             <p class="mt-2 font-mono text-xs text-ink-muted">
                 Carte affichée : <strong class="text-primary">{{ playgroundCard.name }}</strong>
@@ -171,8 +171,8 @@
         </div>
 
         {# ---------------------------------------------------------------- Rarity tiers #}
-        <h2 class="mb-4 mt-14 font-display text-2xl font-bold text-ink-strong">Les 5 paliers (défaut data-rarity)</h2>
-        <div class="grid grid-cols-2 gap-6 md:grid-cols-3 lg:grid-cols-5">
+        <h2 class="mb-4 mt-14 font-display text-2xl font-bold text-ink-strong">Les 4 paliers (défaut data-rarity)</h2>
+        <div class="grid grid-cols-2 gap-6 md:grid-cols-4">
             {% for demo in rarityDemos %}
                 <div class="force-glow">
                     {{ include('components/CardComponent.html.twig', { card: demo.card }) }}

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -164,8 +164,7 @@
                 {% set rarities = [
                     {label: 'Common', chip: 'C', weight: 60, color: 'var(--rarity-common)'},
                     {label: 'Uncommon', chip: 'U', weight: 25, color: 'var(--rarity-uncommon)'},
-                    {label: 'Rare', chip: 'R', weight: 10, color: 'var(--rarity-rare)'},
-                    {label: 'Epic', chip: 'E', weight: 4, color: 'var(--rarity-epic)'},
+                    {label: 'Rare', chip: 'R', weight: 14, color: 'var(--rarity-rare)'},
                     {label: 'Legendary', chip: 'L', weight: 1, color: 'var(--rarity-legendary)'},
                 ] %}
                 <div class="flex flex-col items-stretch md:flex-row">

--- a/tests/Unit/Enum/CardRarityEnumTest.php
+++ b/tests/Unit/Enum/CardRarityEnumTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Enum;
+
+use App\Enum\Entity\CardRarityEnum;
+use PHPUnit\Framework\TestCase;
+
+final class CardRarityEnumTest extends TestCase
+{
+    public function testScaleHasFourTiersWithoutEpic(): void
+    {
+        $values = array_map(static fn (CardRarityEnum $rarity): string => $rarity->value, CardRarityEnum::cases());
+
+        $this->assertSame(['common', 'uncommon', 'rare', 'legendary'], $values);
+        $this->assertNull(CardRarityEnum::tryFrom('epic'));
+    }
+
+    public function testAscendingIsOrderedLeastToMostRare(): void
+    {
+        $this->assertSame(
+            [
+                CardRarityEnum::COMMON,
+                CardRarityEnum::UNCOMMON,
+                CardRarityEnum::RARE,
+                CardRarityEnum::LEGENDARY,
+            ],
+            CardRarityEnum::ascending(),
+        );
+    }
+}


### PR DESCRIPTION
## Phase 3i — Échelle de rareté à 4 paliers (suppression d'« epic »)

L'échelle passe de 5 à **4 paliers** : `common → uncommon → rare → legendary`. Le « 1 seul exemplaire » n'est PAS une rareté — il reste porté par `Card.uniqueFlag` (chantier dédié phase 3j). **`epic` est fusionné dans `rare`.**

### Migration (données, irréversible)
- `Card.rarity = 'epic'` → `'rare'`.
- Dans chaque slot de `Booster.rarityRates`, le poids `"epic"` est replié sur `"rare"`.
- `rarity` est un varchar (pas de type enum Postgres) → aucun ALTER TYPE.
- Validé sur la base dev : la carte epic → rare, le slot `{"epic":100}` → `{"rare":100}`, plus aucun epic.

### Code / UI
- `CardRarityEnum` : retrait du case `EPIC` (+ `ascending()`).
- `holo.css` : recettes epic supprimées (ex-epic rendues comme `rare`) ; `theme.css` : token `--rarity-epic` retiré.
- Ouverture : `BoosterOpening.html.twig` (labels/suffix/`data-shiny`), `booster_opening_controller.js` (couleurs/rank/`SHINY`/burst), `opening.css` (commentaire).
- `homepage.html.twig` : chip *Epic* retiré (poids fusionné dans *Rare*).
- Fixtures : carte & booster epic remappés.

### Tests / qualité
- Nouveau `CardRarityEnumTest` (garde-fou : 4 paliers, `tryFrom('epic')` = null).
- Suite verte (90 tests). `make quality` vert (au passage, 2 findings Rector pré-existants balayés : ordre des args `#[Route]` dans `CollectionController`, flip `instanceof` dans `VisualConfig::isEmpty`).

> PR empilée sur `feat/phase-3h-holo-presets` (#48). À merger après 3h.