### PR TITLE
feat(admin): batch actions publier / repasser en brouillon sur les cartes

### DIFF
--- a/src/Controller/Admin/CardCrudController.php
+++ b/src/Controller/Admin/CardCrudController.php
@@ -10,12 +10,15 @@ use App\Enum\Card\CardEffectEnum;
 use App\Enum\Card\FoilTextureEnum;
 use App\Enum\Entity\CardRarityEnum;
 use App\Enum\Entity\CardStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Assets;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\BatchActionDto;
 use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
@@ -25,6 +28,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ImageField;
 use Symfony\Component\AssetMapper\AssetMapperInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
 
@@ -38,6 +43,7 @@ class CardCrudController extends AbstractCrudController
     public function __construct(
         private readonly UploaderHelper $uploaderHelper,
         private readonly AssetMapperInterface $assetMapper,
+        private readonly EntityManagerInterface $entityManager,
     ) {
     }
 
@@ -79,7 +85,76 @@ class CardCrudController extends AbstractCrudController
     #[\Override]
     public function configureActions(Actions $actions): Actions
     {
-        return $actions->add(Crud::PAGE_INDEX, Action::DETAIL);
+        return $actions
+            ->add(Crud::PAGE_INDEX, Action::DETAIL)
+            ->addBatchAction(
+                Action::new('publishCards', 'Publier')
+                    ->linkToCrudAction('publishCards')
+                    ->addCssClass('btn btn-primary')
+                    ->setIcon('fa fa-eye'),
+            )
+            ->addBatchAction(
+                Action::new('draftCards', 'Repasser en brouillon')
+                    ->linkToCrudAction('draftCards')
+                    ->addCssClass('btn btn-secondary')
+                    ->setIcon('fa fa-eye-slash'),
+            )
+        ;
+    }
+
+    /**
+     * @param AdminContext<Card>   $context
+     * @param BatchActionDto<Card> $batchActionDto
+     */
+    public function publishCards(AdminContext $context, BatchActionDto $batchActionDto): Response
+    {
+        return $this->applyStatusBatch($context, $batchActionDto, CardStatusEnum::PUBLISHED, 'publiée(s)');
+    }
+
+    /**
+     * @param AdminContext<Card>   $context
+     * @param BatchActionDto<Card> $batchActionDto
+     */
+    public function draftCards(AdminContext $context, BatchActionDto $batchActionDto): Response
+    {
+        return $this->applyStatusBatch($context, $batchActionDto, CardStatusEnum::DRAFT, 'repassée(s) en brouillon');
+    }
+
+    /**
+     * Mêmes gardes que le batchDelete natif d'EasyAdmin : rejet si le FQCN
+     * posté (contrôlé par le client) ne vise pas ce CRUD, puis token CSRF lié
+     * à l'action ET au FQCN — le FQCN étant validé d'abord, le token exigé est
+     * de fait toujours celui minté pour Card par le listing.
+     *
+     * @param AdminContext<Card>   $context
+     * @param BatchActionDto<Card> $batchActionDto
+     */
+    private function applyStatusBatch(AdminContext $context, BatchActionDto $batchActionDto, CardStatusEnum $status, string $successLabel): Response
+    {
+        if (Card::class !== $batchActionDto->getEntityFqcn()) {
+            throw new BadRequestHttpException();
+        }
+
+        if (!$this->isCsrfTokenValid('ea-batch-action-' . $batchActionDto->getName() . '-' . $batchActionDto->getEntityFqcn(), $batchActionDto->getCsrfToken())) {
+            return $this->redirectToRoute($context->getDashboardRouteName());
+        }
+
+        $updated = 0;
+        foreach ($batchActionDto->getEntityIds() as $entityId) {
+            $card = $this->entityManager->find(Card::class, $entityId);
+            if ($card instanceof Card && $status !== $card->getStatus()) {
+                $card->setStatus($status);
+                ++$updated;
+            }
+        }
+        $this->entityManager->flush();
+
+        $this->addFlash('success', \sprintf('%d carte%s %s.', $updated, $updated > 1 ? 's' : '', $successLabel));
+
+        // retour au listing d'origine (filtres/tri conservés) — c'est le remplacement
+        // documenté de BatchActionDto::getReferrerUrl(), déprécié en EA 4.22 ; et
+        // AdminUrlGenerator déprécie les URLs non-pretty, donc pas d'URL regénérée
+        return $this->redirect($context->getRequest()->headers->get('referer') ?? '/admin');
     }
 
     /**

--- a/tests/Functional/AdminCardBatchStatusTest.php
+++ b/tests/Functional/AdminCardBatchStatusTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Card;
+use App\Entity\Extension;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Rejoue le flux réel des batch actions EasyAdmin : le token CSRF et l'URL
+ * d'action sont lus sur le bouton du listing (data-action-*), puis POSTés
+ * comme le fait le JS d'EA (batchActionName + entityFqcn + entityIds).
+ */
+final class AdminCardBatchStatusTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private const string INDEX_URL = '/admin?crudAction=index&crudControllerFqcn=App%5CController%5CAdmin%5CCardCrudController';
+
+    private KernelBrowser $client;
+
+    private EntityManagerInterface $entityManager;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->authenticateClient($this->client);
+    }
+
+    public function testBatchPublishOnlyUpdatesSelectedCards(): void
+    {
+        [$first, $second, $untouched] = $this->createCards(CardStatusEnum::DRAFT, 3);
+
+        $this->submitBatchAction('publishCards', [$first, $second]);
+
+        self::assertResponseRedirects();
+        $this->assertStatuses(CardStatusEnum::PUBLISHED, [$first, $second]);
+        $this->assertStatuses(CardStatusEnum::DRAFT, [$untouched]);
+    }
+
+    public function testBatchDraftUpdatesPublishedCards(): void
+    {
+        [$card] = $this->createCards(CardStatusEnum::PUBLISHED, 1);
+
+        $this->submitBatchAction('draftCards', [$card]);
+
+        self::assertResponseRedirects();
+        $this->assertStatuses(CardStatusEnum::DRAFT, [$card]);
+    }
+
+    public function testInvalidCsrfTokenChangesNothing(): void
+    {
+        [$card] = $this->createCards(CardStatusEnum::DRAFT, 1);
+
+        $this->submitBatchAction('publishCards', [$card], csrfToken: 'forged-token');
+
+        // même comportement que le batchDelete natif : redirection dashboard, aucun écrit
+        self::assertResponseRedirects();
+        $this->assertStatuses(CardStatusEnum::DRAFT, [$card]);
+    }
+
+    public function testMismatchedEntityFqcnIsRejected(): void
+    {
+        [$card] = $this->createCards(CardStatusEnum::DRAFT, 1);
+
+        // le FQCN vient du POST, donc du client : viser un autre FQCN doit
+        // buter sur la garde anti-mismatch (vérifiée avant même le CSRF)
+        $this->submitBatchAction('publishCards', [$card], entityFqcn: Extension::class);
+
+        self::assertResponseStatusCodeSame(400);
+        $this->assertStatuses(CardStatusEnum::DRAFT, [$card]);
+    }
+
+    /**
+     * @param list<Card> $cards
+     */
+    private function submitBatchAction(string $actionName, array $cards, ?string $csrfToken = null, ?string $entityFqcn = null): void
+    {
+        $crawler = $this->client->request('GET', self::INDEX_URL);
+        self::assertResponseIsSuccessful();
+
+        $button = $crawler->filter(\sprintf('[data-action-batch="true"][data-action-url*="%s"]', $actionName));
+        $this->assertCount(1, $button, \sprintf('Le bouton batch "%s" doit être présent sur le listing.', $actionName));
+
+        // le vrai token du flux : minté par ActionFactory pendant le GET,
+        // porté par le bouton, lié à la session du client via son cookie
+        $entityFqcn ??= Card::class;
+        $csrfToken ??= (string) $button->attr('data-action-csrf-token');
+
+        $this->client->request('POST', (string) $button->attr('data-action-url'), [
+            'batchActionName' => $actionName,
+            'entityFqcn' => $entityFqcn,
+            'batchActionUrl' => (string) $button->attr('data-action-url'),
+            'batchActionCsrfToken' => $csrfToken,
+            'batchActionEntityIds' => array_map(static fn (Card $card): string => (string) $card->getId(), $cards),
+        ]);
+    }
+
+    /**
+     * @return list<Card>
+     */
+    private function createCards(CardStatusEnum $status, int $count): array
+    {
+        $extension = new Extension()
+            ->setName('Batch status extension ' . uniqid())
+            ->setDescription('Test')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+        ;
+        $this->entityManager->persist($extension);
+
+        $cards = [];
+        for ($i = 0; $i < $count; ++$i) {
+            $card = new Card()
+                ->setName(\sprintf('Batch status card %d %s', $i, uniqid()))
+                ->setDescription('Test')
+                ->setStatus($status)
+                ->setRarity(CardRarityEnum::COMMON)
+                ->setExtension($extension)
+            ;
+            $this->entityManager->persist($card);
+            $cards[] = $card;
+        }
+        $this->entityManager->flush();
+
+        return $cards;
+    }
+
+    /**
+     * @param list<Card> $cards
+     */
+    private function assertStatuses(CardStatusEnum $expected, array $cards): void
+    {
+        // les requêtes du client rebootent le kernel : on relit depuis la base
+        // plutôt que de refresh() des instances potentiellement détachées
+        $this->entityManager->clear();
+
+        foreach ($cards as $card) {
+            $fresh = $this->entityManager->find(Card::class, $card->getId());
+            $this->assertInstanceOf(Card::class, $fresh);
+            $this->assertSame($expected, $fresh->getStatus());
+        }
+    }
+}


