### PR TITLE
chore(logs): coupe le canal deprecation en prod

### DIFF
--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -44,8 +44,11 @@ when@prod:
                 type: stream
                 path: php://stdout
                 level: info
+                # deprecations are dev/CI concerns (phpunit failOnDeprecation is
+                # the guard rail) — in prod they only flood stdout on every hit
+                channels: ["!deprecation"]
 
             console:
                 type: console
                 process_psr_3_messages: false
-                channels: ["!event", "!doctrine"]
+                channels: ["!event", "!doctrine", "!deprecation"]


### PR DESCRIPTION
Les logs prod sont inondés de dépréciations EasyAdmin (plusieurs par page admin). Elles restent pleinement visibles en dev/test, et la CI (`failOnDeprecation`) reste le garde-fou qui force à les corriger — la preuve avec la #79 qui vient d'en purger deux. En prod, elles n'apportent que du bruit : canal exclu des handlers prod.

Pour la dépréciation « pretty admin URLs » restante : corrigeable en EA 4.x (opt-in depuis 4.24), noté comme chantier dédié — c'est le prérequis de la migration EA5 (#67) et ça touche la preview live (JS qui lit crudAction/entityId dans l'URL), les bounces custom et les tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)