### PR TITLE
chore(claude): hook pre-commit compatible sh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "INPUT=$(cat); if printf '%s' \"$INPUT\" | grep -qE '\"command\"[[:space:]]*:[[:space:]]*\"git commit'; then set -o pipefail; { make fix_style && git diff --cached --name-only -z | xargs -0 -r git add -- && make check_style; } 2>&1 | grep -vE 'overriding recipe for target|ignoring old recipe for target'; else true; fi",
+            "command": "INPUT=$(cat); if printf '%s' \"$INPUT\" | grep -qE '\"command\"[[:space:]]*:[[:space:]]*\"git commit'; then OUT=$({ make fix_style && git diff --cached --name-only -z | xargs -0 -r git add -- && make check_style; } 2>&1); RC=$?; printf '%s\\n' \"$OUT\" | grep -vE 'overriding recipe for target|ignoring old recipe for target'; exit $RC; else true; fi",
             "timeout": 180,
             "statusMessage": "Auto-fix + code quality (cs-fixer, rector, phpcs, phpmd, phpstan)..."
           }


### PR DESCRIPTION
`set -o pipefail` n'existe pas en `/bin/sh` : le hook PreToolUse crashait avant même de lancer `make fix_style` et bloquait tout commit. La sortie de make est maintenant capturée puis filtrée, et son code de sortie propagé par un `exit` explicite — même sémantique (un échec de make bloque le commit), mais POSIX-safe. Testé sous `sh` avec un payload commit (checks lancés, échec propagé) et non-commit (exit 0 silencieux).