### PR TITLE
chore(deps): tailwind-bundle 0.14 + binaire épinglé v3.4.17 (remplace #71)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "symfony/validator": "7.4.*",
         "symfony/var-exporter": "^7.4",
         "symfony/yaml": "7.4.*",
-        "symfonycasts/tailwind-bundle": "^0.7.1",
+        "symfonycasts/tailwind-bundle": "^0.14",
         "vich/uploader-bundle": "^2.4",
         "wohali/oauth2-discord-new": "^1.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4739c85f211bd51724a6fcedefbeaf3c",
+    "content-hash": "7a6ca125a99d02dcdbb093ac200f5385",
     "packages": [
         {
             "name": "barlito/utils",
@@ -8643,31 +8643,33 @@
         },
         {
             "name": "symfonycasts/tailwind-bundle",
-            "version": "v0.7.1",
+            "version": "v0.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SymfonyCasts/tailwind-bundle.git",
-                "reference": "81c9e6ff2bb1a95e67fc6af04ca87fccdcf55aa4"
+                "reference": "eb839e8afa3d7dc2220ae1a7a6b8d215ccf85f83"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SymfonyCasts/tailwind-bundle/zipball/81c9e6ff2bb1a95e67fc6af04ca87fccdcf55aa4",
-                "reference": "81c9e6ff2bb1a95e67fc6af04ca87fccdcf55aa4",
+                "url": "https://api.github.com/repos/SymfonyCasts/tailwind-bundle/zipball/eb839e8afa3d7dc2220ae1a7a6b8d215ccf85f83",
+                "reference": "eb839e8afa3d7dc2220ae1a7a6b8d215ccf85f83",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/asset-mapper": "^6.3|^7.0",
-                "symfony/cache": "^6.3|^7.0",
-                "symfony/console": "^5.4|^6.3|^7.0",
-                "symfony/http-client": "^5.4|^6.3|^7.0",
-                "symfony/process": "^5.4|^6.3|^7.0"
+                "php": ">=8.2",
+                "symfony/asset-mapper": "^6.4|^7.0|^8.0",
+                "symfony/cache": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/deprecation-contracts": "^2.2|^3.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/process": "^6.4|^7.0|^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9.6",
-                "symfony/filesystem": "^6.3|^7.0",
-                "symfony/framework-bundle": "^6.3|^7.0",
-                "symfony/phpunit-bridge": "^6.3.9|^7.0"
+                "symfony/filesystem": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/phpunit-bridge": "^8.1",
+                "symfony/yaml": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -8692,9 +8694,15 @@
             ],
             "support": {
                 "issues": "https://github.com/SymfonyCasts/tailwind-bundle/issues",
-                "source": "https://github.com/SymfonyCasts/tailwind-bundle/tree/v0.7.1"
+                "source": "https://github.com/SymfonyCasts/tailwind-bundle/tree/v0.14.0"
             },
-            "time": "2025-01-23T14:54:07+00:00"
+            "funding": [
+                {
+                    "url": "https://symfonycasts.com",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-06-21T15:46:15+00:00"
         },
         {
             "name": "twig/extra-bundle",

--- a/config/packages/symfonycasts_tailwind.yaml
+++ b/config/packages/symfonycasts_tailwind.yaml
@@ -1,0 +1,5 @@
+symfonycasts_tailwind:
+    # sans épinglage, le bundle télécharge le DERNIER CLI Tailwind (v4) sur tout
+    # environnement froid (image CI, prod) — incompatible avec notre setup v3
+    # (tailwind.config.js + directives @tailwind). À bumper avec la migration v4.
+    binary_version: 'v3.4.17'


### PR DESCRIPTION
Le bump #71 était vert en CI **à tort** : la CI ne lance jamais `tailwind:build`, et la 0.14 avec `binary_version: null` télécharge le DERNIER CLI Tailwind (v4) sur tout environnement froid — incompatible avec notre setup v3. Bump repris avec épinglage `binary_version: 'v3.4.17'`, prouvé à froid (cache binaire purgé → re-téléchargement v3.4.17, build OK). 130 tests verts, quality OK.

À noter pour plus tard : la migration Tailwind v4 est un chantier CSS à part entière.

🤖 Generated with [Claude Code](https://claude.com/claude-code)