### PR TITLE
ci(tests): cache le binaire Tailwind (dépendance GitHub Releases flaky)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,17 @@ jobs:
           make doctrine.migrate.ci
           make doctrine.load_fixtures.ci
 
+      # The tailwind bundle downloads its binary from GitHub Releases on first
+      # build — a flaky external dependency (a 504 broke a run on 2026-07-09).
+      # /app is bind-mounted in CI, so the binary lands in var/tailwind on the
+      # runner and can be cached. Keyed on composer.lock: the binary version
+      # follows the bundle version.
+      - name: Cache Tailwind binary
+        uses: actions/cache@v6
+        with:
+          path: var/tailwind
+          key: tailwind-binary-${{ hashFiles('composer.lock') }}
+
       - name: Build Tailwind CSS
         run: make tailwind.build
 

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,14 @@ db.backup:
 # Tailwind est requis pour rendre base.html.twig (TailwindCssAssetCompiler lève
 # une exception si var/tailwind/tailwind.built.css est absent) — nécessaire en CI
 # avant les tests fonctionnels qui rendent des pages.
+# Retry : au premier build, le bundle télécharge son binaire depuis GitHub
+# Releases, qui 504 par intervalles (2 runs cassés le 2026-07-09) — une fois
+# le binaire présent (cache CI ou var/tailwind local), plus aucun réseau.
 tailwind.build:
-	docker exec -t $(app_container_id) bin/console tailwind:build --minify
+	@for i in 1 2 3 4 5; do \
+		docker exec -t $(app_container_id) bin/console tailwind:build --minify && exit 0; \
+		echo "tailwind:build KO (tentative $$i/5) — retry dans 20s"; sleep 20; \
+	done; echo "tailwind:build KO après 5 tentatives"; exit 1
 
 # Smoke test : curl GET / → fail si non-2xx. Sert de garde-fou post-deploy/update.
 smoke.test:


### PR DESCRIPTION
Le job de tests télécharge le binaire TailwindCSS depuis GitHub Releases à chaque run (`make tailwind.build`) — dépendance externe flaky : un `HTTP/2 504` a cassé le run de la #89 aujourd'hui, en plus d'ajouter ~10 s par run.

`/app` est bind-mounté en CI (docker-compose-ci override du compose dev), donc le binaire téléchargé par le bundle vit dans `var/tailwind/` côté runner → `actions/cache` keyé sur `composer.lock` (la version du binaire suit celle du bundle symfonycasts). Premier run = téléchargement + mise en cache, suivants = zéro appel à GitHub Releases.