### PR TITLE
feat(errors): pages 404/403 custom + repli 500 propre

### DIFF
--- a/config/routes/framework.yaml
+++ b/config/routes/framework.yaml
@@ -2,3 +2,11 @@ when@dev:
     _errors:
         resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
         prefix: /_error
+
+# La preview /_error/{code} force showException=false : c'est le seul moyen de
+# rendre les templates d'erreur custom sous kernel.debug (les vraies 40x/500
+# affichent la page de debug), donc on l'expose aussi en test.
+when@test:
+    _errors:
+        resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+        prefix: /_error

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,11 @@
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
+        <!-- Sans ça, kernel.runtime_mode.web = false sous PHPUnit (SAPI cli) et le
+             sélecteur d'error renderer (Symfony 7.3+) répond avec le CliErrorRenderer
+             (dump ANSI) au lieu de la chaîne HTML/Twig — les pages d'erreur custom
+             deviendraient intestables. -->
+        <server name="APP_RUNTIME_MODE" value="web=1" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
     </php>
 

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -1,0 +1,86 @@
+{# Repli générique (500, 503, …) : volontairement autonome — pas d'extends,
+   pas d'asset()/path() — pour rester rendable même si le layout, le routeur
+   ou les assets sont la cause de l'erreur. #}
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Erreur {{ status_code }} — YOUL TCG</title>
+    <style>
+        /* Tokens Violet Arcade recopiés en dur (theme.css peut être indisponible) */
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: #0b0712;
+            color: #f0e8f7;
+            font-family: 'Space Grotesk', system-ui, sans-serif;
+            text-align: center;
+        }
+        .glow {
+            position: fixed;
+            inset: 0;
+            pointer-events: none;
+            background: radial-gradient(ellipse at center, #a435f033, transparent 60%);
+            filter: blur(60px);
+        }
+        .chip {
+            display: inline-block;
+            background: #a435f0;
+            color: #000;
+            padding: 4px 10px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: .15em;
+        }
+        h1 {
+            margin: 24px 0 0;
+            font-size: clamp(4rem, 14vw, 9rem);
+            font-weight: 700;
+            line-height: .85;
+            letter-spacing: -0.05em;
+            text-transform: uppercase;
+            color: #fff;
+        }
+        h1 span { color: #a435f0; }
+        p {
+            margin: 24px auto 0;
+            max-width: 28rem;
+            font-size: 17px;
+            line-height: 1.5;
+            color: #b9a8cf;
+        }
+        a {
+            display: inline-block;
+            margin-top: 32px;
+            padding: 14px 28px;
+            background: #a435f0;
+            color: #000;
+            font-weight: 700;
+            font-size: 14px;
+            letter-spacing: .15em;
+            text-transform: uppercase;
+            text-decoration: none;
+            clip-path: polygon(8px 0, 100% 0, calc(100% - 8px) 100%, 0 100%);
+        }
+        a:hover { background: #ff3db0; }
+    </style>
+</head>
+<body>
+<div class="glow" aria-hidden="true"></div>
+<main>
+    {% set code = status_code ~ '' %}
+    <span class="chip">✖ {{ status_text|upper }}</span>
+    <h1>{{ code|slice(0, 1) }}<span>{{ code|slice(1, 1) }}</span>{{ code|slice(2) }}</h1>
+    <p>
+        Le serveur a pioché une mauvaise carte. On est dessus —
+        réessaie dans quelques instants.
+    </p>
+    <a href="/">Retour à l'accueil ▸</a>
+</main>
+</body>
+</html>

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -1,0 +1,21 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}403 — YOUL TCG{% endblock %}
+
+{% block body %}
+    <main class="relative flex flex-1 flex-col items-center justify-center overflow-hidden px-6 py-24 text-center">
+        <div class="glow-ambient" aria-hidden="true"></div>
+        <div class="relative">
+            <span class="inline-block bg-magenta px-2.5 py-1 font-mono text-[11px] font-bold tracking-[.15em] text-black">⛔ ACCÈS REFUSÉ</span>
+            <h1 class="mt-6 font-display text-[clamp(5rem,16vw,11rem)] font-bold uppercase leading-[.85] tracking-[-0.05em] text-ink-strong">
+                4<span class="text-magenta">0</span>3
+            </h1>
+            <p class="mx-auto mt-6 max-w-md text-[17px] leading-normal text-ink-muted">
+                Cette zone est verrouillée. Ton deck n'a pas le niveau requis pour entrer ici.
+            </p>
+            <div class="mt-8 flex flex-wrap justify-center gap-3">
+                <a href="{{ path('homepage') }}" class="btn-arcade">Retour à l'accueil ▸</a>
+            </div>
+        </div>
+    </main>
+{% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -1,0 +1,22 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}404 — YOUL TCG{% endblock %}
+
+{% block body %}
+    <main class="relative flex flex-1 flex-col items-center justify-center overflow-hidden px-6 py-24 text-center">
+        <div class="glow-ambient" aria-hidden="true"></div>
+        <div class="relative">
+            <span class="inline-block bg-primary px-2.5 py-1 font-mono text-[11px] font-bold tracking-[.15em] text-black">✖ CARTE INTROUVABLE</span>
+            <h1 class="mt-6 font-display text-[clamp(5rem,16vw,11rem)] font-bold uppercase leading-[.85] tracking-[-0.05em] text-ink-strong">
+                4<span class="text-primary">0</span>4
+            </h1>
+            <p class="mx-auto mt-6 max-w-md text-[17px] leading-normal text-ink-muted">
+                Cette page n'existe pas — ou a été retirée de la rotation.
+            </p>
+            <div class="mt-8 flex flex-wrap justify-center gap-3">
+                <a href="{{ path('homepage') }}" class="btn-arcade">Retour à l'accueil ▸</a>
+                <a href="{{ path('boosters') }}" class="btn-ghost">Ouvrir un pack</a>
+            </div>
+        </div>
+    </main>
+{% endblock %}

--- a/tests/Functional/ErrorPagesTest.php
+++ b/tests/Functional/ErrorPagesTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Les templates custom (templates/bundles/TwigBundle/Exception/) ne sont rendus
+ * qu'en debug=false : on passe par la preview /_error/{code} (showException=false)
+ * pour vérifier leur contenu, et par de vraies requêtes pour les codes HTTP.
+ */
+final class ErrorPagesTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private const string DISCORD_ID_JUJU = '195659530363731968';
+
+    public function testCustom404Template(): void
+    {
+        $client = self::createClient();
+        $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', '/_error/404');
+
+        self::assertResponseStatusCodeSame(404);
+        $this->assertStringContainsString('CARTE INTROUVABLE', $crawler->html());
+        // La page étend le layout : header + footer présents
+        $this->assertStringContainsString('TRADING CARD GAME', $crawler->filter('header')->text());
+        $this->assertStringContainsString('youl-made · non-officiel', $crawler->filter('footer')->text());
+        $this->assertCount(1, $crawler->filter('main a[href="/"]'));
+    }
+
+    public function testCustom403Template(): void
+    {
+        $client = self::createClient();
+        $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', '/_error/403');
+
+        self::assertResponseStatusCodeSame(403);
+        $this->assertStringContainsString('ACCÈS REFUSÉ', $crawler->html());
+        $this->assertStringContainsString('TRADING CARD GAME', $crawler->filter('header')->text());
+    }
+
+    public function testGenericErrorTemplateFor500(): void
+    {
+        $client = self::createClient();
+        $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', '/_error/500');
+
+        self::assertResponseStatusCodeSame(500);
+        $this->assertStringContainsString('mauvaise carte', $crawler->html());
+        // Repli autonome : pas de layout partagé (rendable même si le layout est en cause)
+        $this->assertCount(0, $crawler->filter('header'));
+        $this->assertCount(1, $crawler->filter('main a[href="/"]'));
+    }
+
+    public function testGenericErrorTemplateCoversOtherCodes(): void
+    {
+        $client = self::createClient();
+        $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', '/_error/503');
+
+        self::assertResponseStatusCodeSame(503);
+        $this->assertStringContainsString('mauvaise carte', $crawler->html());
+    }
+
+    public function testUnknownRouteReturns404(): void
+    {
+        $client = self::createClient();
+        $client->catchExceptions(true);
+        $this->authenticateClient($client);
+
+        $client->request('GET', '/cette-page-n-existe-pas');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testAdminAreaReturns403ForNonAdmin(): void
+    {
+        $client = self::createClient();
+        $client->catchExceptions(true);
+        $this->authenticateClient($client, self::DISCORD_ID_JUJU);
+
+        $client->request('GET', '/admin');
+
+        self::assertResponseStatusCodeSame(403);
+    }
+}


### PR DESCRIPTION
## Quoi

Pages d'erreur custom à la place des pages Symfony par défaut, via les overrides standards \`templates/bundles/TwigBundle/Exception/\` (rendus automatiquement quand \`kernel.debug=false\`, donc en prod) :

- **\`error404.html.twig\`** — étend le layout Violet Arcade (header/footer complets) : chip « ✖ CARTE INTROUVABLE », gros 404 accenté, CTA accueil + boosters
- **\`error403.html.twig\`** — même structure en magenta : « ⛔ ACCÈS REFUSÉ » (non-admin sur \`/admin\`)
- **\`error.html.twig\`** — repli générique pour **tout le reste (500, 503, …)**, volontairement **autonome** : pas d'\`extends\`, pas de \`path()\`/\`asset()\`, CSS inline avec les tokens du thème en dur — si le 500 vient du layout, du routeur ou des assets, la page d'erreur doit quand même se rendre

Hors périmètre (volontairement) : les anonymes sont interceptés par les listeners JWT avant toute page d'erreur, et les formats non-HTML gardent le rendu Symfony natif.

## Testabilité — deux subtilités

1. La preview \`/_error/{code}\` est exposée en \`when@test\` : en test \`kernel.debug=true\`, les vraies erreurs rendent la page de debug ; la preview force \`showException=false\` et rend les templates custom.
2. \`APP_RUNTIME_MODE=web\` dans phpunit.xml : depuis Symfony 7.3 l'error renderer est choisi selon \`kernel.runtime_mode\` — sous PHPUnit (SAPI cli) c'était le \`CliErrorRenderer\` (dump ANSI) qui répondait, court-circuitant toute la chaîne HTML/Twig.

## Tests

\`ErrorPagesTest\` (6 tests) : contenu custom 404/403 (avec header/footer du layout), rendu du repli générique en 500 et 503 (et absence voulue de layout partagé), route inconnue → 404 réel, non-admin sur \`/admin\` → 403 réel.

Suite complète : **138 tests / 1702 assertions ✅** — \`make quality\` ✅ (hook pre-commit).