### PR TITLE
feat(analytics): events serveur Umami (booster_claimed / booster_opened)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "symfony/dotenv": "7.4.*",
         "symfony/flex": "^2",
         "symfony/framework-bundle": "7.4.*",
+        "symfony/http-client": "7.4.*",
         "symfony/monolog-bundle": "^4.0",
         "symfony/runtime": "7.4.*",
         "symfony/ux-live-component": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a6ca125a99d02dcdbb093ac200f5385",
+    "content-hash": "2c86493960c048dab9cf9bfb6a29475b",
     "packages": [
         {
             "name": "barlito/utils",
@@ -4748,16 +4748,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.4.13",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "e8a112b8415707265a7e614278136a9d92989a6a"
+                "reference": "f6bc6b5a54ff5afac4725cacec9bf2f52eb15920"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/e8a112b8415707265a7e614278136a9d92989a6a",
-                "reference": "e8a112b8415707265a7e614278136a9d92989a6a",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/f6bc6b5a54ff5afac4725cacec9bf2f52eb15920",
+                "reference": "f6bc6b5a54ff5afac4725cacec9bf2f52eb15920",
                 "shasum": ""
             },
             "require": {
@@ -4825,7 +4825,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.4.13"
+                "source": "https://github.com/symfony/http-client/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4845,7 +4845,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T09:57:54+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/http-client-contracts",

--- a/config/packages/http_client.yaml
+++ b/config/packages/http_client.yaml
@@ -1,0 +1,8 @@
+framework:
+    http_client:
+        scoped_clients:
+            # autowired as HttpClientInterface $umamiClient (UmamiAnalyticsTracker);
+            # short timeout: analytics must never noticeably slow a user action
+            umami.client:
+                base_uri: '%env(UMAMI_INGEST_URL)%'
+                timeout: 2

--- a/config/packages/http_client.yaml
+++ b/config/packages/http_client.yaml
@@ -1,8 +1,7 @@
 framework:
     http_client:
         scoped_clients:
-            # autowired as HttpClientInterface $umamiClient (UmamiAnalyticsTracker);
-            # short timeout: analytics must never noticeably slow a user action
+            # autowired as HttpClientInterface $umamiClient
             umami.client:
                 base_uri: '%env(UMAMI_INGEST_URL)%'
                 timeout: 2

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,8 +25,6 @@ services:
     # the decorated service id resolves to the decorator chain when present.
     App\Service\Booster\BoosterClaimQuotaInterface: '@App\Service\Booster\DailyBoosterClaimQuota'
 
-    # No-op by default so test/CI never attempt HTTP; the real Umami tracker is
-    # aliased per environment below (no runtime bypass flag in prod code).
     App\Service\Analytics\AnalyticsTrackerInterface: '@App\Service\Analytics\NullAnalyticsTracker'
 
 when@dev:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,6 +25,18 @@ services:
     # the decorated service id resolves to the decorator chain when present.
     App\Service\Booster\BoosterClaimQuotaInterface: '@App\Service\Booster\DailyBoosterClaimQuota'
 
+    # No-op by default so test/CI never attempt HTTP; the real Umami tracker is
+    # aliased per environment below (no runtime bypass flag in prod code).
+    App\Service\Analytics\AnalyticsTrackerInterface: '@App\Service\Analytics\NullAnalyticsTracker'
+
+when@dev:
+    services:
+        App\Service\Analytics\AnalyticsTrackerInterface: '@App\Service\Analytics\UmamiAnalyticsTracker'
+
+when@prod:
+    services:
+        App\Service\Analytics\AnalyticsTrackerInterface: '@App\Service\Analytics\UmamiAnalyticsTracker'
+
 when@test:
     services:
         _defaults:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -17,6 +17,9 @@ services:
             JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
             # analytics anonymes (stack obs) ; UMAMI_WEBSITE_ID vide = snippet off
             UMAMI_URL: "https://umami.barlito.fr"
+            # events serveur en direct via l'overlay obs_analytics (headers
+            # UA/XFF intacts, pas de détour par Traefik)
+            UMAMI_INGEST_URL: "http://obs_umami:3000"
             UMAMI_WEBSITE_ID: "${UMAMI_WEBSITE_ID}"
             TZ: Europe/Paris
         tty: true
@@ -46,6 +49,7 @@ services:
         networks:
             - traefik_traefik_proxy
             - ytcg_internal
+            - obs_analytics
 
     db:
         image: postgres:18
@@ -95,3 +99,7 @@ networks:
         external: true
     ytcg_internal:
         driver: overlay
+    # Overlay attachable possédé par la stack obs (nom explicite côté
+    # observability-stack) : seul Umami y est joignable
+    obs_analytics:
+        external: true

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -17,8 +17,6 @@ services:
             JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
             # analytics anonymes (stack obs) ; UMAMI_WEBSITE_ID vide = snippet off
             UMAMI_URL: "https://umami.barlito.fr"
-            # events serveur en direct via l'overlay obs_analytics (headers
-            # UA/XFF intacts, pas de détour par Traefik)
             UMAMI_INGEST_URL: "http://obs_umami:3000"
             UMAMI_WEBSITE_ID: "${UMAMI_WEBSITE_ID}"
             TZ: Europe/Paris
@@ -99,7 +97,6 @@ networks:
         external: true
     ytcg_internal:
         driver: overlay
-    # Overlay attachable possédé par la stack obs (nom explicite côté
-    # observability-stack) : seul Umami y est joignable
+    # overlay créé par la stack obs
     obs_analytics:
         external: true

--- a/src/Service/Analytics/AnalyticsTrackerInterface.php
+++ b/src/Service/Analytics/AnalyticsTrackerInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Analytics;
+
+interface AnalyticsTrackerInterface
+{
+    /**
+     * Records an anonymous product event (never any user identifier).
+     *
+     * Fire-and-forget contract: implementations MUST NOT throw — a broken
+     * analytics backend must never break the user flow being tracked.
+     *
+     * @param array<string, bool|float|int|string> $data
+     */
+    public function track(string $event, array $data = []): void;
+}

--- a/src/Service/Analytics/NullAnalyticsTracker.php
+++ b/src/Service/Analytics/NullAnalyticsTracker.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Analytics;
+
+/**
+ * Safe default (test, CI, any env without an Umami instance): events are dropped.
+ */
+final class NullAnalyticsTracker implements AnalyticsTrackerInterface
+{
+    public function track(string $event, array $data = []): void
+    {
+    }
+}

--- a/src/Service/Analytics/UmamiAnalyticsTracker.php
+++ b/src/Service/Analytics/UmamiAnalyticsTracker.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Analytics;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Sends events to Umami's /api/send over the internal obs_analytics network.
+ *
+ * The visitor's User-Agent and IP are forwarded so Umami attributes the event
+ * to the same session as the JS-snippet pageviews (it hashes IP + UA); the
+ * payload itself stays anonymous.
+ */
+final readonly class UmamiAnalyticsTracker implements AnalyticsTrackerInterface
+{
+    // Umami drops events whose UA looks like a bot (isbot), so the no-request
+    // fallback (CLI, workers) must be a plausible browser string
+    private const string FALLBACK_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64) Symfony/UmamiAnalyticsTracker';
+
+    public function __construct(
+        private HttpClientInterface $umamiClient,
+        private RequestStack $requestStack,
+        private LoggerInterface $logger,
+        #[Autowire(env: 'UMAMI_WEBSITE_ID')]
+        private string $websiteId,
+    ) {
+    }
+
+    public function track(string $event, array $data = []): void
+    {
+        if ('' === $this->websiteId) {
+            return;
+        }
+
+        $request = $this->requestStack->getCurrentRequest();
+
+        $headers = ['User-Agent' => $request?->headers->get('User-Agent') ?? self::FALLBACK_USER_AGENT];
+        if (null !== $request?->getClientIp()) {
+            $headers['X-Forwarded-For'] = $request->getClientIp();
+        }
+
+        try {
+            $response = $this->umamiClient->request('POST', '/api/send', [
+                'headers' => $headers,
+                'json' => [
+                    'type' => 'event',
+                    'payload' => [
+                        'website' => $this->websiteId,
+                        'name' => $event,
+                        'data' => $data,
+                        'url' => $request?->getPathInfo() ?? '',
+                        'hostname' => $request?->getHost() ?? '',
+                    ],
+                ],
+            ]);
+            // HttpClient is lazy: consume the response so transport/HTTP errors
+            // surface here, inside the try, instead of at destruct time
+            $response->getStatusCode();
+        } catch (\Throwable $throwable) {
+            $this->logger->warning('Umami event failed', [
+                'event' => $event,
+                'exception' => $throwable,
+            ]);
+        }
+    }
+}

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -10,6 +10,7 @@ use App\Exception\Booster\BoosterException;
 use App\Repository\BoosterRepository;
 use App\Repository\CardRepository;
 use App\Repository\UserBoosterRepository;
+use App\Service\Analytics\AnalyticsTrackerInterface;
 use App\Service\Booster\BoosterClaimService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Uid\Uuid;
@@ -40,6 +41,7 @@ final class BoosterHub extends AbstractController
         private readonly CardRepository $cardRepository,
         private readonly UserBoosterRepository $userBoosterRepository,
         private readonly BoosterClaimService $boosterClaimService,
+        private readonly AnalyticsTrackerInterface $analyticsTracker,
     ) {
     }
 
