### PR TITLE
feat(admin): upload de l'image d'extension (fond des tuiles univers)

### DIFF
--- a/src/Controller/Admin/ExtensionCrudController.php
+++ b/src/Controller/Admin/ExtensionCrudController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Controller\Admin;
 
+use App\Admin\Field\ImageField as VichImageField;
 use App\Entity\Extension;
 use App\Enum\Card\CardEffectEnum;
 use App\Enum\Card\FoilTextureEnum;
@@ -16,6 +17,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\CodeEditorField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ColorField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ImageField;
 
 /**
  * @extends AbstractCrudController<Extension>
@@ -54,6 +56,16 @@ class ExtensionCrudController extends AbstractCrudController
         yield Field::new('description');
         yield ChoiceField::new('status')
             ->setChoices(ExtensionStatusEnum::cases())
+        ;
+        yield ImageField::new('imageName')
+            ->setLabel('Image')
+            ->setBasePath('/uploads/extensions')
+            ->onlyOnIndex()
+        ;
+        yield VichImageField::new('imageFile', allowDelete: true)
+            ->setLabel('Image (tuile univers)')
+            ->setHelp('Fond des tuiles de l\'univers (accueil, /univers, collection). Sans image : artwork de la carte publiée la plus rare, sinon gradient seul.')
+            ->onlyOnForms()
         ;
         yield CodeEditorField::new('visualConfigJson')
             ->setLabel('Visual config')

--- a/tests/Functional/AdminExtensionCrudTest.php
+++ b/tests/Functional/AdminExtensionCrudTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Extension;
+use App\Enum\Entity\ExtensionStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class AdminExtensionCrudTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private const string CRUD_URL = '/admin?crudControllerFqcn=App%5CController%5CAdmin%5CExtensionCrudController';
+
+    public function testNewPageRendersWithTheImageUploadField(): void
+    {
+        // regression guard: EasyAdmin reads every field of the EMPTY entity on
+        // the "new" form — a Vich field wired to a strict getter would 500
+        $client = self::createClient();
+        $client->followRedirects();
+        $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', self::CRUD_URL . '&crudAction=new');
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(1, $crawler->filter('input[type="file"][name*="imageFile"]'));
+    }
+
+    public function testEditPageRendersWithTheImageUploadField(): void
+    {
+        $client = self::createClient();
+        $client->followRedirects();
+        $this->authenticateClient($client);
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $extension = new Extension()
+            ->setName('Crud test extension ' . uniqid())
+            ->setDescription('Test')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+        ;
+        $entityManager->persist($extension);
+        $entityManager->flush();
+
+        $crawler = $client->request('GET', self::CRUD_URL . '&crudAction=edit&entityId=' . $extension->getId());
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(1, $crawler->filter('input[type="file"][name*="imageFile"]'));
+    }
+}


### PR DESCRIPTION
## Quoi

La cascade de fond des tuiles univers (accueil, `/univers`, collection) essaie **d'abord l'image de l'extension** (`extension.imageName`, Vich mapping `extensions`), puis l'artwork de la carte publiée la plus rare, puis le gradient seul. L'entité et les templates étaient prêts… mais le CRUD Extension n'exposait pas l'upload : impossible de customiser la tuile sans toucher la DB.

- `VichImageField('imageFile', allowDelete: true)` sur le formulaire — clearable sans risque, la cascade retombe proprement sur l'artwork le plus rare ;
- aperçu de l'image sur le listing (`ImageField` + `setBasePath('/uploads/extensions')`, même pattern que les bannières) ;
- help text qui explique la cascade à l'admin.

Rien à changer côté templates/resolver : tout consommait déjà `vich_uploader_asset(extension)`.

## Tests

`AdminExtensionCrudTest` : les pages **new** (garde-fou entité vide, même régression que le 500 du « new Card ») et **edit** rendent bien le champ d'upload.

Suite complète : 141 tests ✅ (les 2 dépréciations à cache froid = #87).