### PR TITLE
feat(analytics): pageviews Umami (snippet + stack locale)

### DIFF
--- a/.env
+++ b/.env
@@ -40,9 +40,7 @@ JWT_COOKIE_DOMAIN=.barlito.fr
 ###< lexik/jwt-authentication-bundle ###
 
 ###> Umami analytics ###
-# Empty = analytics off: the pageview snippet is not rendered and server-side
-# tracking is a no-op. Real values live in .env.dev / prod stack environment;
-# UMAMI_WEBSITE_ID is instance-specific (created in the Umami UI).
+# empty = analytics off (real values in .env.dev / prod stack environment)
 UMAMI_URL=
 UMAMI_INGEST_URL=
 UMAMI_WEBSITE_ID=

--- a/.env
+++ b/.env
@@ -38,3 +38,12 @@ LOGOUT_URL='https://yc.barlito.fr/logout'
 ###> lexik/jwt-authentication-bundle ###
 JWT_COOKIE_DOMAIN=.barlito.fr
 ###< lexik/jwt-authentication-bundle ###
+
+###> Umami analytics ###
+# Empty = analytics off: the pageview snippet is not rendered and server-side
+# tracking is a no-op. Real values live in .env.dev / prod stack environment;
+# UMAMI_WEBSITE_ID is instance-specific (created in the Umami UI).
+UMAMI_URL=
+UMAMI_INGEST_URL=
+UMAMI_WEBSITE_ID=
+###< Umami analytics ###

--- a/.env.dev
+++ b/.env.dev
@@ -20,3 +20,12 @@ LOGOUT_URL='https://yc.local.barlito.fr/logout'
 # Repasser à true pour tester le quota/countdown.
 BOOSTER_DAILY_LIMIT_ENABLED=false
 ###< Booster claims ###
+
+###> Umami analytics ###
+# Umami local (service `umami` du docker-compose). Pour activer le tracking :
+# créer le site dans l'UI (https://umami.local.barlito.fr, admin/umami,
+# domaine ytcg.local.barlito.fr) puis copier son UUID dans .env.local :
+# UMAMI_WEBSITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+UMAMI_URL='https://umami.local.barlito.fr'
+UMAMI_INGEST_URL='http://ytcg_umami:3000'
+###< Umami analytics ###

--- a/.env.dev
+++ b/.env.dev
@@ -22,10 +22,7 @@ BOOSTER_DAILY_LIMIT_ENABLED=false
 ###< Booster claims ###
 
 ###> Umami analytics ###
-# Umami local (service `umami` du docker-compose). Pour activer le tracking :
-# créer le site dans l'UI (https://umami.local.barlito.fr, admin/umami,
-# domaine ytcg.local.barlito.fr) puis copier son UUID dans .env.local :
-# UMAMI_WEBSITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# UMAMI_WEBSITE_ID : UUID du site (créé dans l'UI Umami) à mettre en .env.local
 UMAMI_URL='https://umami.local.barlito.fr'
 UMAMI_INGEST_URL='http://ytcg_umami:3000'
 ###< Umami analytics ###

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,6 +22,8 @@ jobs:
       JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
       JWT_SECRET_KEY: ${{ secrets.JWT_SECRET_KEY }}
       JWT_PASSPHRASE: ${{ secrets.JWT_PASSPHRASE }}
+      # UUID du site dans l'UI Umami (pas un secret) ; absent = tracking off
+      UMAMI_WEBSITE_ID: ${{ vars.UMAMI_WEBSITE_ID }}
 
     steps:
       - uses: actions/checkout@v7

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -3,6 +3,9 @@ twig:
     globals:
         # release tag of the running image (footer + admin), 'dev' outside prod
         app_version: '%env(APP_VERSION)%'
+        # umami pageview snippet (base layout); empty = snippet not rendered
+        umami_url: '%env(UMAMI_URL)%'
+        umami_website_id: '%env(UMAMI_WEBSITE_ID)%'
 
 when@test:
     twig:

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -11,6 +11,13 @@ services:
     adminer:
         profiles: [never-in-ci]
 
+    # same treatment: local analytics are pointless in CI
+    umami:
+        profiles: [never-in-ci]
+
+    umami_db:
+        profiles: [never-in-ci]
+
 networks:
     traefik_traefik_proxy:
         external: false

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -15,6 +15,9 @@ services:
             JWT_PUBLIC_KEY: "${JWT_PUBLIC_KEY}"
             JWT_SECRET_KEY: "${JWT_SECRET_KEY}"
             JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
+            # analytics anonymes (stack obs) ; UMAMI_WEBSITE_ID vide = snippet off
+            UMAMI_URL: "https://umami.barlito.fr"
+            UMAMI_WEBSITE_ID: "${UMAMI_WEBSITE_ID}"
             TZ: Europe/Paris
         tty: true
         deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,10 +70,55 @@ services:
             - ytcg_internal
             - traefik_traefik_proxy
 