@@ -145,7 +147,14 @@ final class BoosterHub extends AbstractController
             $this->inventory = null; // the memoized inventory is stale after a claim
         } catch (BoosterException $exception) {
             $this->error = $exception->getUserMessage();
+
+            return;
         }
+
+        $this->analyticsTracker->track('booster_claimed', [
+            'booster' => $booster->getDisplayName(),
+            'extension' => $booster->getExtension()->getName(),
+        ]);
     }
 
     /**

--- a/src/Twig/Components/BoosterOpening.php
+++ b/src/Twig/Components/BoosterOpening.php
@@ -15,6 +15,7 @@ use App\Repository\BoosterRepository;
 use App\Repository\CardRepository;
 use App\Repository\UserBoosterRepository;
 use App\Repository\UserCardRepository;
+use App\Service\Analytics\AnalyticsTrackerInterface;
 use App\Service\Booster\BoosterOpeningService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
@@ -81,6 +82,7 @@ final class BoosterOpening extends AbstractController
         private readonly UserBoosterRepository $userBoosterRepository,
         private readonly UserCardRepository $userCardRepository,
         private readonly BoosterOpeningService $boosterOpeningService,
+        private readonly AnalyticsTrackerInterface $analyticsTracker,
     ) {
     }
 
@@ -239,6 +241,21 @@ final class BoosterOpening extends AbstractController
                 $this->newCardIds[] = $cardId;
             }
         }
+
+        $booster = $this->getBooster();
+        $ranks = $this->rarityRanks();
+        $bestRarity = array_reduce(
+            $result->drawnCards,
+            static fn (CardRarityEnum $best, DrawnCard $drawnCard): CardRarityEnum => ($ranks[$drawnCard->rarity->value] ?? 0) > ($ranks[$best->value] ?? 0) ? $drawnCard->rarity : $best,
+            CardRarityEnum::ascending()[0],
+        );
+        $this->analyticsTracker->track('booster_opened', [
+            'booster' => $booster->getDisplayName(),
+            'extension' => $booster->getExtension()->getName(),
+            'best_rarity' => $bestRarity->value,
+            'holo_count' => \count(array_filter($result->drawnCards, static fn (DrawnCard $drawnCard): bool => $drawnCard->holo)),
+            'new_cards' => \count($this->newCardIds),
+        ]);
     }
 
     #[LiveAction]

--- a/tests/Unit/Service/Analytics/UmamiAnalyticsTrackerTest.php
+++ b/tests/Unit/Service/Analytics/UmamiAnalyticsTrackerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service\Analytics;
+
+use App\Service\Analytics\UmamiAnalyticsTracker;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+final class UmamiAnalyticsTrackerTest extends TestCase
+{
+    private const string WEBSITE_ID = '019807c8-0000-7000-8000-000000000000';
+
+    public function testSendsEventPayloadWithForwardedClientHeaders(): void
+    {
+        $capturedOptions = null;
+        $capturedUrl = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedOptions, &$capturedUrl): MockResponse {
+            $capturedUrl = $url;
+            $capturedOptions = $options;
+
+            return new MockResponse('{"ok":true}');
+        }, 'http://umami.test');
+
+        $tracker = new UmamiAnalyticsTracker(
+            $httpClient,
+            $this->createRequestStack(),
+            $this->createStub(LoggerInterface::class),
+            self::WEBSITE_ID,
+        );
+
+        $tracker->track('booster_opened', ['extension' => 'Origines', 'holo_count' => 2]);
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+        $this->assertSame('http://umami.test/api/send', $capturedUrl);
+        $this->assertIsArray($capturedOptions);
+
+        $payload = json_decode((string) $capturedOptions['body'], true, flags: \JSON_THROW_ON_ERROR);
+        $this->assertSame('event', $payload['type']);
+        $this->assertSame(self::WEBSITE_ID, $payload['payload']['website']);
+        $this->assertSame('booster_opened', $payload['payload']['name']);
+        $this->assertSame(['extension' => 'Origines', 'holo_count' => 2], $payload['payload']['data']);
+        $this->assertSame('/boosters', $payload['payload']['url']);
+        $this->assertSame('ytcg.test', $payload['payload']['hostname']);
+
+        $headers = implode("\n", $capturedOptions['headers']);
+        $this->assertStringContainsString('User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0', $headers);
+        $this->assertStringContainsString('X-Forwarded-For: 203.0.113.7', $headers);
+    }
+
+    public function testFallsBackToBrowserLikeUserAgentWithoutRequest(): void
+    {
+        $capturedOptions = null;
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedOptions): MockResponse {
+            $capturedOptions = $options;
+
+            return new MockResponse('{"ok":true}');
+        }, 'http://umami.test');
+
+        $tracker = new UmamiAnalyticsTracker(
+            $httpClient,
+            new RequestStack(),
+            $this->createStub(LoggerInterface::class),
+            self::WEBSITE_ID,
+        );
+
+        $tracker->track('booster_claimed');
+
+        $this->assertSame(1, $httpClient->getRequestsCount());
+        $this->assertIsArray($capturedOptions);
+        // Umami drops bot-looking user agents (isbot): the fallback must look like a browser
+        $this->assertStringContainsString('User-Agent: Mozilla/5.0', implode("\n", $capturedOptions['headers']));
+    }
+
+    public function testDoesNothingWhenWebsiteIdIsEmpty(): void
+    {
+        $httpClient = new MockHttpClient([], 'http://umami.test');
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->never())->method('warning');
+
+        $tracker = new UmamiAnalyticsTracker($httpClient, $this->createRequestStack(), $logger, '');
+
+        $tracker->track('booster_claimed', ['booster' => 'Origines']);
+
+        $this->assertSame(0, $httpClient->getRequestsCount());
+    }
+
+    public function testTransportErrorIsSwallowedAndLogged(): void
+    {
+        $httpClient = new MockHttpClient(
+            static fn (): MockResponse => new MockResponse('', ['error' => 'connection refused']),
+            'http://umami.test',
+        );
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('warning')->with('Umami event failed', $this->callback(
+            static fn (array $context): bool => 'booster_opened' === $context['event'] && $context['exception'] instanceof \Throwable,
+        ));
+
+        $tracker = new UmamiAnalyticsTracker($httpClient, $this->createRequestStack(), $logger, self::WEBSITE_ID);
+
+        $tracker->track('booster_opened');
+    }
+
+    private function createRequestStack(): RequestStack
+    {
+        $request = Request::create('https://ytcg.test/boosters', server: [
+            'HTTP_USER_AGENT' => 'Mozilla/5.0 (X11; Linux x86_64; rv:120.0) Gecko/20100101 Firefox/120.0',
+            'REMOTE_ADDR' => '203.0.113.7',
+        ]);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return $requestStack;
+    }
+}


### PR DESCRIPTION
## Quoi

Seconde moitié de l'intégration Umami (empilée sur #101) : les events métier, envoyés **côté serveur**.

- **`src/Service/Analytics/`** : `AnalyticsTrackerInterface` (contrat fire-and-forget, ne throw jamais), `UmamiAnalyticsTracker` (scoped http-client `umami.client`, timeout 2s, POST `/api/send`) et `NullAnalyticsTracker`.
- **Attribution visiteur** : le tracker forwarde le `User-Agent` et l'IP du visiteur (`X-Forwarded-For`) pour que les events rejoignent la même session Umami que les pageviews du snippet (hash IP+UA). Fallback UA « navigateur » hors requête HTTP (isbot droppe silencieusement les UA de bots). **Aucun identifiant utilisateur dans les payloads.**
- **Câblage par env** (`services.yaml`) : Null par défaut (test/CI sans HTTP), réel en `when@dev`/`when@prod` — pas de flag de bypass runtime, même logique que l'alias `BoosterClaimQuotaInterface`.
- **Hooks** : `BoosterHub::claimBooster` → `booster_claimed` {booster, extension} ; `BoosterOpening::open` → `booster_opened` {booster, extension, best_rarity, holo_count, new_cards}. Émis après le retour des services, donc après commit de la transaction — un tirage rollback n'émet rien. Les erreurs HTTP sont avalées + loggées en warning : l'ouverture ne casse jamais.
- **Prod** : le service php rejoint l'overlay externe `obs_analytics` (nom explicite posé par barlito/observability-stack#5) et parle à `http://obs_umami:3000` en direct — headers intacts, pas de détour Traefik.
- Pas d'event custom pour /univers : les pageviews URL (`/univers/{slug}`) suffisent.

## Tests

- `UmamiAnalyticsTrackerTest` (MockHttpClient) : payload, forwarding UA/XFF, fallback CLI, website id vide ⇒ 0 requête, erreur transport ⇒ warning sans throw.
- Suite complète : 160 tests verts ; PHPStan niveau 8 OK ; `fix_style`/`check_style` OK ; composer.json valide.

## Déploiement

À merger après #101 ; nécessite un **re-deploy complet** (nouveau réseau sur le service php). Vérifier ensuite `docker service inspect ytcg_php` → `obs_analytics` présent.