### PR TITLE
fix(holo): le preset trainer n'écrase plus le foil choisi

### DIFF
--- a/assets/styles/cards/holo-presets.css
+++ b/assets/styles/cards/holo-presets.css
@@ -463,11 +463,18 @@
     background-size: 170% 170%;
 }
 
-/* trainer foil default (upstream :not(.masked)) */
+/* trainer foil default (upstream :not(.masked)) — trainerbg est déclaré sur
+   .card et non sur .card__shine : une custom property posée sur l'élément
+   lui-même bat toujours la valeur héritée (style inline du composant
+   compris), ce qui écrasait le foil uploadé / foilTexture de bibliothèque.
+   Déclaré sur le parent, c'est un simple défaut que l'inline surclasse. */
+.card.holo--trainer:not(.masked) {
+    --foil: url('/images/holo/poke/trainerbg.png');
+}
+
 .card.holo--trainer:not(.masked) .card__shine,
 .card.holo--trainer:not(.masked) .card__shine:after {
     --mask: none;
-    --foil: url('/images/holo/poke/trainerbg.png');
     --imgsize: 20%;
     background-blend-mode: color-burn, hue, hard-light;
     filter: brightness(calc((var(--pointer-from-center)*0.05) + .6)) contrast(1.5) saturate(1.2);


### PR DESCRIPTION
La règle `:not(.masked)` du preset trainer (reprise du pokeholo upstream) redéclarait `--foil: trainerbg` **directement sur `.card__shine`**. Une custom property déclarée sur l'élément lui-même bat toujours la valeur héritée — y compris le style inline posé par `CardComponent` avec le foil résolu par la cascade (foil uploadé ou `foilTexture` de bibliothèque). Résultat : sur une carte trainer non maskée, le foil choisi était systématiquement remplacé par trainerbg.

**Fix** : la déclaration du défaut remonte sur `.card` — l'inline du composant la surclasse (inline > sélecteur sur le même élément), `.card__shine` hérite du vainqueur. Comportements :
- carte trainer non maskée **sans** foil explicite → trainerbg, rendu strictement identique à avant (tiling 20 %, color-burn) ;
- carte trainer non maskée **avec** foil (upload ou bibliothèque) → le foil choisi s'affiche enfin, avec le rendu trainer (tiling 20 %) ;
- cartes maskées → inchangées (la règle ne les touche pas, elles respectaient déjà le foil).

CSS pur, pas de changement de template ni de resolver — à vérifier visuellement sur `/dev/card-effects` (combo trainer + foilTexture).