### PR TITLE
feat(phase-3j): cartes uniques 1/1 (exclusivité globale au tirage)

### DIFF
--- a/assets/styles/cards/holo-presets.css
+++ b/assets/styles/cards/holo-presets.css
@@ -851,3 +851,34 @@
 
 /* The --card-border accent border already lives in holo.css (.card__front),
  * loaded alongside this file — not duplicated here. */
+
+/* ------------------------------------------------------------- unique (1/1) badge
+ * Shown on one-of-one cards (CardComponent adds .card.unique + the badge). The
+ * selector is more specific than base.css `.card__rotator *` so it can undo the
+ * full-bleed grid sizing that rule forces on every layer, and sit as a small
+ * pill above the holo layers, riding the 3D tilt with the card front. */
+.card__front .card__unique-badge {
+    position: absolute;
+    top: 5%;
+    right: 5%;
+    z-index: 5;
+    display: inline-block;
+    width: auto;
+    aspect-ratio: auto;
+    grid-area: auto;
+    overflow: visible;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: .06em;
+    line-height: 1.35;
+    color: #2a1a00;
+    background: linear-gradient(180deg, #ffe79a, #f4b73a);
+    box-shadow:
+        0 1px 4px rgba(0, 0, 0, .45),
+        inset 0 0 0 1px rgba(255, 255, 255, .55);
+    transform: translateZ(2px);
+    pointer-events: none;
+}

--- a/migrations/Version20260618130000.php
+++ b/migrations/Version20260618130000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Adds card.claimed_by (FK to discord_user) to support one-of-one (unique)
+ * cards: the column holds the owner once a unique card is first drawn. A
+ * claimed unique is filtered out of the draw pool (CardRepository) so it can
+ * never be drawn again. ON DELETE SET NULL frees the card if the owner is
+ * removed.
+ */
+final class Version20260618130000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add card.claimed_by (owner of a one-of-one unique card)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE card ADD claimed_by VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE card ADD CONSTRAINT FK_CARD_CLAIMED_BY FOREIGN KEY (claimed_by) REFERENCES discord_user (discord_id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_CARD_CLAIMED_BY ON card (claimed_by)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE card DROP CONSTRAINT FK_CARD_CLAIMED_BY');
+        $this->addSql('DROP INDEX IDX_CARD_CLAIMED_BY');
+        $this->addSql('ALTER TABLE card DROP claimed_by');
+    }
+}

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -42,6 +42,15 @@ class Card
     private bool $uniqueFlag = false;
 
     /**
+     * Owner of a one-of-one (unique) card. Null while unclaimed; set atomically
+     * the first time the card is drawn (CardRepository::claimUnique). A claimed
+     * unique is filtered out of the draw pool so it can never be drawn again.
+     */
+    #[ORM\ManyToOne]
+    #[ORM\JoinColumn(name: 'claimed_by', referencedColumnName: 'discord_id', nullable: true)]
+    private ?DiscordUser $claimedBy = null;
+
+    /**
      * When true the card is always drawn holo, whatever the slot's holoChance
      * (e.g. legendaries that should always shine).
      */
@@ -138,6 +147,26 @@ class Card
         $this->uniqueFlag = $uniqueFlag;
 
         return $this;
+    }
+
+    public function getClaimedBy(): ?DiscordUser
+    {
+        return $this->claimedBy;
+    }
+
+    public function setClaimedBy(?DiscordUser $claimedBy): static
+    {
+        $this->claimedBy = $claimedBy;
+
+        return $this;
+    }
+
+    /**
+     * A unique card that has already been claimed by someone.
+     */
+    public function isClaimed(): bool
+    {
+        return $this->claimedBy instanceof DiscordUser;
     }
 
     public function isAlwaysHolo(): bool

