### PR TITLE
fix(deps): verrouille symfony/var-exporter en ^7.4 (débloque les PR Dependabot)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/ux-live-component": "^3.1",
         "symfony/ux-twig-component": "^2.23",
         "symfony/validator": "7.4.*",
+        "symfony/var-exporter": "^7.4",
         "symfony/yaml": "7.4.*",
         "symfonycasts/tailwind-bundle": "^0.7.1",
         "tales-from-a-dev/flowbite-bundle": "^0.7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32369721db7a15db40d132e9626939b9",
+    "content-hash": "f23784a1c9bdeed32623d5942d6f104b",
     "packages": [
         {
             "name": "barlito/utils",


### PR DESCRIPTION
Toutes les PR Dependabot rouges (#62/#63/#64/#71 et la CI de #67) échouent pour la même raison : leur lock tire **symfony/var-exporter v8**, où LazyGhost a été supprimé, alors que Doctrine tourne en `enable_lazy_ghost_objects` → `cache:clear` KO au composer install.

Fix minimal : contrainte racine `^7.4` sur var-exporter. La vraie migration (`enable_native_lazy_objects`, PHP 8.4) a été tentée et déclenche une incohérence d'identity map au re-render d'un Live Component — notée comme chantier séparé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)