### PR TITLE
fix(deploy): transmet APP_SECRET au stack deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,6 +16,7 @@ jobs:
     env:
       DOCKER_HOST: ssh://${{ vars.SERVER_USERNAME }}@${{ vars.SERVER_HOST }}:${{ vars.SERVER_PORT }}
       # Substitués dans docker-compose-prod.yml au moment du stack deploy
+      APP_SECRET: ${{ secrets.APP_SECRET }}
       DB_USER: ${{ secrets.DB_USER }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}


### PR DESCRIPTION
Mon fix #61 avait ajouté `APP_SECRET` au compose prod mais pas à la liste de variables que le workflow de deploy exporte au `stack deploy` → substitution vide, `APP_SECRET=""` dans le conteneur, Live Components en 500.

⚠️ **Après merge** : relancer le Deploy Workflow avec **`re-deploy: true`** — un rolling update ne met à jour que l'image, l'environnement du service n'est refait que par un `stack deploy` complet. (Vérifie aussi que le secret GitHub `APP_SECRET` existe bien : `openssl rand -hex 32`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)