### PR TITLE
fix(booster): empêche l'ouverture d'un booster sans rarityRates

### DIFF
--- a/src/Exception/Booster/EmptyRarityRatesException.php
+++ b/src/Exception/Booster/EmptyRarityRatesException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Booster;
+
+final class EmptyRarityRatesException extends BoosterException
+{
+}

--- a/src/Service/Booster/BoosterOpeningService.php
+++ b/src/Service/Booster/BoosterOpeningService.php
@@ -10,6 +10,7 @@ use App\Entity\Booster;
 use App\Entity\BoosterOpening;
 use App\Entity\BoosterOpeningCard;
 use App\Entity\DiscordUser;
+use App\Exception\Booster\EmptyRarityRatesException;
 use App\Exception\Booster\NoBoosterInInventoryException;
 use App\Exception\Booster\NoCardAvailableException;
 use App\Repository\CardRepository;
@@ -36,6 +37,7 @@ final readonly class BoosterOpeningService
 
     /**
      * @throws NoBoosterInInventoryException
+     * @throws EmptyRarityRatesException
      * @throws NoCardAvailableException
      */
     public function open(DiscordUser $discordUser, Booster $booster): BoosterOpeningResult

--- a/src/Service/Booster/CardDrawer.php
+++ b/src/Service/Booster/CardDrawer.php
@@ -9,6 +9,7 @@ use App\Entity\Booster;
 use App\Entity\Card;
 use App\Entity\Extension;
 use App\Enum\Entity\CardRarityEnum;
+use App\Exception\Booster\EmptyRarityRatesException;
 use App\Exception\Booster\NoCardAvailableException;
 use App\Repository\CardRepository;
 use App\Service\Random\RandomService;
@@ -27,12 +28,23 @@ final readonly class CardDrawer
     }
 
     /**
-     * @throws NoCardAvailableException when the extension has no published card
+     * @throws EmptyRarityRatesException when the booster has no slot configured
+     * @throws NoCardAvailableException  when the extension has no published card
      *
      * @return list<DrawnCard>
      */
     public function draw(Booster $booster): array
     {
+        // Guard BEFORE any debit-side effect matters: with zero slots the loop
+        // below would silently return no card while the caller already debited
+        // the booster in the same transaction (the exception triggers rollback).
+        if ([] === $booster->getRarityRates()) {
+            throw new EmptyRarityRatesException(
+                \sprintf('Booster "%s" has empty rarityRates: no slot to draw.', $booster->getDisplayName()),
+                'Ce booster est mal configuré et ne peut pas être ouvert pour le moment, réessaie plus tard.',
+            );
+        }
+
         $pool = $this->loadPool($booster->getExtension());
 
         if ([] === $pool) {

--- a/tests/Unit/Service/CardDrawerTest.php
+++ b/tests/Unit/Service/CardDrawerTest.php
@@ -8,6 +8,7 @@ use App\Entity\Booster;
 use App\Entity\Card;
 use App\Entity\Extension;
 use App\Enum\Entity\CardRarityEnum;
+use App\Exception\Booster\EmptyRarityRatesException;
 use App\Exception\Booster\NoCardAvailableException;
 use App\Repository\CardRepository;
 use App\Service\Booster\CardDrawer;
@@ -142,6 +143,25 @@ final class CardDrawerTest extends TestCase
             $this->assertFalse($drawnCards[0]->holo);
             $this->assertTrue($drawnCards[1]->holo);
         }
+    }
+
+    public function testThrowsWhenRarityRatesAreEmpty(): void
+    {
+        // The guard must fire before any pool load or roll: an empty slot list
+        // would otherwise "draw" zero cards while the caller already debited
+        // the booster in the same transaction.
+        $cardRepository = $this->createMock(CardRepository::class);
+        $cardRepository->expects($this->never())->method('findDrawablePool');
+        $drawer = new CardDrawer($cardRepository, new RandomService());
+
+        $booster = new Booster()
+            ->setExtension($this->extension())
+            ->setRarityRates([])
+        ;
+
+        $this->expectException(EmptyRarityRatesException::class);
+
+        $drawer->draw($booster);
     }
 
     public function testThrowsWhenExtensionHasNoPublishedCard(): void

