### PR TITLE
feat(univers): pastille LIVE conditionnée aux boosters claimables

### DIFF
--- a/src/Controller/UniverseController.php
+++ b/src/Controller/UniverseController.php
@@ -61,6 +61,7 @@ class UniverseController extends AbstractController
                 'owned' => $owned,
                 'percentage' => $item['cardCount'] > 0 ? (int) round($owned / $item['cardCount'] * 100) : 0,
                 'coverImage' => $coverImages[$extensionId] ?? null,
+                'hasClaimableBooster' => $item['hasClaimableBooster'],
             ];
         }, $extensions);
 

--- a/src/Repository/ExtensionRepository.php
+++ b/src/Repository/ExtensionRepository.php
@@ -22,14 +22,19 @@ class ExtensionRepository extends ServiceEntityRepository
     }
 
     /**
-     * @return list<array{extension: Extension, cardCount: int}>
+     * hasClaimableBooster drives the LIVE badge on the universe tiles: an
+     * universe is "live" only when at least one of its boosters is claimable.
+     *
+     * @return list<array{extension: Extension, cardCount: int, hasClaimableBooster: bool}>
      */
     public function findPublishedWithPublishedCardCount(): array
     {
-        /** @var list<array{0: Extension, cardCount: string|int}> $rows */
+        // both joins fan out the rows, hence the DISTINCT counts
+        /** @var list<array{0: Extension, cardCount: string|int, claimableBoosterCount: string|int}> $rows */
         $rows = $this->createQueryBuilder('e')
-            ->select('e', 'COUNT(c.id) AS cardCount')
+            ->select('e', 'COUNT(DISTINCT c.id) AS cardCount', 'COUNT(DISTINCT b.id) AS claimableBoosterCount')
             ->leftJoin('e.cards', 'c', 'WITH', 'c.status = :cardStatus')
+            ->leftJoin('e.boosters', 'b', 'WITH', 'b.claimable = true')
             ->andWhere('e.status = :status')
             ->setParameter('cardStatus', CardStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
             ->setParameter('status', ExtensionStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
@@ -40,7 +45,11 @@ class ExtensionRepository extends ServiceEntityRepository
         ;
 
         return array_map(
-            static fn (array $row): array => ['extension' => $row[0], 'cardCount' => (int) $row['cardCount']],
+            static fn (array $row): array => [
+                'extension' => $row[0],
+                'cardCount' => (int) $row['cardCount'],
+                'hasClaimableBooster' => (int) $row['claimableBoosterCount'] > 0,
+            ],
             $rows,
         );
     }

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -135,9 +135,12 @@
                             {% endif %}
                             <div class="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-black/90" aria-hidden="true"></div>
 
-                            <div class="absolute left-4 right-4 top-4">
-                                <span class="chip-mono bg-black/80 px-2 py-0.5 font-bold text-live">● LIVE</span>
-                            </div>
+                            {# live = at least one claimable booster right now #}
+                            {% if item.hasClaimableBooster %}
+                                <div class="absolute left-4 right-4 top-4">
+                                    <span class="chip-mono bg-black/80 px-2 py-0.5 font-bold text-live" data-testid="live-badge">● LIVE</span>
+                                </div>
+                            {% endif %}
 
                             <div class="absolute bottom-4 left-4 right-4">
                                 <h3 class="font-display font-bold uppercase leading-[.95] tracking-[-0.03em] text-white {{ loop.first ? 'text-4xl' : 'text-[22px]' }}">

--- a/templates/pages/universes.html.twig
+++ b/templates/pages/universes.html.twig
@@ -41,9 +41,12 @@
                         {% endif %}
                         <div class="absolute inset-0 bg-gradient-to-b from-black/50 via-transparent to-black/95" aria-hidden="true"></div>
 
-                        <div class="absolute left-4 right-4 top-4">
-                            <span class="chip-mono bg-black/80 px-2 py-0.5 font-bold text-live">● LIVE</span>
-                        </div>
+                        {# live = at least one claimable booster right now #}
+                        {% if universe.hasClaimableBooster %}
+                            <div class="absolute left-4 right-4 top-4">
+                                <span class="chip-mono bg-black/80 px-2 py-0.5 font-bold text-live" data-testid="live-badge">● LIVE</span>
+                            </div>
+                        {% endif %}
 
                         <div class="absolute bottom-4 left-4 right-4">
                             <h2 class="font-display text-2xl font-bold uppercase leading-[.95] tracking-[-0.03em] text-white">

--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -87,6 +87,48 @@ final class HomepageTest extends WebTestCase
         $this->assertStringNotContainsString($draftExtension->getName(), $grid);
     }
 
+    public function testLiveBadgeOnlyShowsWithAClaimableBooster(): void
+    {
+        $this->authenticateClient($this->client);
+
+        // two fresh published universes: they take the newest featured slots
+        $liveExtension = $this->createPublishedExtension('Univers live ' . uniqid());
+        $this->entityManager->persist(
+            new Booster()
+                ->setExtension($liveExtension)
+                ->setName('Pack Claimable Home')
+                ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]]),
+        );
+        $silentExtension = $this->createPublishedExtension('Univers silencieux ' . uniqid());
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        $badgeIn = static fn (Extension $extension): int => $crawler
+            ->filterXPath(\sprintf(
+                '//article[.//a[@href="/univers/%s"]]//*[@data-testid="live-badge"]',
+                $extension->getSlug(),
+            ))
+            ->count()
+        ;
+
+        $this->assertSame(1, $badgeIn($liveExtension));
+        $this->assertSame(0, $badgeIn($silentExtension));
+    }
+
+    private function createPublishedExtension(string $name): Extension
+    {
+        $extension = new Extension()
+            ->setName($name)
+            ->setDescription('Extension de test homepage')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($extension);
+
+        return $extension;
+    }
+
     public function testHomepageSurvivesEmptyDayCards(): void
     {
         $this->authenticateClient($this->client);

--- a/tests/Functional/UniverseControllerTest.php
+++ b/tests/Functional/UniverseControllerTest.php
@@ -59,6 +59,38 @@ final class UniverseControllerTest extends WebTestCase
         );
     }
 
