### PR TITLE
chore(vich): namespace Mapping\Attribute (annotations dépréciées en 2.9)

### DIFF
--- a/src/Entity/Booster.php
+++ b/src/Entity/Booster.php
@@ -12,7 +12,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Validator\Constraints as Assert;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
 #[ORM\Entity(repositoryClass: BoosterRepository::class)]

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Validator\Constraints as Assert;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
 #[ORM\Entity(repositoryClass: CardRepository::class)]

--- a/src/Entity/Extension.php
+++ b/src/Entity/Extension.php
@@ -18,7 +18,7 @@ use Gedmo\Mapping\Annotation as Gedmo;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Validator\Constraints as Assert;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
 #[ORM\Entity(repositoryClass: ExtensionRepository::class)]

--- a/src/Entity/ExtensionBanner.php
+++ b/src/Entity/ExtensionBanner.php
@@ -9,7 +9,7 @@ use Barlito\Utils\Traits\IdUuidTrait;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Timestampable\Traits\TimestampableEntity;
 use Symfony\Component\HttpFoundation\File\File;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
+use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 /**
  * A hero banner of an extension's universe page. An extension can have


### PR DESCRIPTION
vich/uploader-bundle 2.9 déprécie `Mapping\Annotation` au profit de `Mapping\Attribute` (drop-in, 4 entités touchées).

La dépréciation ne se déclenche qu'au **premier chargement des metadata** (cache de test froid) : la CI passait par chance — les migrations + fixtures réchauffent le cache avant phpunit — mais toute suite vraiment froide sortait en échec avec `failOnDeprecation` (reproduit sur master : `rm -rf var/cache/test` + suite → exit 1 ; après ce fix → exit 0, 139 tests verts).