--- a/src/Repository/CardRepository.php
+++ b/src/Repository/CardRepository.php
@@ -31,9 +31,14 @@ class CardRepository extends ServiceEntityRepository
      */
     public function findExtensionIdsWithPublishedCards(): array
     {
+        // Same drawability rule as findDrawablePool (a claimed 1/1 unique is not
+        // drawable): the hub's "ouvrable" state and the opening page must agree
+        // with what CardDrawer can actually draw, or an extension left with only
+        // claimed uniques would show "Ouvrir" and then fail the draw.
         return array_map(static fn (mixed $id): string => (string) $id, array_values($this->createQueryBuilder('c')
             ->select('IDENTITY(c.extension) AS extensionId')
             ->andWhere('c.status = :status')
+            ->andWhere('c.uniqueFlag = false OR c.claimedBy IS NULL')
             ->setParameter('status', CardStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
             ->distinct()
             ->getQuery()

--- a/src/Repository/CardRepository.php
+++ b/src/Repository/CardRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\Card;
+use App\Entity\DiscordUser;
 use App\Entity\Extension;
 use App\Enum\Entity\CardStatusEnum;
 use App\Enum\Entity\ExtensionStatusEnum;
@@ -55,6 +56,49 @@ class CardRepository extends ServiceEntityRepository
             ->orderBy('c.name', 'ASC')
             ->getQuery()
             ->getResult());
+    }
+
+    /**
+     * The draw pool of an extension: published cards, EXCLUDING one-of-one
+     * unique cards that are already claimed (so a claimed unique can never be
+     * drawn again). Available (unclaimed) uniques stay in the pool.
+     *
+     * @return list<Card>
+     */
+    public function findDrawablePool(Extension $extension): array
+    {
+        return array_values($this->createQueryBuilder('c')
+            ->andWhere('c.extension = :extension')
+            ->andWhere('c.status = :status')
+            ->andWhere('c.uniqueFlag = false OR c.claimedBy IS NULL')
+            ->setParameter('extension', $extension)
+            ->setParameter('status', CardStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
+            ->getQuery()
+            ->getResult());
+    }
+
+    /**
+     * Atomically claims a one-of-one unique card for a user: a single
+     * conditional UPDATE that only succeeds while the card is still unclaimed.
+     * Two concurrent openings serialise on the row, so exactly one wins.
+     *
+     * @return bool true if this call claimed the card, false if it was already taken
+     */
+    public function claimUnique(Card $card, DiscordUser $discordUser): bool
+    {
+        $affected = $this->createQueryBuilder('c')
+            ->update()
+            ->set('c.claimedBy', ':owner')
+            ->where('c = :card')
+            ->andWhere('c.uniqueFlag = true')
+            ->andWhere('c.claimedBy IS NULL')
+            ->setParameter('owner', $discordUser)
+            ->setParameter('card', $card)
+            ->getQuery()
+            ->execute()
+        ;
+
+        return 1 === $affected;
     }
 
     /**

--- a/src/Service/Booster/BoosterOpeningService.php
+++ b/src/Service/Booster/BoosterOpeningService.php
@@ -90,7 +90,7 @@ final readonly class BoosterOpeningService
                 $claimedHere[$cardId] = true;
                 $resolved[] = $drawnCard;
             } else {
-                $resolved[] = $this->cardDrawer->drawReplacement($booster, $drawnCard->rarity);
+                $resolved[] = $this->cardDrawer->drawReplacement($booster, $drawnCard->rarity, $drawnCard->holo);
             }
         }
 

--- a/src/Service/Booster/BoosterOpeningService.php
+++ b/src/Service/Booster/BoosterOpeningService.php
@@ -11,6 +11,7 @@ use App\Entity\BoosterOpeningCard;
 use App\Entity\DiscordUser;
 use App\Exception\Booster\NoBoosterInInventoryException;
 use App\Exception\Booster\NoCardAvailableException;
+use App\Repository\CardRepository;
 use App\Service\Random\RandomService;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Clock\ClockInterface;
@@ -28,6 +29,7 @@ final readonly class BoosterOpeningService
         private RandomService $randomService,
         private EntityManagerInterface $entityManager,
         private ClockInterface $clock,
+        private CardRepository $cardRepository,
     ) {
     }
 
@@ -46,7 +48,9 @@ final readonly class BoosterOpeningService
 
             $opening = new BoosterOpening($discordUser, $booster, $seed, $openedAt);
 
-            foreach ($this->aggregate($this->cardDrawer->draw($booster)) as $aggregated) {
+            $drawnCards = $this->resolveUniqueClaims($discordUser, $booster, $this->cardDrawer->draw($booster));
+
+            foreach ($this->aggregate($drawnCards) as $aggregated) {
                 $this->userInventoryService->addCard($discordUser, $aggregated['card']->card, $aggregated['quantity'], $aggregated['holoQuantity']);
                 $opening->addBoosterOpeningCard(new BoosterOpeningCard($opening, $aggregated['card']->card, $aggregated['quantity'], $aggregated['holoQuantity']));
             }
@@ -56,6 +60,41 @@ final readonly class BoosterOpeningService
 
             return $opening;
         });
+    }
+
+    /**
+     * Atomically claims each drawn one-of-one unique. A unique already taken by
+     * a concurrent opening (or rolled twice in THIS booster) is swapped for a
+     * replacement card of the same rarity, so a 1/1 is never credited twice.
+     *
+     * @param list<DrawnCard> $drawnCards
+     *
+     * @return list<DrawnCard>
+     */
+    private function resolveUniqueClaims(DiscordUser $discordUser, Booster $booster, array $drawnCards): array
+    {
+        $resolved = [];
+        $claimedHere = [];
+
+        foreach ($drawnCards as $drawnCard) {
+            if (!$drawnCard->card->isUnique()) {
+                $resolved[] = $drawnCard;
+
+                continue;
+            }
+
+            $cardId = (string) $drawnCard->card->getId();
+            $won = !isset($claimedHere[$cardId]) && $this->cardRepository->claimUnique($drawnCard->card, $discordUser);
+
+            if ($won) {
+                $claimedHere[$cardId] = true;
+                $resolved[] = $drawnCard;
+            } else {
+                $resolved[] = $this->cardDrawer->drawReplacement($booster, $drawnCard->rarity);
+            }
+        }
+
+        return $resolved;
     }
 
     /**

--- a/src/Service/Booster/CardDrawer.php
+++ b/src/Service/Booster/CardDrawer.php
@@ -9,7 +9,6 @@ use App\Entity\Booster;
 use App\Entity\Card;
 use App\Entity\Extension;
 use App\Enum\Entity\CardRarityEnum;
-use App\Enum\Entity\CardStatusEnum;
 use App\Exception\Booster\NoCardAvailableException;
 use App\Repository\CardRepository;
 use App\Service\Random\RandomService;
@@ -58,18 +57,42 @@ final readonly class CardDrawer
     }
 
     /**
-     * @return array<string, non-empty-list<Card>> published cards grouped by rarity value
+     * Draws a single replacement card of (or near) the given rarity, excluding
+     * ALL unique cards. Used when a drawn unique was claimed by someone else in
+     * a concurrent opening: the slot falls back to another card of the rarity.
      */
-    private function loadPool(Extension $extension): array
+    public function drawReplacement(Booster $booster, CardRarityEnum $rarity): DrawnCard
     {
-        $cards = $this->cardRepository->findBy([
-            'extension' => $extension,
-            'status' => CardStatusEnum::PUBLISHED,
-        ]);
+        $pool = $this->loadPool($booster->getExtension(), excludeUniques: true);
 
+        if ([] === $pool) {
+            throw new NoCardAvailableException(\sprintf('Extension "%s" has no non-unique card for a replacement draw.', $booster->getExtension()->getName()));
+        }
+
+        $resolved = $this->resolveAvailableRarity($pool, $rarity);
+        $candidates = $pool[$resolved->value];
+        $card = $candidates[$this->randomService->getInt(0, \count($candidates) - 1)];
+
+        // No slot context here, so only the card's forced-holo flag applies.
+        return new DrawnCard($card, $resolved, $card->isAlwaysHolo());
+    }
+
+    /**
+     * Published cards of the extension grouped by rarity, EXCLUDING claimed
+     * one-of-one uniques (filtered in SQL). With $excludeUniques every unique
+     * card is dropped — used to build a replacement pool free of uniques.
+     *
+     * @return array<string, non-empty-list<Card>>
+     */
+    private function loadPool(Extension $extension, bool $excludeUniques = false): array
+    {
         $pool = [];
 
-        foreach ($cards as $card) {
+        foreach ($this->cardRepository->findDrawablePool($extension) as $card) {
+            if ($excludeUniques && $card->isUnique()) {
+                continue;
+            }
+
             $pool[$card->getRarity()->value][] = $card;
         }
 

--- a/src/Service/Booster/CardDrawer.php
+++ b/src/Service/Booster/CardDrawer.php
@@ -59,22 +59,29 @@ final readonly class CardDrawer
     /**
      * Draws a single replacement card of (or near) the given rarity, excluding
      * ALL unique cards. Used when a drawn unique was claimed by someone else in
-     * a concurrent opening: the slot falls back to another card of the rarity.
+     * a concurrent opening: the slot falls back to another card of the rarity,
+     * KEEPING the holo the slot originally rolled (losing the unique must not
+     * also cost a holo the booster config guaranteed).
+     *
+     * Rolls on the RNG side stream: whether a replacement happens depends on
+     * concurrent claims, so it must not desync the seed-replay of the main draw.
      */
-    public function drawReplacement(Booster $booster, CardRarityEnum $rarity): DrawnCard
+    public function drawReplacement(Booster $booster, CardRarityEnum $rarity, bool $holo = false): DrawnCard
     {
         $pool = $this->loadPool($booster->getExtension(), excludeUniques: true);
 
         if ([] === $pool) {
-            throw new NoCardAvailableException(\sprintf('Extension "%s" has no non-unique card for a replacement draw.', $booster->getExtension()->getName()));
+            throw new NoCardAvailableException(
+                \sprintf('Extension "%s" has no non-unique card for a replacement draw.', $booster->getExtension()->getName()),
+                'Ce booster n\'a aucune carte à tirer pour le moment, réessaie plus tard.',
+            );
         }
 
         $resolved = $this->resolveAvailableRarity($pool, $rarity);
         $candidates = $pool[$resolved->value];
-        $card = $candidates[$this->randomService->getInt(0, \count($candidates) - 1)];
+        $card = $candidates[$this->randomService->getSideInt(0, \count($candidates) - 1)];
 
-        // No slot context here, so only the card's forced-holo flag applies.
-        return new DrawnCard($card, $resolved, $card->isAlwaysHolo());
+        return new DrawnCard($card, $resolved, $holo || $card->isAlwaysHolo());
     }
 
     /**

--- a/src/Service/Random/RandomService.php
+++ b/src/Service/Random/RandomService.php
@@ -16,12 +16,15 @@ final class RandomService
 {
     private ?Randomizer $randomizer = null;
 
+    private ?Randomizer $sideRandomizer = null;
+
     private ?int $seed = null;
 
     public function seed(int $seed): void
     {
         $this->seed = $seed;
         $this->randomizer = new Randomizer(new Mt19937($seed));
+        $this->sideRandomizer = new Randomizer(new Mt19937(crc32($seed . '-side')));
     }
 
     public function getSeed(): ?int
@@ -34,5 +37,19 @@ final class RandomService
         $this->randomizer ??= new Randomizer(new Mt19937());
 
         return $this->randomizer->getInt($min, $max);
+    }
+
+    /**
+     * Draws from a SIDE stream derived from the seed. Rolls that depend on
+     * concurrent state (e.g. the replacement draw for a unique card claimed by
+     * another opening) must use this stream: consuming it never advances the
+     * main stream, so replaying the stored seed still reproduces the main draw
+     * whatever happened concurrently.
+     */
+    public function getSideInt(int $min, int $max): int
+    {
+        $this->sideRandomizer ??= new Randomizer(new Mt19937());
+
+        return $this->sideRandomizer->getInt($min, $max);
     }
 }

--- a/templates/components/CardComponent.html.twig
+++ b/templates/components/CardComponent.html.twig
@@ -10,7 +10,7 @@
 {%- if visual.holoSaturation is not null %}{% set styleVars = styleVars|merge(["--holo-saturation: #{visual.holoSaturation}"]) %}{% endif -%}
 {%- if visual.holoGlitter is not null %}{% set styleVars = styleVars|merge(["--holo-glitter: #{visual.holoGlitter}"]) %}{% endif -%}
 <div id="{{ id }}"
-     class="card interactive{{ visual.hasMask ? ' masked' }}{{ holo ? ' holo' }}{{ visual.cssClass ? ' ' ~ visual.cssClass }}{{ visual.holoEffect ? ' ' ~ visual.holoEffect.cssClass }}"
+     class="card interactive{{ visual.hasMask ? ' masked' }}{{ holo ? ' holo' }}{{ card.isUnique ? ' unique' }}{{ visual.cssClass ? ' ' ~ visual.cssClass }}{{ visual.holoEffect ? ' ' ~ visual.holoEffect.cssClass }}"
      data-rarity="{{ card.rarity.value }}"
      data-controller="card"
      {%- if styleVars is not empty %} style="{{ styleVars|join('; ') }}"{% endif %}>
@@ -20,6 +20,7 @@
                 <img src="{{ vich_uploader_asset(card) }}" alt="{{ card.name }}" onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
                 <div class="card__shine"></div>
                 <div class="card__glare"></div>
+                {%- if card.isUnique %}<div class="card__unique-badge" title="Carte unique — un seul exemplaire">1/1</div>{% endif -%}
             </div>
         </div>
     </div>

--- a/tests/Integration/Service/BoosterOpeningServiceTest.php
+++ b/tests/Integration/Service/BoosterOpeningServiceTest.php
@@ -133,6 +133,75 @@ final class BoosterOpeningServiceTest extends KernelTestCase
         $this->assertSame([], $this->entityManager->getRepository(BoosterOpening::class)->findBy(['discordUser' => $scenario['user']]));
     }
 
+    public function testUniqueCardIsClaimedByFirstOpenerAndNeverDrawnAgain(): void
+    {
+        $extension = new Extension()
+            ->setName('Unique test extension ' . uniqid())
+            ->setDescription('Test extension')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($extension);
+
+        // The only RARE card is a one-of-one; a filler COMMON gives the draw a
+        // fallback once the unique is claimed.
+        $unique = new Card()
+            ->setName('One of one')
+            ->setDescription('Test card')
+            ->setStatus(CardStatusEnum::PUBLISHED)
+            ->setRarity(CardRarityEnum::RARE)
+            ->setExtension($extension)
+            ->setUnique(true)
+        ;
+        $unique->setImageName('default_card.png');
+        $this->entityManager->persist($unique);
+
+        $filler = new Card()
+            ->setName('Filler common')
+            ->setDescription('Test card')
+            ->setStatus(CardStatusEnum::PUBLISHED)
+            ->setRarity(CardRarityEnum::COMMON)
+            ->setExtension($extension)
+        ;
+        $filler->setImageName('default_card.png');
+        $this->entityManager->persist($filler);
+
+        $booster = new Booster()
+            ->setExtension($extension)
+            ->setRarityRates([['rarities' => ['rare' => 100], 'holoChance' => 0]])
+        ;
+        $booster->setImageName('default_card.png');
+        $this->entityManager->persist($booster);
+
+        $alice = new DiscordUser()->setDiscordId('uniq-alice-' . uniqid())->setUsername('Alice');
+        $bob = new DiscordUser()->setDiscordId('uniq-bob-' . uniqid())->setUsername('Bob');
+        foreach ([$alice, $bob] as $user) {
+            $this->entityManager->persist($user);
+            $this->entityManager->persist(new UserBooster()->setDiscordUser($user)->setBooster($booster)->setQuantity(1));
+        }
+        $this->entityManager->flush();
+
+        // Alice opens first: the RARE slot draws the only rare card (the unique) and claims it.
+        $this->openingService->open($alice, $booster);
+        // Bob opens next: the claimed unique is filtered out of the pool, so the
+        // RARE slot falls back to the common — Bob can never get the 1/1.
+        $this->openingService->open($bob, $booster);
+
+        $this->entityManager->clear();
+
+        $claimed = $this->entityManager->getRepository(Card::class)->find($unique->getId());
+        $this->assertNotNull($claimed?->getClaimedBy());
+        $this->assertSame($alice->getDiscordId(), $claimed->getClaimedBy()->getDiscordId());
+
+        $this->assertNotNull(
+            $this->entityManager->getRepository(UserCard::class)->findOneBy(['discordUser' => $alice, 'card' => $unique]),
+            'The first opener must own the unique card.',
+        );
+        $this->assertNull(
+            $this->entityManager->getRepository(UserCard::class)->findOneBy(['discordUser' => $bob, 'card' => $unique]),
+            'A claimed 1/1 must never be drawn by another player.',
+        );
+    }
+
     /**
      * @param list<array<string, int>>|null $rarityRates plain weight maps, wrapped per-slot with $holoChance
      *

--- a/tests/Integration/Service/BoosterOpeningServiceTest.php
+++ b/tests/Integration/Service/BoosterOpeningServiceTest.php
@@ -202,6 +202,46 @@ final class BoosterOpeningServiceTest extends KernelTestCase
         );
     }
 
+    public function testExtensionLeftWithOnlyClaimedUniquesIsNoLongerDrawable(): void
+    {
+        $extension = new Extension()
+            ->setName('Claimed-out extension ' . uniqid())
+            ->setDescription('Test extension')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($extension);
+
+        // The ONLY published card is a one-of-one unique.
+        $unique = new Card()
+            ->setName('Sole one of one')
+            ->setDescription('Test card')
+            ->setStatus(CardStatusEnum::PUBLISHED)
+            ->setRarity(CardRarityEnum::RARE)
+            ->setExtension($extension)
+            ->setUnique(true)
+        ;
+        $unique->setImageName('default_card.png');
+        $this->entityManager->persist($unique);
+
+        $owner = new DiscordUser()->setDiscordId('uniq-owner-' . uniqid())->setUsername('Owner');
+        $this->entityManager->persist($owner);
+        $this->entityManager->flush();
+
+        $cardRepository = $this->entityManager->getRepository(Card::class);
+        \assert($cardRepository instanceof \App\Repository\CardRepository);
+
+        // Before the claim, the hub/controller drawability check lists the extension…
+        $this->assertContains((string) $extension->getId(), $cardRepository->findExtensionIdsWithPublishedCards());
+
+        $cardRepository->claimUnique($unique, $owner);
+
+        // …and once its only card is claimed, both the drawability check and the
+        // actual draw pool agree the extension is exhausted (no more "Ouvrir"
+        // button leading straight into a draw error).
+        $this->assertNotContains((string) $extension->getId(), $cardRepository->findExtensionIdsWithPublishedCards());
+        $this->assertSame([], $cardRepository->findDrawablePool($extension));
+    }
+
     /**
      * @param list<array<string, int>>|null $rarityRates plain weight maps, wrapped per-slot with $holoChance
      *

--- a/tests/Unit/Service/CardDrawerTest.php
+++ b/tests/Unit/Service/CardDrawerTest.php
@@ -153,6 +153,34 @@ final class CardDrawerTest extends TestCase
         $drawer->draw($this->booster([['common' => 100]]));
     }
 
+    public function testDrawReplacementNeverReturnsAUniqueCard(): void
+    {
+        $unique = $this->card('Unique rare', CardRarityEnum::RARE)->setUnique(true);
+        $drawer = $this->createDrawer([
+            $unique,
+            $this->card('Plain rare', CardRarityEnum::RARE),
+        ]);
+        $booster = $this->booster([['rare' => 100]]);
+
+        for ($i = 0; $i < 100; ++$i) {
+            $replacement = $drawer->drawReplacement($booster, CardRarityEnum::RARE);
+
+            $this->assertFalse($replacement->card->isUnique());
+            $this->assertSame('Plain rare', $replacement->card->getName());
+        }
+    }
+
+    public function testDrawReplacementThrowsWhenOnlyUniqueCardsExist(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Unique rare', CardRarityEnum::RARE)->setUnique(true),
+        ]);
+
+        $this->expectException(NoCardAvailableException::class);
+
+        $drawer->drawReplacement($this->booster([['rare' => 100]]), CardRarityEnum::RARE);
+    }
+
     public function testSameSeedReproducesTheSameDraw(): void
     {
         $cards = [
@@ -195,7 +223,7 @@ final class CardDrawerTest extends TestCase
     private function repositoryWith(array $publishedCards): CardRepository
     {
         $cardRepository = $this->createStub(CardRepository::class);
-        $cardRepository->method('findBy')->willReturn($publishedCards);
+        $cardRepository->method('findDrawablePool')->willReturn($publishedCards);
 
         return $cardRepository;
     }

--- a/tests/Unit/Service/CardDrawerTest.php
+++ b/tests/Unit/Service/CardDrawerTest.php
@@ -181,6 +181,46 @@ final class CardDrawerTest extends TestCase
         $drawer->drawReplacement($this->booster([['rare' => 100]]), CardRarityEnum::RARE);
     }
 
+    public function testDrawReplacementKeepsTheHoloRolledBySlot(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Plain rare', CardRarityEnum::RARE),
+        ]);
+        $booster = $this->booster([['rare' => 100]]);
+
+        // Losing the unique must not also cost the holo the slot rolled.
+        $this->assertTrue($drawer->drawReplacement($booster, CardRarityEnum::RARE, holo: true)->holo);
+        $this->assertFalse($drawer->drawReplacement($booster, CardRarityEnum::RARE, holo: false)->holo);
+    }
+
+    public function testDrawReplacementDoesNotDesyncTheSeededMainStream(): void
+    {
+        $cards = [
+            $this->card('Common A', CardRarityEnum::COMMON),
+            $this->card('Common B', CardRarityEnum::COMMON),
+            $this->card('Plain rare', CardRarityEnum::RARE),
+        ];
+        $booster = $this->booster([['common' => 70, 'rare' => 30], ['common' => 70, 'rare' => 30]]);
+
+        $names = static fn (array $drawnCards): array => array_map(
+            static fn ($drawnCard): string => $drawnCard->card->getName() . ($drawnCard->holo ? '*' : ''),
+            $drawnCards,
+        );
+
+        // Reference: seeded draw with no replacement roll in between.
+        $reference = new RandomService();
+        $reference->seed(20260706);
+        $referenceDraw = $names(new CardDrawer($this->repositoryWith($cards), $reference)->draw($booster));
+
+        // Same seed, but a replacement roll happens first — the audit guarantee
+        // is that the stored seed still replays the main draw identically.
+        $random = new RandomService();
+        $random->seed(20260706);
+        $drawer = new CardDrawer($this->repositoryWith($cards), $random);
+        $drawer->drawReplacement($booster, CardRarityEnum::RARE);
+        $this->assertSame($referenceDraw, $names($drawer->draw($booster)));
+    }
+
     public function testSameSeedReproducesTheSameDraw(): void
     {
         $cards = [


### PR DESCRIPTION
## Phase 3j — Cartes uniques 1/1 (exclusivité globale au tirage)

Une carte marquée **unique** (`Card.uniqueFlag`, déjà présent + toggle BO) ne peut être possédée que par **un seul joueur** dans tout le jeu. C'est un *type* de carte (édition 1/1), pas une rareté.

### Mécanique
- **`Card.claimedBy`** (FK `DiscordUser`, nullable) + migration. `isClaimed()`. ON DELETE SET NULL (un compte supprimé libère la carte).
- **Filtre SQL du pool** — `CardRepository::findDrawablePool()` exclut les uniques **déjà revendiquées** (`uniqueFlag = false OR claimedBy IS NULL`). Une 1/1 possédée ne ressort jamais d'un booster.
- **Revendication atomique** — `CardRepository::claimUnique()` = `UPDATE … WHERE claimed_by IS NULL` (les ouvertures concurrentes sérialisent sur la ligne → exactement un gagnant).
- **Fallback** — `BoosterOpeningService` revendique chaque unique tirée ; si elle a été prise par une ouverture concurrente (ou tirée 2× dans le même booster), le slot retombe sur **une autre carte de la même rareté** (`CardDrawer::drawReplacement`, qui exclut toutes les uniques). → option « autre carte de même rareté » retenue.

### Visuel
- Badge **« 1/1 »** sur les cartes uniques (`CardComponent` ajoute la classe `.unique` + le badge), positionné au-dessus des calques holo et qui suit le tilt 3D.

### Tests (91 verts)
- `CardDrawerTest` : `drawReplacement` ne renvoie jamais d'unique / lève si seules des uniques existent.
- `BoosterOpeningServiceTest` (intégration) : le 1er ouvreur revendique l'unique (`claimedBy` posé, il la possède) ; un 2e ouvreur ne peut plus la tirer (exclue du pool, fallback rareté).
- `make quality` vert (2 fixes Rector pré-existants balayés, identiques à #49).

> Phase **parallèle** à #49 (epic→4 paliers) : fichiers **disjoints**, toutes deux basées sur `feat/phase-3h-holo-presets`. Inclut le commit glare de 3h. À merger après 3h.