### PR DESCRIPTION
## Quoi

Deux **batch actions** EasyAdmin sur le listing des cartes : sélectionne des cartes → « Publier » ou « Repasser en brouillon » en un clic (pratique après un ajout en masse d'artworks, qui crée tout en DRAFT).

## Sécurité

Mêmes gardes que le \`batchDelete\` natif d'EA, dans cet ordre :
1. **Garde anti-mismatch FQCN** : le \`entityFqcn\` vient du POST (contrôlé par le client) — s'il ne vise pas \`Card\`, 400 direct ;
2. **CSRF** : token lié à l'action ET au FQCN (\`ea-batch-action-<action>-<fqcn>\`), celui que le listing mint sur le bouton — token invalide → redirect dashboard sans écrire.

Redirection de sortie via le referer (le listing d'origine, filtres/tri conservés) : \`BatchActionDto::getReferrerUrl()\` est déprécié depuis EA 4.22 et \`AdminUrlGenerator\` déprécie les URLs non-pretty — les deux font échouer la suite (\`failOnDeprecation\`).

## Tests

\`AdminCardBatchStatusTest\` (4 tests) rejoue le **vrai flux** : le token CSRF et l'URL d'action sont lus sur les attributs \`data-action-*\` du bouton du listing, puis POSTés comme le fait le JS d'EA.
- publish ne touche que les cartes sélectionnées ;
- draft repasse une carte publiée en brouillon ;
- token CSRF forgé → rien n'est écrit ;
- FQCN mismatch (Extension) → 400, rien n'est écrit.

Suite complète : **143 tests / 1728 assertions ✅** — quality ✅ (hook pre-commit).