--- a/tests/Unit/Validator/ValidRarityRatesValidatorTest.php
+++ b/tests/Unit/Validator/ValidRarityRatesValidatorTest.php
@@ -16,13 +16,18 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
  */
 final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
 {
-    private ValidRarityRates $constraint;
+    /**
+     * The parent class already declares a protected $constraint property:
+     * redeclaring it (or narrowing its visibility) is a PHP fatal error,
+     * hence the distinct name.
+     */
+    private ValidRarityRates $rarityRatesConstraint;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->constraint = new ValidRarityRates();
+        $this->rarityRatesConstraint = new ValidRarityRates();
     }
 
     public function testValidRarityRatesRaiseNoViolation(): void
@@ -30,7 +35,7 @@ final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate([
             ['rarities' => ['common' => 100], 'holoChance' => 0],
             ['rarities' => ['common' => 60, 'rare' => 30, 'legendary' => 10], 'holoChance' => 100],
-        ], $this->constraint);
+        ], $this->rarityRatesConstraint);
 
         $this->assertNoViolation();
     }
@@ -39,14 +44,14 @@ final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
     {
         $this->expectException(UnexpectedValueException::class);
 
-        $this->validator->validate('not-an-array', $this->constraint);
+        $this->validator->validate('not-an-array', $this->rarityRatesConstraint);
     }
 
     public function testEmptySlotListIsRejected(): void
     {
-        $this->validator->validate([], $this->constraint);
+        $this->validator->validate([], $this->rarityRatesConstraint);
 
-        $this->buildViolation($this->constraint->emptyMessage)->assertRaised();
+        $this->buildViolation($this->rarityRatesConstraint->emptyMessage)->assertRaised();
     }
 
     #[DataProvider('provideMalformedSlots')]
@@ -55,9 +60,9 @@ final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
         $this->validator->validate([
             ['rarities' => ['common' => 100], 'holoChance' => 10],
             $slot,
-        ], $this->constraint);
+        ], $this->rarityRatesConstraint);
 
-        $this->buildViolation($this->constraint->invalidSlotMessage)
+        $this->buildViolation($this->rarityRatesConstraint->invalidSlotMessage)
             ->setParameter('{{ slot }}', '2')
             ->assertRaised()
         ;
@@ -78,9 +83,9 @@ final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
     {
         $this->validator->validate([
             ['rarities' => $rarities, 'holoChance' => 10],
-        ], $this->constraint);
+        ], $this->rarityRatesConstraint);
 
-        $this->buildViolation($this->constraint->invalidRaritiesMessage)
+        $this->buildViolation($this->rarityRatesConstraint->invalidRaritiesMessage)
             ->setParameter('{{ slot }}', '1')
             ->assertRaised()
         ;
@@ -99,9 +104,9 @@ final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
     {
         $this->validator->validate([
             ['rarities' => ['epic' => 10], 'holoChance' => 10],
-        ], $this->constraint);
+        ], $this->rarityRatesConstraint);
 
-        $this->buildViolation($this->constraint->invalidRarityMessage)
+        $this->buildViolation($this->rarityRatesConstraint->invalidRarityMessage)
             ->setParameter('{{ slot }}', '1')
             ->setParameter('{{ rarity }}', 'epic')
             ->setParameter('{{ rarities }}', implode(', ', array_column(CardRarityEnum::cases(), 'value')))
@@ -114,9 +119,9 @@ final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
     {
         $this->validator->validate([
             ['rarities' => ['common' => $weight], 'holoChance' => 10],
-        ], $this->constraint);
+        ], $this->rarityRatesConstraint);
 
-        $this->buildViolation($this->constraint->invalidWeightMessage)
+        $this->buildViolation($this->rarityRatesConstraint->invalidWeightMessage)
             ->setParameter('{{ slot }}', '1')
             ->setParameter('{{ rarity }}', 'common')
             ->assertRaised()
@@ -138,9 +143,9 @@ final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
     {
         $this->validator->validate([
             ['rarities' => ['common' => 100], 'holoChance' => $holoChance],
-        ], $this->constraint);
+        ], $this->rarityRatesConstraint);
 
-        $this->buildViolation($this->constraint->invalidHoloChanceMessage)
+        $this->buildViolation($this->rarityRatesConstraint->invalidHoloChanceMessage)
             ->setParameter('{{ slot }}', '1')
             ->assertRaised()
         ;
