### PR TITLE
fix(prod): APP_SECRET manquant (500 hub/admin) + passe « gros youl »

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 ### Configuration Notes
 
 **Environment Variables (required):**
+- `APP_SECRET`: kernel secret (signs Live Component checksums — an empty value 500s every page rendering one, hub and admin included)
 - `DATABASE_URL`: PostgreSQL connection string
 - `JWT_SECRET_KEY`: Path to JWT private key
 - `JWT_PUBLIC_KEY`: Path to JWT public key

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -5,6 +5,9 @@ services:
             - ytcg_caddy_data:/data
             - ytcg_public_data:/app/public/images
         environment:
+            # kernel.secret : signe notamment les checksums des Live Components —
+            # vide, toute page qui en rend un (hub, admin) tombe en 500
+            APP_SECRET: "${APP_SECRET}"
             DATABASE_URL: "postgresql://${DB_USER}:${DB_PASSWORD}@ytcg_db:5432/ytcg?serverVersion=18&charset=utf8"
             JWT_PUBLIC_KEY: "${JWT_PUBLIC_KEY}"
             JWT_SECRET_KEY: "${JWT_SECRET_KEY}"

--- a/templates/pages/collection.html.twig
+++ b/templates/pages/collection.html.twig
@@ -164,7 +164,7 @@
                 {% else %}
                     <div class="border border-dashed border-hairline px-8 py-20 text-center text-ink-dim" data-testid="empty-state">
                         <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Vide.</p>
-                        <p class="mt-3 text-sm">Aucune carte de cet univers. Ouvre un pack.</p>
+                        <p class="mt-3 text-sm">Aucune carte de cet univers. Ouvre un pack, gros youl.</p>
                         <a href="{{ path('boosters') }}" class="btn-arcade mt-8">Ouvrir un pack ▸</a>
                     </div>
                 {% endif %}

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -17,11 +17,11 @@
                     <h1 class="mt-6 font-display text-[clamp(2.75rem,4.8vw,6rem)] font-bold uppercase leading-[.9] tracking-[-0.05em] text-ink-strong">
                         Ouvre.<br>
                         <span class="text-primary">Collectionne.</span><br>
-                        <span class="bg-gradient-to-r from-primary to-magenta bg-clip-text text-transparent">Frime.</span>
+                        <span class="bg-gradient-to-r from-primary to-magenta bg-clip-text text-transparent">Gros Youl.</span>
                     </h1>
                     <p class="mt-7 max-w-md text-[17px] leading-normal text-ink-muted">
-                        Le TCG fan-made où tous tes univers préférés s'affrontent.
-                        Ouvre tes packs quotidiens, chasse les légendaires et complète ta collection.
+                        Le TCG youl-made où tous tes univers préférés s'affrontent.
+                        Ouvre tes packs quotidiens, chasse les légendaires et complète ta collection de gros youl.
                     </p>
                     <div class="mt-8 flex flex-wrap gap-3">
                         <a href="{{ path('boosters') }}" class="btn-arcade">Ouvrir un pack ▸</a>
@@ -66,6 +66,7 @@
             '✦ %d cartes à collectionner'|format(cardsTotal),
             '✦ 2 packs / jour',
             '✦ %d paliers de rareté'|format(rarities|length),
+            '✦ 100 % youl-made',
         ] %}
         {# La boucle marquee = 2 copies de la piste, translateX(-50%). Chaque
            copie répète les items 3× pour rester plus large que le viewport :

--- a/templates/parts/_footer.html.twig
+++ b/templates/parts/_footer.html.twig
@@ -12,6 +12,6 @@
                    style="accent-color: #a435f0;">
             CRT
         </label>
-        <span>fan-made · non-officiel</span>
+        <span>youl-made · non-officiel</span>
     </div>
 </footer>

--- a/tests/Functional/EmptyHubTest.php
+++ b/tests/Functional/EmptyHubTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class EmptyHubTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    public function testBoostersPageWithNoBoosterAtAll(): void
+    {
+        $client = self::createClient();
+        $this->authenticateClient($client);
+
+        $em = self::getContainer()->get(EntityManagerInterface::class);
+        foreach (['user_booster', 'booster_claim', 'booster_opening_card', 'booster_opening', 'booster', 'user_card', 'card', 'extension_banner', 'extension'] as $table) {
+            $em->getConnection()->executeStatement("DELETE FROM $table");
+        }
+
+        $client->request('GET', '/boosters');
+        self::assertResponseIsSuccessful();
+        $client->request('GET', '/');
+        self::assertResponseIsSuccessful();
+        $client->request('GET', '/univers');
+        self::assertResponseIsSuccessful();
+        $client->request('GET', '/collection');
+        self::assertResponseIsSuccessful();
+    }
+}

--- a/tests/Functional/LayoutTest.php
+++ b/tests/Functional/LayoutTest.php
@@ -34,7 +34,7 @@ final class LayoutTest extends WebTestCase
         self::assertResponseIsSuccessful();
         $this->assertStringContainsString('YOUL', $crawler->filter('header')->text());
         $this->assertStringContainsString('TRADING CARD GAME', $crawler->filter('header')->text());
-        $this->assertStringContainsString('fan-made · non-officiel', $crawler->filter('footer')->text());
+        $this->assertStringContainsString('youl-made · non-officiel', $crawler->filter('footer')->text());
     }
 
     #[DataProvider('pageProvider')]


### PR DESCRIPTION
- « Frime. » → « Gros Youl. » (gradient conservé), « fan-made » → « youl-made » (hero, footer, ticker), « complète ta collection de gros youl », empty state collection « Ouvre un pack, gros youl. »
- Nouveau test fonctionnel : /, /boosters, /univers et /collection rendent en 200 sur une base **entièrement vide** — le scénario prod jour 1 n'était couvert par aucun test. NB : ce test passe déjà → la 500 prod signalée sur /boosters n'est PAS causée par l'absence de boosters ; trace prod attendue pour diagnostiquer (suspects : asset-map:compile absent du build CI, spécificité env prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)