### PR TITLE
chore(deps): retire flowbite-bundle (inutilisé) — remplace #65

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,8 +177,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 **Asset Pipeline:**
 - Uses Symfony AssetMapper (no Webpack/build step)
 - Importmap manages dependencies
-- Flowbite UI components for carousels and dropdowns
-- Tailwind CSS for styling
+- Tailwind CSS for styling (carousels are the in-house `carousel` Stimulus controller)
 
 ### File Uploads
 

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "symfony/var-exporter": "^7.4",
         "symfony/yaml": "7.4.*",
         "symfonycasts/tailwind-bundle": "^0.7.1",
-        "tales-from-a-dev/flowbite-bundle": "^0.7.1",
         "vich/uploader-bundle": "^2.4",
         "wohali/oauth2-discord-new": "^1.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f23784a1c9bdeed32623d5942d6f104b",
+    "content-hash": "0ec529a848aff8f03d6f83cb3f6ad1af",
     "packages": [
         {
             "name": "barlito/utils",
@@ -1738,71 +1738,6 @@
             "time": "2025-12-13T19:37:35+00:00"
         },
         {
-            "name": "gehrisandro/tailwind-merge-php",
-            "version": "v1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/gehrisandro/tailwind-merge-php.git",
-                "reference": "400040c89bc958ed130699ee4db0213f689cd498"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/gehrisandro/tailwind-merge-php/zipball/400040c89bc958ed130699ee4db0213f689cd498",
-                "reference": "400040c89bc958ed130699ee4db0213f689cd498",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.2.0",
-                "psr/simple-cache": "^3.0"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.13.8",
-                "nunomaduro/collision": "^v8.9.1",
-                "pestphp/pest": "^v4.4.2",
-                "pestphp/pest-plugin-type-coverage": "^v4.0.3",
-                "phpstan/phpstan": "^2.1.42",
-                "rector/rector": "^2.3.9",
-                "symfony/var-dumper": "^v7.4.6"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/TailwindMerge.php"
-                ],
-                "psr-4": {
-                    "TailwindMerge\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Sandro Gehri",
-                    "email": "sandrogehri@gmail.com"
-                }
-            ],
-            "description": "TailwindMerge for PHP merges multiple Tailwind CSS classes by automatically resolving conflicts between them",
-            "keywords": [
-                "classes",
-                "merge",
-                "php",
-                "tailwindcss"
-            ],
-            "support": {
-                "issues": "https://github.com/gehrisandro/tailwind-merge-php/issues",
-                "source": "https://github.com/gehrisandro/tailwind-merge-php/tree/v1.2.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/gehrisandro",
-                    "type": "github"
-                }
-            ],
-            "time": "2026-03-21T06:39:15+00:00"
-        },
-        {
             "name": "guzzlehttp/guzzle",
             "version": "7.12.1",
             "source": {
@@ -3023,57 +2958,6 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
             "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
-            "name": "psr/simple-cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/simple-cache.git",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\SimpleCache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for simple caching",
-            "keywords": [
-                "cache",
-                "caching",
-                "psr",
-                "psr-16",
-                "simple-cache"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
-            },
-            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -8823,120 +8707,6 @@
                 "source": "https://github.com/SymfonyCasts/tailwind-bundle/tree/v0.7.1"
             },
             "time": "2025-01-23T14:54:07+00:00"
-        },
-        {
-            "name": "tales-from-a-dev/flowbite-bundle",
-            "version": "v0.7.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tales-from-a-dev/flowbite-bundle.git",
-                "reference": "cfc2fbebba6989f0d8b5cc00fdc95b7f3edabe2f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tales-from-a-dev/flowbite-bundle/zipball/cfc2fbebba6989f0d8b5cc00fdc95b7f3edabe2f",
-                "reference": "cfc2fbebba6989f0d8b5cc00fdc95b7f3edabe2f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/http-kernel": "^6.4 || ^7.0",
-                "symfony/twig-bridge": "^6.4 || ^7.0",
-                "tales-from-a-dev/twig-tailwind-extra": "^0.3"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.15",
-                "phpunit/phpunit": "^10.0",
-                "symfony/form": "^6.4 || ^7.0",
-                "symfony/intl": "^6.4 || ^7.0",
-                "symfony/security-csrf": "^6.4 || ^7.0",
-                "symfony/translation": "^6.4 || ^7.0"
-            },
-            "type": "symfony-bundle",
-            "autoload": {
-                "psr-4": {
-                    "TalesFromADev\\FlowbiteBundle\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Romain Monteil",
-                    "email": "monteil.romain@gmail.com"
-                }
-            ],
-            "description": "A Symfony form theme for Flowbite",
-            "homepage": "https://github.com/tales-from-a-dev/flowbite-bundle",
-            "keywords": [
-                "bundle",
-                "flowbite",
-                "form",
-                "symfony",
-                "theme"
-            ],
-            "support": {
-                "issues": "https://github.com/tales-from-a-dev/flowbite-bundle/issues",
-                "source": "https://github.com/tales-from-a-dev/flowbite-bundle/tree/v0.7.1"
-            },
-            "time": "2024-12-11T13:52:04+00:00"
-        },
-        {
-            "name": "tales-from-a-dev/twig-tailwind-extra",
-            "version": "v0.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/tales-from-a-dev/twig-tailwind-extra.git",
-                "reference": "a3cb86414dd5810740cf91966bc1cf10047ce8ef"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/tales-from-a-dev/twig-tailwind-extra/zipball/a3cb86414dd5810740cf91966bc1cf10047ce8ef",
-                "reference": "a3cb86414dd5810740cf91966bc1cf10047ce8ef",
-                "shasum": ""
-            },
-            "require": {
-                "gehrisandro/tailwind-merge-php": "^1.0",
-                "php": ">=8.2",
-                "symfony/cache": "^6.4 || ^7.0",
-                "symfony/framework-bundle": "^6.4 || ^7.0",
-                "twig/twig": "^3.0"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.38",
-                "symfony/phpunit-bridge": "^6.4 || ^7.0"
-            },
-            "type": "twig",
-            "autoload": {
-                "psr-4": {
-                    "TalesFromADev\\Twig\\Extra\\Tailwind\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Romain Monteil",
-                    "email": "monteil.romain@gmail.com"
-                }
-            ],
-            "description": "A Twig extension for Tailwind",
-            "homepage": "https://github.com/tales-from-a-dev/twig-tailwind-extra",
-            "keywords": [
-                "extension",
-                "symfony",
-                "tailwind",
-                "twig"
-            ],
-            "support": {
-                "issues": "https://github.com/tales-from-a-dev/twig-tailwind-extra/issues",
-                "source": "https://github.com/tales-from-a-dev/twig-tailwind-extra/tree/v0.3.0"
-            },
-            "time": "2024-08-07T23:27:08+00:00"
         },
         {
             "name": "twig/extra-bundle",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -17,8 +17,6 @@ return [
     EasyCorp\Bundle\EasyAdminBundle\EasyAdminBundle::class => ['all' => true],
     KnpU\OAuth2ClientBundle\KnpUOAuth2ClientBundle::class => ['all' => true],
     Symfonycasts\TailwindBundle\SymfonycastsTailwindBundle::class => ['all' => true],
-    TalesFromADev\Twig\Extra\Tailwind\Bridge\Symfony\Bundle\TalesFromADevTwigExtraTailwindBundle::class => ['all' => true],
-    TalesFromADev\FlowbiteBundle\TalesFromADevFlowbiteBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\DebugBundle\DebugBundle::class => ['dev' => true],
     Symfony\UX\TwigComponent\TwigComponentBundle::class => ['all' => true],

--- a/symfony.lock
+++ b/symfony.lock
@@ -401,24 +401,6 @@
     "symfonycasts/tailwind-bundle": {
         "version": "v0.7.1"
     },
-    "tales-from-a-dev/flowbite-bundle": {
-        "version": "0.7",
-        "recipe": {
-            "repo": "github.com/symfony/recipes-contrib",
-            "branch": "main",
-            "version": "0.4",
-            "ref": "8c5eef17730535682128557a1016872fd3e81c33"
-        }
-    },
-    "tales-from-a-dev/twig-tailwind-extra": {
-        "version": "0.3",
-        "recipe": {
-            "repo": "github.com/symfony/recipes-contrib",
-            "branch": "main",
-            "version": "0.2",
-            "ref": "7243ab070ed66198eb82c026684e9b9773e7b64a"
-        }
-    },
     "theofidry/alice-data-fixtures": {
         "version": "1.7",
         "recipe": {


### PR DESCRIPTION
L'audit code-mort a prouvé que flowbite-bundle n'est utilisé nulle part : aucune entrée importmap, aucun import dans assets/, aucun form theme déclaré, aucun `<form>` Twig hors EasyAdmin, et les `data-carousel-*` appartiennent au controller Stimulus maison. Plutôt que de bumper un package mort (#65), on le retire (avec son bundle transitif twig-extra-tailwind dans bundles.php).

Vérifié : cache:clear dev+test, tailwind:build, 130 tests verts, quality OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)