+    public function testLiveBadgeOnlyShowsWithAClaimableBooster(): void
+    {
+        // a published universe whose only booster is event-only (non claimable)
+        $eventExtension = new Extension()
+            ->setName('Univers event ' . uniqid())
+            ->setDescription('Distribution par code uniquement')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($eventExtension);
+        $this->entityManager->persist(
+            new Booster()
+                ->setExtension($eventExtension)
+                ->setName('Pack Event Only')
+                ->setClaimable(false)
+                ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]]),
+        );
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/univers');
+
+        self::assertResponseIsSuccessful();
+        $grid = $crawler->filter('[data-testid="universes-grid"]');
+        $badgeIn = static fn (string $slug): int => $grid
+            ->filter(\sprintf('a[href="/univers/%s"] [data-testid="live-badge"]', $slug))
+            ->count()
+        ;
+
+        // the scenario extension has a claimable booster, the event one doesn't
+        $this->assertSame(1, $badgeIn($this->extension->getSlug()));
+        $this->assertSame(0, $badgeIn($eventExtension->getSlug()));
+    }
+
     public function testShowRendersHeroWithFullDescriptionAndStats(): void
     {
         $crawler = $this->client->request('GET', '/univers/' . $this->extension->getSlug());


### PR DESCRIPTION
## Quoi

La pastille **● LIVE** sur les tuiles univers ne s'affiche plus systématiquement : elle n'apparaît que si l'univers a **au moins un booster claimable** en ce moment. Un univers dont les boosters sont tous event-only (ou sans booster) n'affiche plus rien.

Appliqué aux deux endroits qui rendent les tuiles :
- la grille `/univers`
- la section univers de la homepage

## Comment

`ExtensionRepository::findPublishedWithPublishedCardCount()` gagne un `LEFT JOIN e.boosters b WITH b.claimable = true` + `COUNT(DISTINCT b.id)`, exposé comme booléen `hasClaimableBooster`. Les deux pages utilisent déjà cette requête → **zéro requête supplémentaire**. Les deux `COUNT` passent en `DISTINCT` (le double join démultiplie les lignes).

Le compteur « XX UNIVERS LIVE » du hero `/univers` et le « XX LIVE / 01 SOON » homepage restent le nombre d'univers publiés (inchangés).

## Tests

- `UniverseControllerTest::testLiveBadgeOnlyShowsWithAClaimableBooster` — badge présent sur la tuile de l'univers avec booster claimable, absent sur celle dont l'unique booster est event-only
- `HomepageTest::testLiveBadgeOnlyShowsWithAClaimableBooster` — même règle sur les tuiles featured de la homepage
- Suite complète verte (147 tests), `make quality` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)