### PR TITLE
feat(phase-3k1): zoom 3D des cartes + retours hub/homepage

### DIFF
--- a/assets/lib/card_tilt.js
+++ b/assets/lib/card_tilt.js
@@ -57,6 +57,10 @@ export class CardTilt {
     constructor(element) {
         this.element = element;
         this.rotator = element.querySelector('.card__rotator');
+        // The zoom translate/scale lives on the translater, NOT on the root:
+        // every pointer/centre computation must measure the translater's rect,
+        // or a zoomed card tracks the mouse against its empty grid slot.
+        this.translater = element.querySelector('.card__translater') || element;
         this.springs = {
             rotateX: this._spring(0),
             rotateY: this._spring(0),
@@ -102,6 +106,7 @@ export class CardTilt {
         if (activeInstance === this) {
             activeInstance = null;
         }
+        this._restoreAncestors();
         this._stopLoop();
     }
 
@@ -127,11 +132,12 @@ export class CardTilt {
         this.active = true;
         this.element.classList.add('active');
 
-        const rect = this.element.getBoundingClientRect();
+        const rect = this.translater.getBoundingClientRect();
         const scaleW = (window.innerWidth / rect.width) * 0.9;
         const scaleH = (window.innerHeight / rect.height) * 0.9;
         this.springs.scale.target = Math.min(scaleW, scaleH, MAX_POPOVER_SCALE);
         this.springs.flip.target = POPOVER_FLIP_DEG;
+        this._boostAncestors();
         this._setCenter();
 
         this._bindActiveListeners();
@@ -158,9 +164,9 @@ export class CardTilt {
 
     /** Aim the translate springs so the card sits at the viewport centre. */
     _setCenter() {
-        const rect = this.element.getBoundingClientRect();
-        // rect already includes the current translate, so add it back to get the
-        // delta from the card's resting position to the viewport centre.
+        const rect = this.translater.getBoundingClientRect();
+        // The translater's rect includes the current translate, so add it back
+        // to get the delta from the card's resting position to the centre.
         this.springs.translateX.target = round(
             window.innerWidth / 2 - rect.left - rect.width / 2 + this.springs.translateX.value,
         );
@@ -193,8 +199,52 @@ export class CardTilt {
         }
     }
 
+    /**
+     * A zoomed card must paint above everything, but any ancestor that creates
+     * a stacking context (transform/filter/z-index/opacity wrappers — the
+     * homepage hero does exactly that) traps its z-index. While active, lift
+     * every such ancestor; restored once the card has settled back home.
+     */
+    _boostAncestors() {
+        if (this._boosted) {
+            return;
+        }
+        this._boosted = [];
+        let node = this.element.parentElement;
+        while (node && node !== document.body) {
+            const style = getComputedStyle(node);
+            const createsContext = style.zIndex !== 'auto'
+                || style.transform !== 'none'
+                || style.filter !== 'none'
+                || (style.backdropFilter && style.backdropFilter !== 'none')
+                || parseFloat(style.opacity) < 1
+                || style.isolation === 'isolate'
+                || style.willChange.includes('transform')
+                || style.willChange.includes('opacity');
+            if (createsContext) {
+                this._boosted.push([node, node.style.position, node.style.zIndex]);
+                if (style.position === 'static') {
+                    node.style.position = 'relative'; // z-index needs a positioned box
+                }
+                node.style.zIndex = '500';
+            }
+            node = node.parentElement;
+        }
+    }
+
+    _restoreAncestors() {
+        if (!this._boosted) {
+            return;
+        }
+        for (const [node, position, zIndex] of this._boosted) {
+            node.style.position = position;
+            node.style.zIndex = zIndex;
+        }
+        this._boosted = null;
+    }
+
     _handlePointerMove(event) {
-        const rect = this.element.getBoundingClientRect();
+        const rect = this.translater.getBoundingClientRect();
         if (!rect.width || !rect.height) {
             return;
         }
@@ -266,6 +316,9 @@ export class CardTilt {
         if (!this.pointerInside && energy < SETTLE_THRESHOLD) {
             this._stopLoop();
             this.element.classList.remove('interacting');
+            if (!this.active) {
+                this._restoreAncestors(); // back in the grid: drop the lift
+            }
 
             return;
         }

--- a/assets/lib/card_tilt.js
+++ b/assets/lib/card_tilt.js
@@ -38,6 +38,9 @@ const POPOVER_STIFFNESS = 90;
 const POPOVER_DAMPING = 18;
 // Largest zoom factor when a card is activated (pokeholo uses 1.75).
 const MAX_POPOVER_SCALE = 1.75;
+// Full turn the card makes around Y while gliding to the viewport centre —
+// the click-to-zoom reads as "the card flips out of the grid into your hand".
+const POPOVER_FLIP_DEG = 360;
 // Clamp dt so a backgrounded tab doesn't make the integration explode.
 const MAX_DT = 0.032;
 const SETTLE_THRESHOLD = 0.01;
@@ -60,10 +63,11 @@ export class CardTilt {
             glareX: this._spring(50),
             glareY: this._spring(50),
             opacity: this._spring(0),
-            // popover springs (click-to-zoom): centre translation + scale
+            // popover springs (click-to-zoom): centre translation + scale + flip
             scale: this._spring(1),
             translateX: this._spring(0),
             translateY: this._spring(0),
+            flip: this._spring(0),
         };
         this.pointerInside = false;
         this.active = false;
@@ -127,6 +131,7 @@ export class CardTilt {
         const scaleW = (window.innerWidth / rect.width) * 0.9;
         const scaleH = (window.innerHeight / rect.height) * 0.9;
         this.springs.scale.target = Math.min(scaleW, scaleH, MAX_POPOVER_SCALE);
+        this.springs.flip.target = POPOVER_FLIP_DEG;
         this._setCenter();
 
         this._bindActiveListeners();
@@ -143,6 +148,7 @@ export class CardTilt {
         this.springs.scale.target = 1;
         this.springs.translateX.target = 0;
         this.springs.translateY.target = 0;
+        this.springs.flip.target = 0; // spins back the other way on the way home
         if (activeInstance === this) {
             activeInstance = null;
         }
@@ -237,9 +243,9 @@ export class CardTilt {
         const dt = Math.min((now - this.lastTime) / 1000, MAX_DT);
         this.lastTime = now;
 
-        // The popover springs (scale / translate) use a softer, slower spring
-        // than the tilt springs so the zoom glides instead of snapping.
-        const popover = new Set(['scale', 'translateX', 'translateY']);
+        // The popover springs (scale / translate / flip) use a softer, slower
+        // spring than the tilt springs so the zoom glides instead of snapping.
+        const popover = new Set(['scale', 'translateX', 'translateY', 'flip']);
 
         let energy = 0;
         for (const [name, spring] of Object.entries(this.springs)) {
@@ -268,7 +274,7 @@ export class CardTilt {
     }
 
     _render() {
-        const { rotateX, rotateY, glareX, glareY, opacity, scale, translateX, translateY } = this.springs;
+        const { rotateX, rotateY, glareX, glareY, opacity, scale, translateX, translateY, flip } = this.springs;
         const pointerFromCenter = clamp(
             Math.sqrt((glareY.value - 50) ** 2 + (glareX.value - 50) ** 2) / 50,
             0,
@@ -288,7 +294,9 @@ export class CardTilt {
         style.setProperty('--translate-x', `${translateX.value}px`);
         style.setProperty('--translate-y', `${translateY.value}px`);
 
-        this.rotator.style.transform = `rotateX(${rotateX.value}deg) rotateY(${rotateY.value}deg)`;
+        // Snap sub-degree flip residue so the settled card is perfectly flat.
+        const flipDeg = Math.abs(flip.value - flip.target) < 0.5 ? flip.target : flip.value;
+        this.rotator.style.transform = `rotateX(${rotateX.value}deg) rotateY(${rotateY.value + flipDeg}deg)`;
     }
 }
 

--- a/assets/lib/card_tilt.js
+++ b/assets/lib/card_tilt.js
@@ -140,8 +140,9 @@ export class CardTilt {
         this.element.classList.add('active');
 
         const rect = this.translater.getBoundingClientRect();
-        const scaleW = (window.innerWidth / rect.width) * 0.9;
-        const scaleH = (window.innerHeight / rect.height) * 0.9;
+        // ~3/4 of the viewport: the poke-holo presence — big, not wall-to-wall.
+        const scaleW = (window.innerWidth / rect.width) * 0.75;
+        const scaleH = (window.innerHeight / rect.height) * 0.75;
         this.springs.scale.target = Math.min(scaleW, scaleH, MAX_POPOVER_SCALE);
         this.springs.flip.target = POPOVER_FLIP_DEG;
         this._boostAncestors();
@@ -284,9 +285,10 @@ export class CardTilt {
         if (this.frame !== null) {
             return;
         }
-        // back on a compositor layer while the springs animate (see settle)
+        // back on a compositor layer + 3D context while the springs animate
         this.translater.style.willChange = '';
         this.rotator.style.willChange = '';
+        this.element.classList.remove('is-flat');
         this.element.classList.add('interacting');
         this.lastTime = performance.now();
         this.frame = requestAnimationFrame((now) => this._tick(now));
@@ -303,11 +305,10 @@ export class CardTilt {
         const dt = Math.min((now - this.lastTime) / 1000, MAX_DT);
         this.lastTime = now;
 
-        // The popover springs (scale / translate) use a softer, slower spring
-        // than the tilt springs so the zoom glides instead of snapping. The
-        // flip stays on the stiff spring: a punchier spin that also settles
-        // fast — the crisp re-raster below waits on every spring.
-        const popover = new Set(['scale', 'translateX', 'translateY']);
+        // The popover springs (scale / translate / flip) use a softer, slower
+        // spring than the tilt springs so the zoom (and its spin) glides at the
+        // poke-holo pace instead of snapping.
+        const popover = new Set(['scale', 'translateX', 'translateY', 'flip']);
 
         let settled = true;
         for (const [name, spring] of Object.entries(this.springs)) {
@@ -341,12 +342,22 @@ export class CardTilt {
                     this._restoreAncestors(); // back in the grid: drop the lift
                 }
             }
-            // Drop the will-change layer promotion once settled: with it on, the
-            // GPU keeps the raster cached at pre-zoom size and just stretches it
-            // (visibly pixelated at dpr 1). Cleared, the browser re-rasterises
-            // the card crisp at its final scale; _startLoop re-promotes.
+            // Crispness at rest: inside a 3D rendering context (perspective +
+            // preserve-3d) the GPU pins the raster at LAYOUT size and merely
+            // stretches it — visibly pixelated once zoomed, dpr 1 worst. When
+            // the card has settled flat (identity rotation), drop out of 3D
+            // entirely (is-flat + transform none) and release will-change: the
+            // browser re-rasterises at the real on-screen scale. _startLoop
+            // restores the 3D context the moment anything moves again.
             this.translater.style.willChange = 'auto';
             this.rotator.style.willChange = 'auto';
+            const flat = Math.abs(this.springs.rotateX.value) < 0.1
+                && Math.abs(this.springs.rotateY.value) < 0.1
+                && Math.abs(this.springs.flip.value % 360) < 0.5;
+            if (flat) {
+                this.rotator.style.transform = 'none';
+                this.element.classList.add('is-flat');
+            }
 
             return;
         }

--- a/assets/lib/card_tilt.js
+++ b/assets/lib/card_tilt.js
@@ -36,14 +36,21 @@ const SPRING_DAMPING = 22;
 // damped so the card glides to centre rather than snapping.
 const POPOVER_STIFFNESS = 90;
 const POPOVER_DAMPING = 18;
-// Largest zoom factor when a card is activated (pokeholo uses 1.75).
-const MAX_POPOVER_SCALE = 1.75;
+// Largest zoom factor when a card is activated. High cap on purpose: the real
+// limit is the 90% viewport fit computed in activate(), so the card gets as
+// big as the screen allows whatever its size in the grid.
+const MAX_POPOVER_SCALE = 3;
 // Full turn the card makes around Y while gliding to the viewport centre —
 // the click-to-zoom reads as "the card flips out of the grid into your hand".
 const POPOVER_FLIP_DEG = 360;
 // Clamp dt so a backgrounded tab doesn't make the integration explode.
 const MAX_DT = 0.032;
-const SETTLE_THRESHOLD = 0.01;
+// Per-spring rest tolerance. A quarter of a degree/pixel is invisible, and
+// waiting for less keeps the loop (and the pixelated GPU layer) alive for
+// seconds while the 360° flip creeps to zero. Unit-scaled springs (opacity
+// 0..1, scale ~1..3) need a much finer tolerance or the final snap would jump.
+const SETTLE_EPSILONS = { opacity: 0.01, scale: 0.005 };
+const SETTLE_EPSILON = 0.25;
 
 const clamp = (value, min = 0, max = 100) => Math.min(Math.max(value, min), max);
 const round = (value, precision = 3) => parseFloat(value.toFixed(precision));
@@ -277,6 +284,9 @@ export class CardTilt {
         if (this.frame !== null) {
             return;
         }
+        // back on a compositor layer while the springs animate (see settle)
+        this.translater.style.willChange = '';
+        this.rotator.style.willChange = '';
         this.element.classList.add('interacting');
         this.lastTime = performance.now();
         this.frame = requestAnimationFrame((now) => this._tick(now));
@@ -293,11 +303,13 @@ export class CardTilt {
         const dt = Math.min((now - this.lastTime) / 1000, MAX_DT);
         this.lastTime = now;
 
-        // The popover springs (scale / translate / flip) use a softer, slower
-        // spring than the tilt springs so the zoom glides instead of snapping.
-        const popover = new Set(['scale', 'translateX', 'translateY', 'flip']);
+        // The popover springs (scale / translate) use a softer, slower spring
+        // than the tilt springs so the zoom glides instead of snapping. The
+        // flip stays on the stiff spring: a punchier spin that also settles
+        // fast — the crisp re-raster below waits on every spring.
+        const popover = new Set(['scale', 'translateX', 'translateY']);
 
-        let energy = 0;
+        let settled = true;
         for (const [name, spring] of Object.entries(this.springs)) {
             const stiffness = popover.has(name) ? POPOVER_STIFFNESS : SPRING_STIFFNESS;
             const damping = popover.has(name) ? POPOVER_DAMPING : SPRING_DAMPING;
@@ -305,24 +317,41 @@ export class CardTilt {
                 - damping * spring.velocity;
             spring.velocity += acceleration * dt;
             spring.value += spring.velocity * dt;
-            energy += Math.abs(spring.velocity) + Math.abs(spring.value - spring.target);
+            const epsilon = SETTLE_EPSILONS[name] ?? SETTLE_EPSILON;
+            if (Math.abs(spring.value - spring.target) > epsilon || Math.abs(spring.velocity) > epsilon) {
+                settled = false;
+            }
         }
 
-        this._render();
-
-        // Stop once everything has settled (a zoomed-in card keeps its scale via
-        // the persisted CSS vars + the .active class; the .card.active CSS rule
-        // holds its z-index above the grid).
-        if (!this.pointerInside && energy < SETTLE_THRESHOLD) {
-            this._stopLoop();
-            this.element.classList.remove('interacting');
-            if (!this.active) {
-                this._restoreAncestors(); // back in the grid: drop the lift
+        // Stop as soon as every spring is within tolerance — snapped exactly on
+        // target so the final frame is pixel-perfect. The next pointermove or
+        // click restarts the loop, so idling here only burns frames. The hover
+        // state (interacting class + holo layers) is only dropped once the
+        // pointer has actually left.
+        if (settled) {
+            for (const spring of Object.values(this.springs)) {
+                spring.value = spring.target;
+                spring.velocity = 0;
             }
+            this._render();
+            this._stopLoop();
+            if (!this.pointerInside) {
+                this.element.classList.remove('interacting');
+                if (!this.active) {
+                    this._restoreAncestors(); // back in the grid: drop the lift
+                }
+            }
+            // Drop the will-change layer promotion once settled: with it on, the
+            // GPU keeps the raster cached at pre-zoom size and just stretches it
+            // (visibly pixelated at dpr 1). Cleared, the browser re-rasterises
+            // the card crisp at its final scale; _startLoop re-promotes.
+            this.translater.style.willChange = 'auto';
+            this.rotator.style.willChange = 'auto';
 
             return;
         }
 
+        this._render();
         this.frame = requestAnimationFrame((nextNow) => this._tick(nextNow));
     }
 

--- a/assets/styles/cards/base.css
+++ b/assets/styles/cards/base.css
@@ -105,6 +105,22 @@
     position: relative;
     z-index: calc(var(--card-scale) * 120);
   }
+
+  /* Settled, flat card taken OUT of its 3D rendering context (card_tilt.js
+     toggles this): inside perspective + preserve-3d the GPU rasterises at
+     layout size and stretches — pixelated once zoomed. Flat, the browser
+     re-rasterises at the true on-screen scale. */
+  .card.is-flat .card__translater,
+  .card.is-flat .card__rotator {
+    perspective: none;
+    transform-style: flat;
+  }
+  /* their translate3d(0,0,.01px) exists only for 3D ordering — flat, it just
+     pins another layer rasterised at layout size */
+  .card.is-flat .card__front,
+  .card.is-flat .card__front img {
+    transform: none;
+  }
   
   .card.active .card__translater,
   .card.active .card__rotator {

--- a/assets/styles/cards/base.css
+++ b/assets/styles/cards/base.css
@@ -100,6 +100,9 @@
   }
   
   .card.interacting {
+    /* positioned so the z-index applies; scales with the zoom so a card
+       gliding back home still paints above the grid until it lands */
+    position: relative;
     z-index: calc(var(--card-scale) * 120);
   }
   

--- a/assets/styles/cards/holo-presets.css
+++ b/assets/styles/cards/holo-presets.css
@@ -846,7 +846,10 @@
  * and scaled up; keep it above the grid once the tilt loop settles and drops the
  * .interacting class. */
 .card.active {
-    z-index: 120;
+    /* above the sticky header (z-50) and every grid badge; position makes the
+       z-index effective whatever display the parent gives the card */
+    position: relative;
+    z-index: 500;
 }
 
 /* The --card-border accent border already lives in holo.css (.card__front),

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -96,9 +96,11 @@
      * tall screen) instead of the cramped ~640px the old 58vh/700px cap produced. */
     width: min(54vw, 1180px, calc(78vh * 0.92));
     aspect-ratio: .92;
-    /* small upward bias; the pack is now top-aligned inside the canvas (JS), so the
-     * heavy lifting is done there and we only nudge the stage up a touch */
-    margin-top: clamp(-48px, -2.5vh, -8px);
+    /* upward bias; the pack is top-aligned inside the canvas (JS) but the column
+     * centers its content (justify-content), so only HALF of this margin actually
+     * moves the pack up — hence the seemingly large values (≈-99px at 900px of
+     * viewport ≈ a ~38px visual lift). The clipped canvas top is empty/transparent. */
+    margin-top: clamp(-140px, -11vh, -30px);
 }
 @media (max-width: 900px) {
     .opening__pack-stage {
@@ -153,12 +155,21 @@
 .opening__showcase {
     position: absolute;
     inset: -8% -6%;
+    /* the showcase is centered on the stage, which the pack-phase margin above
+     * pulls up; push the reveal back down by the same visual offset (half the
+     * extra margin — flex centering absorbs the other half) so its composition
+     * stays put: the rarity label must clear the 64px header, not slide under it */
+    transform: translateY(clamp(11px, 4.25vh, 46px));
     z-index: 5;
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     cursor: pointer;
+}
+/* the small mobile stage margin needs no reveal compensation */
+@media (max-width: 900px) {
+    .opening__showcase { transform: none; }
 }
 
 .opening__aura {

--- a/src/Repository/BoosterRepository.php
+++ b/src/Repository/BoosterRepository.php
@@ -25,7 +25,10 @@ class BoosterRepository extends ServiceEntityRepository
     public function findPublished(): array
     {
         return $this->createQueryBuilder('booster')
+            // addSelect hydrates the extension in the same query: the hub reads
+            // extension.name/image on every booster, one lazy load each otherwise
             ->join('booster.extension', 'extension')
+            ->addSelect('extension')
             ->andWhere('extension.status = :status')
             ->setParameter('status', ExtensionStatusEnum::PUBLISHED)
             ->orderBy('extension.name', 'ASC')

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -27,6 +27,14 @@ final class BoosterHub extends AbstractController
     #[LiveProp]
     public ?string $error = null;
 
+    /**
+     * Inventory is read twice per render (hero total + packs grid): memoize
+     * the query for the lifetime of the (per-request) component instance.
+     *
+     * @var array<string, int>|null
+     */
+    private ?array $inventory = null;
+
     public function __construct(
         private readonly BoosterRepository $boosterRepository,
         private readonly CardRepository $cardRepository,
@@ -88,13 +96,25 @@ final class BoosterHub extends AbstractController
      */
     public function getInventory(): array
     {
+        if (null !== $this->inventory) {
+            return $this->inventory;
+        }
+
         $inventory = [];
 
         foreach ($this->userBoosterRepository->findBy(['discordUser' => $this->getDiscordUser()]) as $userBooster) {
             $inventory[(string) $userBooster->getBooster()->getId()] = $userBooster->getQuantity();
         }
 
-        return $inventory;
+        return $this->inventory = $inventory;
+    }
+
+    /**
+     * Total unopened boosters across every pack type, for the hero counter.
+     */
+    public function getTotalOwned(): int
+    {
+        return array_sum($this->getInventory());
     }
 
     #[LiveAction]
@@ -112,6 +132,7 @@ final class BoosterHub extends AbstractController
 
         try {
             $this->boosterClaimService->claim($this->getDiscordUser(), $booster);
+            $this->inventory = null; // the memoized inventory is stale after a claim
         } catch (BoosterException $exception) {
             $this->error = $exception->getUserMessage();
         }

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -32,6 +32,11 @@
                     {% else %}
                         <p class="chip-mono text-live">✦ {{ this.remainingClaims }} pack{{ this.remainingClaims > 1 ? 's' }} à récupérer</p>
                     {% endif %}
+
+                    {% set totalOwned = this.totalOwned %}
+                    <p class="chip-mono {{ totalOwned > 0 ? 'text-primary' : 'text-ink-dim' }}" data-testid="total-owned">
+                        ◈ {{ totalOwned }} pack{{ totalOwned > 1 ? 's' }} en stock
+                    </p>
                 </div>
             </div>
         </section>
@@ -87,29 +92,39 @@
                                        aria-label="Ouvrir un pack {{ booster.extension.name }}"></a>
                                 {% endif %}
 
-                                {# footer: claim chip on the left, open / status on the right #}
-                                <div class="relative z-20 mt-4 flex items-center justify-between border-t border-hairline pt-3">
+                                {# footer: owned stock on the left, open / status on the right, claim below #}
+                                <div class="relative z-20 mt-4 border-t border-hairline pt-3">
+                                    <div class="flex min-h-7 items-center justify-between gap-2">
+                                        {% if owned > 0 %}
+                                            <span class="chip-mono border border-primary/40 bg-primary/10 px-2 py-1 font-bold text-primary" data-testid="owned-count">
+                                                ◈ {{ owned }} pack{{ owned > 1 ? 's' }} à ouvrir
+                                            </span>
+                                        {% else %}
+                                            <span class="chip-mono border border-transparent px-2 py-1 text-ink-dim" data-testid="owned-count">
+                                                ◈ Aucun pack
+                                            </span>
+                                        {% endif %}
+
+                                        {% if owned > 0 and drawable %}
+                                            <a href="{{ path('booster_open', {id: booster.id}) }}"
+                                               class="flex items-center gap-1 font-display text-xs font-bold uppercase tracking-[.12em] text-ink-strong transition hover:text-primary">
+                                                Ouvrir <span aria-hidden="true">›</span>
+                                            </a>
+                                        {% elseif not drawable %}
+                                            <span class="font-mono text-[11px] uppercase tracking-[.1em] text-ink-dim"
+                                                  title="Cette extension n'a pas encore de carte publiée.">À venir</span>
+                                        {% endif %}
+                                    </div>
+
                                     {% if remainingClaims > 0 %}
                                         <button type="button"
                                                 data-action="live#action"
                                                 data-live-action-param="claimBooster"
                                                 data-live-booster-id-param="{{ booster.id }}"
-                                                class="font-mono text-[11px] font-bold uppercase tracking-[.1em] text-primary transition hover:text-ink-strong">
+                                                class="mt-2 px-2 font-mono text-[11px] font-bold uppercase tracking-[.1em] text-primary transition hover:text-ink-strong">
                                             <span data-loading="hide">+ Récupérer</span>
                                             <span data-loading="show" class="hidden">···</span>
                                         </button>
-                                    {% else %}
-                                        <span class="chip-mono text-ink-dim">×{{ owned }}</span>
-                                    {% endif %}
-
-                                    {% if owned > 0 and drawable %}
-                                        <a href="{{ path('booster_open', {id: booster.id}) }}"
-                                           class="flex items-center gap-1 font-display text-xs font-bold uppercase tracking-[.12em] text-ink-strong transition hover:text-primary">
-                                            Ouvrir <span aria-hidden="true">›</span>
-                                        </a>
-                                    {% elseif not drawable %}
-                                        <span class="font-mono text-[11px] uppercase tracking-[.1em] text-ink-dim"
-                                              title="Cette extension n'a pas encore de carte publiée.">À venir</span>
                                     {% endif %}
                                 </div>
                             </article>

--- a/templates/components/CardComponent.html.twig
+++ b/templates/components/CardComponent.html.twig
@@ -16,6 +16,12 @@
      {%- if styleVars is not empty %} style="{{ styleVars|join('; ') }}"{% endif %}>
     <div class="card__translater">
         <div class="card__rotator">
+            {# real back face: shown mid-spin by the click-to-zoom flip
+               (card__front is backface-hidden, so without it the card would
+               blink out between 90° and 270°) #}
+            <div class="card__back" aria-hidden="true">
+                <img src="{{ asset('images/card-back.svg') }}" alt="" draggable="false">
+            </div>
             <div class="card__front">
                 <img src="{{ vich_uploader_asset(card) }}" alt="{{ card.name }}" onerror="this.onerror=null;this.src='{{ asset('images/cards/default_card.png') }}';">
                 <div class="card__shine"></div>

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -53,12 +53,19 @@
         </section>
 
         {# ---------------------------------------------------------- Ticker #}
+        {# Paliers de rareté (source unique ticker + section Raretés) : doit suivre CardRarityEnum #}
+        {% set rarities = [
+            {label: 'Common', chip: 'C', color: 'var(--rarity-common)'},
+            {label: 'Uncommon', chip: 'U', color: 'var(--rarity-uncommon)'},
+            {label: 'Rare', chip: 'R', color: 'var(--rarity-rare)'},
+            {label: 'Legendary', chip: 'L', color: 'var(--rarity-legendary)'},
+        ] %}
         {% set tickerItems = [
             "✦ %s packs ouverts"|format(packsOpenedCount|number_format(0, ',', ' ')),
             '✦ %d univers'|format(extensions|length),
             '✦ %d cartes à collectionner'|format(cardsTotal),
             '✦ 2 packs / jour',
-            '✦ 5 paliers de rareté',
+            '✦ %d paliers de rareté'|format(rarities|length),
         ] %}
         {# La boucle marquee = 2 copies de la piste, translateX(-50%). Chaque
            copie répète les items 3× pour rester plus large que le viewport :
@@ -157,25 +164,18 @@
             <div class="mx-auto max-w-7xl">
                 <p class="eyebrow">02 / Raretés</p>
                 <h2 class="mb-10 mt-4 font-display text-5xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-6xl">
-                    5 paliers.
+                    {{ rarities|length }} paliers.
                 </h2>
 
-                {# Poids purement indicatifs (copy marketing) : les vrais taux sont définis par booster #}
-                {% set rarities = [
-                    {label: 'Common', chip: 'C', weight: 60, color: 'var(--rarity-common)'},
-                    {label: 'Uncommon', chip: 'U', weight: 25, color: 'var(--rarity-uncommon)'},
-                    {label: 'Rare', chip: 'R', weight: 14, color: 'var(--rarity-rare)'},
-                    {label: 'Legendary', chip: 'L', weight: 1, color: 'var(--rarity-legendary)'},
-                ] %}
-                <div class="flex flex-col items-stretch md:flex-row">
+                {# Pas de « drop rate » global affiché : les vrais taux sont définis slot par slot, booster par booster #}
+                <div class="grid md:grid-cols-4">
                     {% for rarity in rarities %}
                         <div class="px-5 py-8 {{ not loop.last ? 'md:border-r md:border-white/10' }}"
-                             style="flex: {{ rarity.weight + 5 }} 1 0%; border-top: 3px solid {{ rarity.color }}; background: linear-gradient(180deg, color-mix(in srgb, {{ rarity.color }} 9%, transparent), transparent);">
-                            <p class="chip-mono font-bold !tracking-[.2em]" style="color: {{ rarity.color }};">{{ rarity.chip }} · {{ rarity.label|upper }}</p>
-                            <p class="mt-4 font-display text-5xl font-bold tracking-[-0.04em] text-ink-strong">
-                                {{ rarity.weight }}<span class="text-2xl" style="color: {{ rarity.color }};">%</span>
+                             style="border-top: 3px solid {{ rarity.color }}; background: linear-gradient(180deg, color-mix(in srgb, {{ rarity.color }} 9%, transparent), transparent);">
+                            <p class="chip-mono font-bold !tracking-[.2em]" style="color: {{ rarity.color }};">TIER {{ '%02d'|format(loop.index) }}</p>
+                            <p class="mt-4 font-display text-4xl font-bold uppercase tracking-[-0.04em] text-ink-strong">
+                                {{ rarity.chip }}<span class="text-2xl" style="color: {{ rarity.color }};"> · {{ rarity.label }}</span>
                             </p>
-                            <p class="chip-mono mt-2 text-ink-dim">drop rate</p>
                         </div>
                     {% endfor %}
                 </div>

--- a/tests/Functional/BoosterHubComponentTest.php
+++ b/tests/Functional/BoosterHubComponentTest.php
@@ -36,6 +36,23 @@ final class BoosterHubComponentTest extends WebTestCase
         $this->assertNotNull($userBooster);
         $this->assertSame(1, $userBooster->getQuantity());
         $this->assertNull($component->component()->error);
+
+        // The owned count is surfaced on the pack card and totalled in the hero.
+        $rendered = (string) $component->render();
+        $this->assertStringContainsString('◈ 1 pack à ouvrir', $rendered);
+        $this->assertStringContainsString('◈ 1 pack en stock', $rendered);
+    }
+
+    public function testEmptyInventoryShowsAnExplicitZeroStockState(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $rendered = (string) $component->render();
+
+        $this->assertStringContainsString('◈ Aucun pack', $rendered);
+        $this->assertStringContainsString('◈ 0 pack en stock', $rendered);
     }
 
     public function testClaimBoosterWithMalformedIdReportsNotFoundInsteadOfCrashing(): void

--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -49,7 +49,7 @@ final class HomepageTest extends WebTestCase
         // The design uppercases through CSS: the DOM keeps the source case.
         $body = $crawler->filter('main')->text();
         $this->assertStringContainsString('PRESS START', $body);
-        $this->assertStringContainsString('5 paliers.', $body);
+        $this->assertStringContainsString('4 paliers.', $body);
         $this->assertStringContainsString('Prochain univers', $body);
     }
 


### PR DESCRIPTION
Première tranche des retours UX de la phase 3k (découpe de l'ex-PR #53 pour des reviews digestes — histoire inchangée, uniquement des refs posées sur les commits existants).

## Contenu
- **Zoom 3D au clic** sur toutes les cartes : flip 360° avec vrai dos de carte, ~75 % du viewport façon poke-holo, spring d'origine
- Carte zoomée toujours au premier plan (gestion des stacking contexts) + suivi souris recalibré
- Netteté du zoom au repos (sortie du contexte de rendu 3D une fois posée)
- **Hub** : pack 3D remonté dans la vue d'ouverture, compteur de packs possédés lisible, fix du N+1 extensions
- **Homepage** : purge des chiffres incohérents (4 paliers réels, drop rates fictifs retirés)

## Review
- `assets/lib/card_tilt.js` concentre la logique zoom/tilt
- Chaque commit était vert (tests + quality) au moment de son écriture

🤖 Generated with [Claude Code](https://claude.com/claude-code)