### PR TITLE
fix(admin): 500 sur « new Card » + ajout de cartes en masse

### DIFF
--- a/config/packages/test/vich_uploader.yaml
+++ b/config/packages/test/vich_uploader.yaml
@@ -1,0 +1,17 @@
+# En test, les uploads partent dans le cache du kernel : les tests d'upload
+# (batch de cartes…) ne doivent pas semer de fichiers dans public/images,
+# qui est un volume de contenu réel.
+vich_uploader:
+    mappings:
+        cards:
+            upload_destination: '%kernel.cache_dir%/uploads/cards'
+        boosters:
+            upload_destination: '%kernel.cache_dir%/uploads/boosters'
+        extensions:
+            upload_destination: '%kernel.cache_dir%/uploads/extensions'
+        banners:
+            upload_destination: '%kernel.cache_dir%/uploads/banners'
+        masks:
+            upload_destination: '%kernel.cache_dir%/uploads/masks'
+        foils:
+            upload_destination: '%kernel.cache_dir%/uploads/foils'

--- a/src/Controller/Admin/AdminCardBatchController.php
+++ b/src/Controller/Admin/AdminCardBatchController.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Entity\Card;
+use App\Entity\Extension;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\FileType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Batch card creation: one card per uploaded artwork. Cards are created as
+ * DRAFT with a placeholder description — the point is to mass-import artworks,
+ * then refine each card (name, description, visuals) from the regular CRUD.
+ */
+class AdminCardBatchController extends AbstractController
+{
+    private const string DESCRIPTION_PLACEHOLDER = 'À compléter.';
+
+    public function __construct(
+        private readonly AdminUrlGenerator $adminUrlGenerator,
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    #[Route('/admin/cards/batch', name: 'admin_cards_batch')]
+    public function __invoke(Request $request): Response
+    {
+        // The template extends the EasyAdmin layout, which needs the admin
+        // context: a direct hit bounces through the dashboard (same trick as
+        // the admin guide).
+        if (!$request->attributes->has(EA::CONTEXT_REQUEST_ATTRIBUTE)) {
+            return $this->redirect(
+                $this->adminUrlGenerator->setRoute('admin_cards_batch')->generateUrl(),
+            );
+        }
+
+        $form = $this->buildForm();
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            /** @var array{extension: Extension, rarity: CardRarityEnum, images: list<UploadedFile>} $data */
+            $data = $form->getData();
+
+            foreach ($data['images'] as $image) {
+                $card = new Card()
+                    ->setName($this->nameFromFilename($image))
+                    ->setDescription(self::DESCRIPTION_PLACEHOLDER)
+                    ->setStatus(CardStatusEnum::DRAFT)
+                    ->setRarity($data['rarity'])
+                    ->setExtension($data['extension'])
+                ;
+                $card->setImageFile($image);
+                $this->entityManager->persist($card);
+            }
+
+            $this->entityManager->flush();
+
+            $this->addFlash('success', \sprintf(
+                '%d carte(s) créée(s) en brouillon dans « %s » — noms dérivés des fichiers, descriptions à compléter.',
+                \count($data['images']),
+                $data['extension']->getName(),
+            ));
+
+            return $this->redirect(
+                $this->adminUrlGenerator->setController(CardCrudController::class)->setAction('index')->generateUrl(),
+            );
+        }
+
+        return $this->render('admin/card_batch.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    /**
+     * @return FormInterface<array{extension: Extension, rarity: CardRarityEnum, images: list<UploadedFile>}|null>
+     */
+    private function buildForm(): FormInterface
+    {
+        return $this->createFormBuilder()
+            ->add('extension', EntityType::class, [
+                'class' => Extension::class,
+                'choice_label' => 'name',
+                'label' => 'Extension',
+            ])
+            ->add('rarity', ChoiceType::class, [
+                'label' => 'Rareté (appliquée à tout le lot)',
+                'choices' => CardRarityEnum::cases(),
+                'choice_label' => static fn (CardRarityEnum $rarity): string => ucfirst($rarity->value),
+                'choice_value' => static fn (?CardRarityEnum $rarity): string => $rarity->value ?? '',
+                'data' => CardRarityEnum::COMMON,
+            ])
+            ->add('images', FileType::class, [
+                'label' => 'Artworks (une carte par fichier)',
+                'multiple' => true,
+                'attr' => ['accept' => 'image/png,image/jpeg,image/webp'],
+                'constraints' => [
+                    new Assert\Count(min: 1, minMessage: 'Sélectionne au moins un fichier.'),
+                    new Assert\All([
+                        new Assert\Image(
+                            maxSize: '8M',
+                            mimeTypes: ['image/png', 'image/jpeg', 'image/webp'],
+                            mimeTypesMessage: 'Formats acceptés : PNG, JPEG, WebP.',
+                        ),
+                    ]),
+                ],
+            ])
+            ->getForm()
+        ;
+    }
+
+    /**
+     * "farph_evo-alt_red-dead.png" → "Farph Evo Alt Red Dead".
+     */
+    private function nameFromFilename(UploadedFile $image): string
+    {
+        $base = pathinfo($image->getClientOriginalName(), \PATHINFO_FILENAME);
+        $name = trim((string) preg_replace('/[_\-\s]+/', ' ', $base));
+
+        return '' !== $name ? mb_convert_case($name, \MB_CASE_TITLE, 'UTF-8') : 'Carte sans nom';
+    }
+}

--- a/src/Controller/Admin/AdminCardBatchController.php
+++ b/src/Controller/Admin/AdminCardBatchController.php
@@ -71,13 +71,15 @@ class AdminCardBatchController extends AbstractController
             $this->entityManager->flush();
 
             $this->addFlash('success', \sprintf(
-                '%d carte(s) créée(s) en brouillon dans « %s » — noms dérivés des fichiers, descriptions à compléter.',
+                '%d carte(s) créée(s) en brouillon dans « %s » — noms dérivés des fichiers, descriptions à compléter (CRUD Cards).',
                 \count($data['images']),
                 $data['extension']->getName(),
             ));
 
+            // redirect vers la page elle-même (route custom) : générer une URL
+            // d'action CRUD sans pretty URLs est déprécié par EasyAdmin 4.14+
             return $this->redirect(
-                $this->adminUrlGenerator->setController(CardCrudController::class)->setAction('index')->generateUrl(),
+                $this->adminUrlGenerator->setRoute('admin_cards_batch')->generateUrl(),
             );
         }
 

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace App\Controller\Admin;
 
-use App\Entity\Booster;
-use App\Entity\Card;
-use App\Entity\Extension;
-use App\Entity\ExtensionBanner;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
@@ -45,11 +41,11 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::linkToDashboard('Dashboard', 'fa fa-home');
 
         yield MenuItem::section('Card Settings');
-        yield MenuItem::linkToCrud('Cards', 'fas fa-wallet', Card::class);
+        yield MenuItem::linkTo(CardCrudController::class, 'Cards', 'fas fa-wallet');
         yield MenuItem::linkToRoute('Ajout en masse', 'fa fa-images', 'admin_cards_batch');
-        yield MenuItem::linkToCrud('Extensions', 'fa fa-chart-bar', Extension::class);
-        yield MenuItem::linkToCrud('Bannières d\'univers', 'fa fa-image', ExtensionBanner::class);
-        yield MenuItem::linkToCrud('Boosters', 'fa fa-box-open', Booster::class);
+        yield MenuItem::linkTo(ExtensionCrudController::class, 'Extensions', 'fa fa-chart-bar');
+        yield MenuItem::linkTo(ExtensionBannerCrudController::class, 'Bannières d\'univers', 'fa fa-image');
+        yield MenuItem::linkTo(BoosterCrudController::class, 'Boosters', 'fa fa-box-open');
 
         yield MenuItem::section('Aide');
         yield MenuItem::linkToRoute('Guide admin', 'fa fa-book', 'admin_guide');

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -46,6 +46,7 @@ class DashboardController extends AbstractDashboardController
 
         yield MenuItem::section('Card Settings');
         yield MenuItem::linkToCrud('Cards', 'fas fa-wallet', Card::class);
+        yield MenuItem::linkToRoute('Ajout en masse', 'fa fa-images', 'admin_cards_batch');
         yield MenuItem::linkToCrud('Extensions', 'fa fa-chart-bar', Extension::class);
         yield MenuItem::linkToCrud('Bannières d\'univers', 'fa fa-image', ExtensionBanner::class);
         yield MenuItem::linkToCrud('Boosters', 'fa fa-box-open', Booster::class);

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -183,10 +183,13 @@ class Card
         return $this;
     }
 