@@ -160,13 +165,13 @@ final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
     {
         $this->validator->validate([
             ['rarities' => ['epic' => 0], 'holoChance' => 10],
-        ], $this->constraint);
+        ], $this->rarityRatesConstraint);
 
-        $this->buildViolation($this->constraint->invalidRarityMessage)
+        $this->buildViolation($this->rarityRatesConstraint->invalidRarityMessage)
             ->setParameter('{{ slot }}', '1')
             ->setParameter('{{ rarity }}', 'epic')
             ->setParameter('{{ rarities }}', implode(', ', array_column(CardRarityEnum::cases(), 'value')))
-            ->buildNextViolation($this->constraint->invalidWeightMessage)
+            ->buildNextViolation($this->rarityRatesConstraint->invalidWeightMessage)
             ->setParameter('{{ slot }}', '1')
             ->setParameter('{{ rarity }}', 'epic')
             ->assertRaised()

--- a/tests/Unit/Validator/ValidRarityRatesValidatorTest.php
+++ b/tests/Unit/Validator/ValidRarityRatesValidatorTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Validator;
+
+use App\Enum\Entity\CardRarityEnum;
+use App\Validator\ValidRarityRates;
+use App\Validator\ValidRarityRatesValidator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @extends ConstraintValidatorTestCase<ValidRarityRatesValidator>
+ */
+final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
+{
+    private ValidRarityRates $constraint;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->constraint = new ValidRarityRates();
+    }
+
+    public function testValidRarityRatesRaiseNoViolation(): void
+    {
+        $this->validator->validate([
+            ['rarities' => ['common' => 100], 'holoChance' => 0],
+            ['rarities' => ['common' => 60, 'rare' => 30, 'legendary' => 10], 'holoChance' => 100],
+        ], $this->constraint);
+
+        $this->assertNoViolation();
+    }
+
+    public function testNonArrayValueIsRejected(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+
+        $this->validator->validate('not-an-array', $this->constraint);
+    }
+
+    public function testEmptySlotListIsRejected(): void
+    {
+        $this->validator->validate([], $this->constraint);
+
+        $this->buildViolation($this->constraint->emptyMessage)->assertRaised();
+    }
+
+    #[DataProvider('provideMalformedSlots')]
+    public function testMalformedSlotIsRejected(mixed $slot): void
+    {
+        $this->validator->validate([
+            ['rarities' => ['common' => 100], 'holoChance' => 10],
+            $slot,
+        ], $this->constraint);
+
+        $this->buildViolation($this->constraint->invalidSlotMessage)
+            ->setParameter('{{ slot }}', '2')
+            ->assertRaised()
+        ;
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function provideMalformedSlots(): iterable
+    {
+        yield 'not an array' => ['not-a-slot'];
+        yield 'missing rarities key' => [['holoChance' => 10]];
+        yield 'missing holoChance key' => [['rarities' => ['common' => 100]]];
+    }
+
+    #[DataProvider('provideInvalidRaritiesMaps')]
+    public function testInvalidRaritiesMapIsRejected(mixed $rarities): void
+    {
+        $this->validator->validate([
+            ['rarities' => $rarities, 'holoChance' => 10],
+        ], $this->constraint);
+
+        $this->buildViolation($this->constraint->invalidRaritiesMessage)
+            ->setParameter('{{ slot }}', '1')
+            ->assertRaised()
+        ;
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function provideInvalidRaritiesMaps(): iterable
+    {
+        yield 'not an array' => ['common'];
+        yield 'empty map' => [[]];
+    }
+
+    public function testUnknownRarityIsRejected(): void
+    {
+        $this->validator->validate([
+            ['rarities' => ['epic' => 10], 'holoChance' => 10],
+        ], $this->constraint);
+
+        $this->buildViolation($this->constraint->invalidRarityMessage)
+            ->setParameter('{{ slot }}', '1')
+            ->setParameter('{{ rarity }}', 'epic')
+            ->setParameter('{{ rarities }}', implode(', ', array_column(CardRarityEnum::cases(), 'value')))
+            ->assertRaised()
+        ;
+    }
+
+    #[DataProvider('provideInvalidWeights')]
+    public function testInvalidWeightIsRejected(mixed $weight): void
+    {
+        $this->validator->validate([
+            ['rarities' => ['common' => $weight], 'holoChance' => 10],
+        ], $this->constraint);
+
+        $this->buildViolation($this->constraint->invalidWeightMessage)
+            ->setParameter('{{ slot }}', '1')
+            ->setParameter('{{ rarity }}', 'common')
+            ->assertRaised()
+        ;
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function provideInvalidWeights(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-5];
+        yield 'not an integer' => ['100'];
+    }
+
+    #[DataProvider('provideInvalidHoloChances')]
+    public function testInvalidHoloChanceIsRejected(mixed $holoChance): void
+    {
+        $this->validator->validate([
+            ['rarities' => ['common' => 100], 'holoChance' => $holoChance],
+        ], $this->constraint);
+
+        $this->buildViolation($this->constraint->invalidHoloChanceMessage)
+            ->setParameter('{{ slot }}', '1')
+            ->assertRaised()
+        ;
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function provideInvalidHoloChances(): iterable
+    {
+        yield 'below zero' => [-1];
+        yield 'above one hundred' => [101];
+        yield 'not an integer' => ['10'];
+    }
+
+    public function testUnknownRarityWithInvalidWeightRaisesBothViolations(): void
+    {
+        $this->validator->validate([
+            ['rarities' => ['epic' => 0], 'holoChance' => 10],
+        ], $this->constraint);
+
+        $this->buildViolation($this->constraint->invalidRarityMessage)
+            ->setParameter('{{ slot }}', '1')
+            ->setParameter('{{ rarity }}', 'epic')
+            ->setParameter('{{ rarities }}', implode(', ', array_column(CardRarityEnum::cases(), 'value')))
+            ->buildNextViolation($this->constraint->invalidWeightMessage)
+            ->setParameter('{{ slot }}', '1')
+            ->setParameter('{{ rarity }}', 'epic')
+            ->assertRaised()
+        ;
+    }
+
+    protected function createValidator(): ValidRarityRatesValidator
+    {
+        return new ValidRarityRatesValidator();
+    }
+}


### PR DESCRIPTION
## Problème

`CardDrawer::draw()` itère sur `booster.rarityRates`. Si le tableau est vide (défaut de la colonne **et** de l'entité `Booster`), la boucle ne s'exécute pas et `draw()` retourne `[]` sans erreur. Or dans `BoosterOpeningService::open()`, le débit d'inventaire (`debitBooster`) a lieu **avant** le tirage, dans la même transaction : l'utilisateur perdait son booster et recevait zéro carte.

La contrainte `ValidRarityRates` n'est appliquée que par le formulaire EasyAdmin — un booster créé via fixtures, console ou SQL passe au travers.

## Fix

- Nouvelle `EmptyRarityRatesException` dans la hiérarchie `BoosterException` (message technique EN + message utilisateur FR), levée en tête de `draw()`, avant tout accès au pool ou tirage.
- Comme le débit est dans la même transaction (`wrapInTransaction`), l'exception provoque le rollback : le booster n'est pas consommé.
- Les composants Live (`BoosterOpening`) attrapent déjà `BoosterException` → le joueur voit un message propre : « Ce booster est mal configuré et ne peut pas être ouvert pour le moment, réessaie plus tard. »
- PHPDoc `@throws` mis à jour sur `CardDrawer::draw()` et `BoosterOpeningService::open()`.

## Tests

- **`CardDrawerTest::testThrowsWhenRarityRatesAreEmpty`** : booster à `rarityRates` vide → `EmptyRarityRatesException`, et `findDrawablePool` n'est jamais appelé (rien n'est tiré).
- **`ValidRarityRatesValidatorTest`** (nouveau, via `ConstraintValidatorTestCase`) — le validateur n'avait aucun test : configuration valide, liste de slots vide, valeur non-tableau (`UnexpectedValueException`), slot mal formé (non-tableau, clé `rarities` ou `holoChance` manquante), map de raretés invalide (non-tableau, vide), rareté inconnue, poids invalide (0, négatif, non entier), `holoChance` hors [0, 100] ou non entier, cumul de deux violations sur un même slot.
- Le test d'intégration existant `testOpeningRollsBackWhenExtensionHasNoPublishedCard` (rollback quand le tirage échoue) reste inchangé et vert : il passe par `withPublishedCards: false`, pas par des rates vides.