### PR TITLE
fix(admin): l'upload en masse ne meurt plus en silence sur post_max_size

### DIFF
--- a/.docker/php/app.ini
+++ b/.docker/php/app.ini
@@ -4,6 +4,14 @@ apc.enable_cli = 1
 session.use_strict_mode = 1
 zend.detect_unicode = 0
 
+; Admin batch upload (one card per artwork) — the PHP defaults kill the whole
+; POST past the limit: post_max_size 8M drops the body at request startup
+; (empty form on the Symfony side) and max_file_uploads SILENTLY ignores every
+; file after the 20th. Caddy does not cap the body, PHP is the only limit.
+upload_max_filesize = 24M
+post_max_size = 256M
+max_file_uploads = 100
+
 ; https://symfony.com/doc/current/performance.html
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600

--- a/src/Controller/Admin/AdminCardBatchController.php
+++ b/src/Controller/Admin/AdminCardBatchController.php
@@ -93,7 +93,14 @@ class AdminCardBatchController extends AbstractController
      */
     private function buildForm(): FormInterface
     {
-        return $this->createFormBuilder()
+        return $this->createFormBuilder(options: [
+            // rendered by the root form_errors(form) when PHP drops a POST
+            // bigger than post_max_size (the option only accepts a callable)
+            'upload_max_size_message' => static fn (): string => \sprintf(
+                'Lot trop lourd : le serveur accepte %s par envoi — fais plusieurs lots.',
+                \ini_get('post_max_size'),
+            ),
+        ])
             ->add('extension', EntityType::class, [
                 'class' => Extension::class,
                 'choice_label' => 'name',

--- a/templates/admin/card_batch.html.twig
+++ b/templates/admin/card_batch.html.twig
@@ -13,6 +13,10 @@
         </p>
 
         {{ form_start(form) }}
+            {# ROOT form errors: this is where the post_max_size rejection lands
+               (Symfony submits the form with a global error when PHP dropped
+               the body) — without this line the page stays silent #}
+            <div class="mb-3">{{ form_errors(form) }}</div>
             <div class="mb-3">{{ form_row(form.extension) }}</div>
             <div class="mb-3">{{ form_row(form.rarity) }}</div>
             <div class="mb-3">{{ form_row(form.images) }}</div>


### PR DESCRIPTION
## Le symptôme

POST de ~69 Mo d'artworks sur l'ajout en masse → `PHP Warning: POST Content-Length of 69632208 bytes exceeds the limit of 8388608 bytes` → PHP droppe le body entier au démarrage de la requête, Symfony reçoit un formulaire vide, la page re-render **sans aucun message**.

## Deux fixes

**1. Les limites PHP** (`.docker/php/app.ini`, dev + prod) : `upload_max_filesize 24M`, `post_max_size 256M`, et `max_file_uploads 100` — ce dernier est un piège cousin : au-delà de 20 fichiers (défaut), PHP ignore **silencieusement** les fichiers surnuméraires, le batch aurait créé 20 cartes sur 30 sans erreur. Vérifié : Caddy/FrankenPHP ne borne pas le body, PHP est la seule limite. La contrainte `Image(maxSize: 8M)` par fichier reste inchangée (largement au-dessus d'un artwork normal).

**2. Le silence** : quand PHP droppe le body, Symfony soumet quand même le formulaire avec une erreur… sur le formulaire **racine** — que le template ne rendait jamais (`form_errors(form)` absent). Ajouté, avec un message français explicite via `upload_max_size_message` (callable obligatoire dans cette version) qui affiche la limite courante et suggère de faire plusieurs lots.

## Notes

- Le changement d'ini nécessite un **rebuild d'image + release** pour toucher la prod.
- Pas de test automatisé pour le dépassement : `ServerParams` lit l'ini du process, non simulable proprement en fonctionnel — le rendu de l'erreur racine est du template pur. Suite complète verte par ailleurs (139 tests).
- Les 2 dépréciations vich à cache froid visibles en local sont le sujet de #87.