-    public function getExtension(): Extension
+    /**
+     * Nullable on purpose: EasyAdmin reads every field of the EMPTY entity on
+     * the "new" form — a strict getter turns that page into a 500. A persisted
+     * card always has one (NotBlank + JoinColumn non-null).
+     */
+    public function getExtension(): ?Extension
     {
-        \assert($this->extension instanceof Extension);
-
         return $this->extension;
     }
 

--- a/src/Service/Card/CardVisualResolver.php
+++ b/src/Service/Card/CardVisualResolver.php
@@ -31,6 +31,10 @@ final readonly class CardVisualResolver
     public function resolve(Card $card): ResolvedCardVisual
     {
         $extension = $card->getExtension();
+
+        if (!$extension instanceof Extension) {
+            throw new \LogicException(\sprintf('Card "%s" has no extension: only persisted cards can be visually resolved.', $card->getName()));
+        }
         $override = $card->getVisualConfigOverride();
         $config = $extension->getVisualConfig();
 

--- a/templates/admin/card_batch.html.twig
+++ b/templates/admin/card_batch.html.twig
@@ -1,0 +1,22 @@
+{% extends '@EasyAdmin/page/content.html.twig' %}
+
+{% block content_title %}🖼️ Ajout de cartes en masse{% endblock %}
+
+{% block main %}
+    <div style="max-width: 720px;">
+        <p>
+            Une carte est créée <strong>par fichier uploadé</strong> : nom dérivé du nom de
+            fichier (<code>ahri_kda.png</code> → « Ahri Kda »), statut <strong>Draft</strong>,
+            description à compléter. Tu affines ensuite chaque carte (description, visuel,
+            mask/foil) depuis le CRUD Cards avant de publier — rien n'est visible des joueurs
+            tant que la carte n'est pas publiée.
+        </p>
+
+        {{ form_start(form) }}
+            <div class="mb-3">{{ form_row(form.extension) }}</div>
+            <div class="mb-3">{{ form_row(form.rarity) }}</div>
+            <div class="mb-3">{{ form_row(form.images) }}</div>
+            <button type="submit" class="btn btn-primary">Créer les cartes</button>
+        {{ form_end(form) }}
+    </div>
+{% endblock %}

--- a/templates/admin/guide.html.twig
+++ b/templates/admin/guide.html.twig
@@ -55,7 +55,7 @@
         <h2 id="flow">2. Créer un univers de A à Z</h2>
         <ol>
             <li>Créer l'<strong>Extension</strong> (statut Draft) : nom, description complète, image de couverture.</li>
-            <li>Créer les <strong>Cartes</strong> : artwork obligatoire, rareté, description. Publier les cartes prêtes.</li>
+            <li>Créer les <strong>Cartes</strong> : artwork obligatoire, rareté, description. Pour un set entier, <strong>« Ajout en masse »</strong> (menu Cards) crée une carte draft par artwork uploadé, noms dérivés des fichiers. Publier les cartes prêtes.</li>
             <li>Ajouter les <strong>masks</strong> (à la main ou via <code>castor holo:masks &lt;slug&gt;</code>) et éventuels <strong>foils</strong> pour les cartes premium.</li>
             <li>Régler le <strong>visuel</strong> : preset holo + glow au niveau extension, surcharges par carte si besoin (preview live dans le formulaire carte).</li>
             <li>Créer le(s) <strong>Booster(s)</strong> : les slots <code>rarityRates</code> définissent le nombre de cartes et les taux.</li>

--- a/tests/Functional/AdminCardBatchTest.php
+++ b/tests/Functional/AdminCardBatchTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Card;
+use App\Entity\Extension;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class AdminCardBatchTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    public function testBatchCreatesOneDraftCardPerUploadedArtwork(): void
+    {
+        $client = self::createClient();
+        $client->followRedirects();
+        $this->authenticateClient($client);
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $extension = new Extension()
+            ->setName('Batch test extension ' . uniqid())
+            ->setDescription('Test')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+        ;
+        $entityManager->persist($extension);
+        $entityManager->flush();
+
+        $crawler = $client->request('GET', '/admin/cards/batch');
+        self::assertResponseIsSuccessful();
+
+        // DomCrawler can't set several files on one `multiple` input: POST by hand
+        $form = $crawler->selectButton('Créer les cartes')->form();
+        $token = $crawler->filter('input[name="form[_token]"]')->attr('value');
+        $client->request('POST', $form->getUri(), [
+            'form' => [
+                'extension' => (string) $extension->getId(),
+                'rarity' => CardRarityEnum::RARE->value,
+                '_token' => $token,
+            ],
+        ], [
+            'form' => [
+                'images' => [
+                    $this->uploadedArtwork('ahri_kda-alt.png'),
+                    $this->uploadedArtwork('one-of-one.png'),
+                ],
+            ],
+        ]);
+        self::assertResponseIsSuccessful();
+
+        /** @var list<Card> $cards */
+        $cards = $entityManager->getRepository(Card::class)->findBy(['extension' => $extension], ['name' => 'ASC']);
+        $this->assertCount(2, $cards);
+        $this->assertSame(['Ahri Kda Alt', 'One Of One'], array_map(static fn (Card $card): string => $card->getName(), $cards));
+        foreach ($cards as $card) {
+            $this->assertSame(CardStatusEnum::DRAFT, $card->getStatus());
+            $this->assertSame(CardRarityEnum::RARE, $card->getRarity());
+            $this->assertSame('À compléter.', $card->getDescription());
+            $this->assertNotNull($card->getImageName(), 'Vich must have stored the artwork.');
+        }
+    }
+
+    public function testAdminNewCardPageRenders(): void
+    {
+        // regression: EasyAdmin reads every field of the EMPTY entity on the
+        // "new" form — a strict getExtension() used to turn this page into a 500
+        $client = self::createClient();
+        $client->followRedirects();
+        $this->authenticateClient($client);
+
+        $client->request('GET', '/admin?crudAction=new&crudControllerFqcn=App%5CController%5CAdmin%5CCardCrudController');
+
+        self::assertResponseIsSuccessful();
+    }
+
+    /**
+     * Raw $_FILES-style array: BrowserKit serialises its request history and
+     * rejects UploadedFile objects there.
+     *
+     * @return array{tmp_name: string, name: string, type: string, error: int, size: int}
+     */
+    private function uploadedArtwork(string $clientName): array
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'batch-art-');
+        \assert(false !== $tmp);
+        copy(__DIR__ . '/../../public/images/cards/default_card.png', $tmp);
+
+        return [
+            'tmp_name' => $tmp,
+            'name' => $clientName,
+            'type' => 'image/png',
+            'error' => \UPLOAD_ERR_OK,
+            'size' => (int) filesize($tmp),
+        ];
+    }
+}


### PR DESCRIPTION
## Fix : 500 sur la création de carte
EasyAdmin lit chaque champ de l'entité **vide** sur le formulaire « new » : `Card::getExtension()` strict (assert hérité de la purge du baseline PHPStan) → `AssertionError` → 500. Getter rendu nullable (style make:entity — une carte persistée a toujours son extension : NotBlank + FK non nulle) ; `CardVisualResolver`, seul appelant strict, jette désormais un `LogicException` explicite. Test de régression sur le rendu de la page. Pages « new » de Booster/Bannière vérifiées saines.

## Feature : ajout de cartes en masse
Menu **Cards → Ajout en masse** : extension + rareté du lot + multi-upload d'artworks (PNG/JPEG/WebP, 8 Mo max) → une carte **DRAFT** par fichier, nom dérivé du nom de fichier, description « À compléter. ». Rien n'est visible des joueurs avant publication — le flux reste : import en masse → affinage carte par carte → publier. Documenté dans le guide admin.

Bonus : les uploads de l'env test partent dans `%kernel.cache_dir%` — les tests ne polluent plus `public/images` (volume de contenu réel).

132 tests verts, quality OK, vérifié en navigateur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)