### PR TITLE
ci(release): buildcache sur GHCR au lieu de Docker Hub (fix quota 429)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
 
     permissions:
       contents: read
-      # écriture du buildcache sur GHCR (login GITHUB_TOKEN natif)
+      # buildcache is written to GHCR (native GITHUB_TOKEN login)
       packages: write
 
     steps:
@@ -18,12 +18,12 @@ jobs:
         with:
           submodules: 'true'
 
-      # Buildx + cache type=registry permettent de réutiliser les layers Docker
-      # entre runs, indépendamment du ref Git. type=gha aurait été branch-scoped
-      # → chaque tag aurait son cache isolé. Le cache vit sur GHCR (gratuit,
-      # sans rate limit) et PAS sur Docker Hub : chaque layer de cache compte
-      # comme un pull dans le quota du compte (~200/6h en plan gratuit) — c'est
-      # ce qui a fait tomber la release v1.0.1 en 429 un jour de CI chargée.
+      # Buildx + type=registry cache reuse Docker layers across runs regardless
+      # of the Git ref. type=gha would be ref-scoped → every tag would get an
+      # isolated, empty cache. The cache lives on GHCR (free, no rate limit)
+      # and NOT on Docker Hub: every cache layer counts as a pull against the
+      # account quota (~200/6h on the free plan) — that's what 429'd the
+      # v1.0.1 release on a busy CI day.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      # écriture du buildcache sur GHCR (login GITHUB_TOKEN natif)
+      packages: write
+
     steps:
       - uses: actions/checkout@v7
         with:
@@ -15,9 +20,10 @@ jobs:
 
       # Buildx + cache type=registry permettent de réutiliser les layers Docker
       # entre runs, indépendamment du ref Git. type=gha aurait été branch-scoped
-      # → chaque tag aurait son cache isolé. Avec type=registry, on stocke le
-      # cache dans Docker Hub sous le tag :buildcache (séparé des images
-      # runnables), accessible depuis n'importe quelle release.
+      # → chaque tag aurait son cache isolé. Le cache vit sur GHCR (gratuit,
+      # sans rate limit) et PAS sur Docker Hub : chaque layer de cache compte
+      # comme un pull dans le quota du compte (~200/6h en plan gratuit) — c'est
+      # ce qui a fait tomber la release v1.0.1 en 429 un jour de CI chargée.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -26,6 +32,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_READ_WRITE_DELETE_ACCESS_TOKEN }}
+
+      - name: Login to GHCR (buildcache)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Main Image
         uses: docker/build-push-action@v7
@@ -39,5 +52,5 @@ jobs:
             ${{ secrets.DOCKER_HUB_USERNAME }}/youl-tcg:latest
           build-args: |
             APP_VERSION=${{ github.ref_name }}
-          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/youl-tcg:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/youl-tcg:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -5,6 +5,12 @@ services:
     db:
         container_name: ytcg_db
 
+    # un override ne peut pas supprimer un service : le profile jamais activé
+    # fait ignorer adminer par pull/build/up — inutile en CI, il comptait pour
+    # un tiers des pulls Docker Hub de chaque job (quota du compte)
+    adminer:
+        profiles: [jamais-en-ci]
+
 networks:
     traefik_traefik_proxy:
         external: false

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -5,11 +5,11 @@ services:
     db:
         container_name: ytcg_db
 
-    # un override ne peut pas supprimer un service : le profile jamais activé
-    # fait ignorer adminer par pull/build/up — inutile en CI, il comptait pour
-    # un tiers des pulls Docker Hub de chaque job (quota du compte)
+    # an override file cannot remove a service: the never-activated profile
+    # makes pull/build/up ignore adminer — useless in CI, it accounted for a
+    # third of every job's Docker Hub pulls (account quota)
     adminer:
-        profiles: [jamais-en-ci]
+        profiles: [never-in-ci]
 
 networks:
     traefik_traefik_proxy:


### PR DESCRIPTION
Le `buildcache` de la release vivait sur Docker Hub : chaque layer de cache tiré/poussé comptait dans le quota du compte (~200 pulls/6h en plan gratuit). Le train Dependabot d'aujourd'hui l'a épuisé → release v1.0.1 en `429 Too Many Requests` sur le pull de `dunglas/frankenphp`.

Fix : le cache part sur **GHCR** (gratuit, sans rate limit, login `GITHUB_TOKEN` natif, permission `packages: write`). On garde `type=registry` — donc le cache reste partagé entre toutes les releases, contrairement à `type=gha` qui est isolé par ref (raison documentée du choix initial). Docker Hub ne sert plus qu'à l'image de base (2-3 pulls/release) et au push des images finales.

Premier run post-merge : cache froid (GHCR vide) → build complet une fois, puis régime normal.

À répliquer ensuite sur php-starter et carapp (même pattern, même exposition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)