+    # Umami local : même image épinglée qu'en prod (stack obs) pour tester le
+    # snippet et les events serveur avant déploiement
+    umami:
+        image: ghcr.io/umami-software/umami:postgresql-v2.19.0
+        environment:
+            DATABASE_TYPE: postgresql
+            DATABASE_URL: postgresql://postgres:root@ytcg_umami_db:5432/umami
+            APP_SECRET: local-dev-umami-secret
+            DISABLE_TELEMETRY: 1
+            TZ: Europe/Paris
+        deploy:
+            labels:
+                - traefik.enable=true
+
+                - traefik.http.services.ytcg_umami.loadbalancer.server.port=3000
+
+                - traefik.http.routers.ytcg_umami.rule=Host(`umami.local.barlito.fr`)
+                - traefik.http.routers.ytcg_umami.entrypoints=http
+
+                - traefik.http.routers.ytcg_umami-secure.rule=Host(`umami.local.barlito.fr`)
+                - traefik.http.routers.ytcg_umami-secure.entrypoints=https
+                - traefik.http.routers.ytcg_umami-secure.tls=true
+        networks:
+            - ytcg_internal
+            - traefik_traefik_proxy
+
+    umami_db:
+        image: postgres:18
+        environment:
+            POSTGRES_PASSWORD: root
+            POSTGRES_DB: umami
+            TZ: Europe/Paris
+            PGTZ: Europe/Paris
+        volumes:
+            # postgres:18 a déplacé PGDATA : on monte /var/lib/postgresql (et plus .../data)
+            - ytcg_umami_db_data:/var/lib/postgresql:rw
+        healthcheck:
+            test: [ "CMD-SHELL", "pg_isready -U postgres"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+        networks:
+            - ytcg_internal
+
 volumes:
     ytcg_caddy_data:
     ytcg_caddy_config:
     ytcg_db_data:
+    ytcg_umami_db_data:
 
 networks:
     traefik_traefik_proxy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,8 +70,7 @@ services:
             - ytcg_internal
             - traefik_traefik_proxy
 
-    # Umami local : même image épinglée qu'en prod (stack obs) pour tester le
-    # snippet et les events serveur avant déploiement
+    # même image épinglée qu'en prod (stack obs)
     umami:
         image: ghcr.io/umami-software/umami:postgresql-v2.19.0
         environment:

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -21,6 +21,9 @@
         {% block importmap %}
             {{ importmap('app') }}
         {% endblock %}
+        {% if umami_url and umami_website_id %}
+            <script defer src="{{ umami_url }}/script.js" data-website-id="{{ umami_website_id }}"></script>
+        {% endif %}
     {% endblock %}
 </head>
 <body class="flex min-h-screen flex-col bg-bg font-sans text-ink antialiased">

--- a/tests/Functional/LayoutTest.php
+++ b/tests/Functional/LayoutTest.php
@@ -88,6 +88,18 @@ final class LayoutTest extends WebTestCase
         $this->assertSame('dev', $crawler->filter('[data-testid="app-version"]')->first()->text());
     }
 
+    public function testUmamiSnippetIsAbsentWhenUnconfigured(): void
+    {
+        $client = self::createClient();
+        $this->authenticateClient($client);
+
+        $crawler = $client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        // UMAMI_URL / UMAMI_WEBSITE_ID default to '' (see .env): no tracking
+        $this->assertCount(0, $crawler->filter('script[data-website-id]'));
+    }
+
     public function testAdminLinkOnlyVisibleForAdmin(): void
     {
         $client = self::createClient();


### PR DESCRIPTION
## Quoi

Première moitié de l'intégration Umami (analytics **anonymes** — aucun discordId ne quitte l'app) : les pageviews via le snippet JS officiel.

- **Stack dev locale** : services `umami` + `umami_db` dans `docker-compose.yml` (host `umami.local.barlito.fr`, même image épinglée que la prod), masqués en CI via le profil `never-in-ci` (pattern adminer).
- **Env** : `UMAMI_URL` / `UMAMI_INGEST_URL` / `UMAMI_WEBSITE_ID` vides par défaut dans `.env` (**vide = feature off**, test/CI inertes) ; valeurs locales dans `.env.dev`, l'UUID du site va dans `.env.local` (instructions en commentaire).
- **Snippet** : rendu dans `base.html.twig` uniquement si les deux globals Twig sont non vides.
- **Prod** : `UMAMI_URL` statique + `UMAMI_WEBSITE_ID` interpolé depuis la variable de repo GitHub (à créer après le premier déploiement d'Umami côté observability-stack — barlito/observability-stack#5) ; variable absente ⇒ snippet off, pas d'échec de deploy.

`UMAMI_INGEST_URL` est posé dès maintenant mais consommé par la PR suivante (events serveur).

## Tests

- `LayoutTest::testUmamiSnippetIsAbsentWhenUnconfigured` : env par défaut ⇒ aucun `script[data-website-id]` rendu.
- PHPStan niveau 8 OK, suite complète 156 tests verts, `fix_style`/`check_style` OK.

## Dépendances

À merger **après** barlito/observability-stack#5 (le snippet pointe sur `umami.barlito.fr`) ; nécessite un **re-deploy complet** (pas le fast path `--image`) pour appliquer les changements d'environment du compose.

⚠️ Note : le hook qualité local (`.claude/settings.json`) est cassé (`set -o pipefail` sous /bin/sh) — les checks ont été lancés manuellement pour cette PR.