### PR TITLE
chore(prod): durcissement de la stack de production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Contexte de build Docker : n'embarquer que ce que .docker/Dockerfile
+# consomme réellement. NE PAS exclure .docker/ (COPY de app.ini,
+# app.prod.ini et du Caddyfile), ni composer.*/symfony.lock, .env,
+# importmap.php, assets/, config/, src/, templates/, migrations/, bin/,
+# translations/, tailwind.config.js, public/ (index.php + images statiques).
+
+# VCS / CI (le Dockerfile fait déjà rm -rf .github après COPY)
+.git
+.github
+
+# Outillage local
+.idea
+.claude
+docs
+
+# Généré au build dans l'image — ne jamais écraser le vendor --no-dev
+# ni le var/ créés par le Dockerfile avec des artefacts locaux
+vendor
+var
+node_modules
+
+# Contenu runtime : uploads Vich (volume en prod) et assets compilés
+# (asset-map:compile les régénère dans l'image)
+public/uploads
+public/assets
+
+# Dev/test uniquement (bundles Alice scopés dev/test, autoload-dev ignoré
+# par --no-dev)
+tests
+fixtures
+
+# Secrets et overrides locaux — ne doivent jamais entrer dans l'image
+.env.local
+.env.local.php
+.env.*.local

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,6 +1,9 @@
 services:
     php:
-        image: barlito/youl-tcg:${TAG}
+        # ${VAR:?...} : une variable absente ou vide fait échouer le
+        # `docker stack deploy` au lieu de déployer une valeur vide
+        # (mode de défaillance de l'incident APP_SECRET).
+        image: barlito/youl-tcg:${TAG:?TAG is required}
         volumes:
             - ytcg_caddy_data:/data
             # Uniquement le contenu uploadé (Vich) : public/images/ (textures
@@ -10,11 +13,11 @@ services:
         environment:
             # kernel.secret : signe notamment les checksums des Live Components —
             # vide, toute page qui en rend un (hub, admin) tombe en 500
-            APP_SECRET: "${APP_SECRET}"
-            DATABASE_URL: "postgresql://${DB_USER}:${DB_PASSWORD}@ytcg_db:5432/ytcg?serverVersion=18&charset=utf8"
-            JWT_PUBLIC_KEY: "${JWT_PUBLIC_KEY}"
-            JWT_SECRET_KEY: "${JWT_SECRET_KEY}"
-            JWT_PASSPHRASE: "${JWT_PASSPHRASE}"
+            APP_SECRET: "${APP_SECRET:?APP_SECRET is required}"
+            DATABASE_URL: "postgresql://${DB_USER:?DB_USER is required}:${DB_PASSWORD:?DB_PASSWORD is required}@ytcg_db:5432/ytcg?serverVersion=18&charset=utf8"
+            JWT_PUBLIC_KEY: "${JWT_PUBLIC_KEY:?JWT_PUBLIC_KEY is required}"
+            JWT_SECRET_KEY: "${JWT_SECRET_KEY:?JWT_SECRET_KEY is required}"
+            JWT_PASSPHRASE: "${JWT_PASSPHRASE:?JWT_PASSPHRASE is required}"
             TZ: Europe/Paris
         tty: true
         deploy:
@@ -47,7 +50,7 @@ services:
     db:
         image: postgres:18
         environment:
-            POSTGRES_PASSWORD: ${DB_PASSWORD}
+            POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
             POSTGRES_DB: ytcg
             TZ: Europe/Paris
             PGTZ: Europe/Paris

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -64,24 +64,6 @@ services:
         networks:
             - ytcg_internal
 
-    adminer:
-        image: adminer
-        deploy:
-            labels:
-                - traefik.enable=true
-
-                - traefik.http.services.ytcg_adminer.loadbalancer.server.port=8080
-
-                - traefik.http.routers.ytcg_adminer.rule=Host(`ytcg-adminer.barlito.fr`)
-                - traefik.http.routers.ytcg_adminer.entrypoints=http
-
-                - traefik.http.routers.ytcg_adminer-secure.rule=Host(`ytcg-adminer.barlito.fr`)
-                - traefik.http.routers.ytcg_adminer-secure.entrypoints=https
-                - traefik.http.routers.ytcg_adminer-secure.tls=true
-        networks:
-            - ytcg_internal
-            - traefik_traefik_proxy
-
 volumes:
     ytcg_db_data:
     ytcg_caddy_data:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,8 +1,5 @@
 services:
     php:
-        # ${VAR:?...} : une variable absente ou vide fait échouer le
-        # `docker stack deploy` au lieu de déployer une valeur vide
-        # (mode de défaillance de l'incident APP_SECRET).
         image: barlito/youl-tcg:${TAG:?TAG is required}
         volumes:
             - ytcg_caddy_data:/data


### PR DESCRIPTION
## Contenu

### 1. Suppression d'Adminer en prod
Le service `adminer` de `docker-compose-prod.yml` exposait la DB de production derrière un simple vhost Traefik public (`ytcg-adminer.barlito.fr`), sans authentification devant. Il est retiré de la prod ; Adminer reste disponible en dev (`docker-compose.yml`, inchangé). Aucune autre référence prod (Makefile, workflows, docs, CLAUDE.md) ne pointe dessus — la mention dans `docker-compose-ci.yml` concerne le fichier dev et reste valable.

### 2. Garde-fous d'interpolation (`${VAR:?}`)
Toutes les variables substituées dans `docker-compose-prod.yml` passent en `${VAR:?VAR is required}` : `TAG`, `APP_SECRET`, `DB_USER`, `DB_PASSWORD`, `JWT_PUBLIC_KEY`, `JWT_SECRET_KEY`, `JWT_PASSPHRASE`. Un secret absent ou **vide** fait désormais échouer le `docker stack deploy` au lieu de déployer une valeur vide (mode de défaillance de l'incident APP_SECRET, cf. 2d6a7d9). Chaque variable a été vérifiée : toutes sont fournies par `deploy.yaml` et consommées (kernel, lexik/jwt, Postgres) — aucune n'est optionnelle.

Vérifié localement :
- `docker compose -f docker-compose-prod.yml config -q` OK avec toutes les vars exportées ;
- échec explicite (`required variable JWT_PASSPHRASE is missing a value`) avec une var manquante.

### 3. `.dockerignore`
Le contexte de build n'embarque plus : VCS (`.git`, `.github`), outillage local (`.idea`, `.claude`, `docs`), `vendor/` et `var/` (un vendor local écraserait l'install `--no-dev` de l'image), `public/uploads` (volume) et `public/assets` (régénéré par `asset-map:compile`), `tests/` et `fixtures/` (bundles Alice scopés dev/test, autoload-dev ignoré par `--no-dev`), et les `.env` locaux (secrets).

Chaque étape du Dockerfile a été vérifiée contre la liste : `.docker/` reste **volontairement inclus** (le build COPY `app.ini`, `app.prod.ini` et le `Caddyfile` depuis le contexte avant le `rm -rf .docker`), de même que `composer.*`/`symfony.lock`, `.env` (`composer dump-env prod`), `importmap.php`, `assets/`, `templates/`, `tailwind.config.js`, `config/`, `src/`, `migrations/`, `bin/`, `public/index.php` et `public/images`.

## Note de déploiement

⚠️ La suppression d'Adminer nécessite un **re-deploy complet du stack** (`docker stack deploy`, input `re-deploy` du workflow) : un simple `service update` ne supprime pas le service `ytcg_adminer` devenu orphelin. Le vhost `ytcg-adminer.barlito.fr` peut ensuite être nettoyé côté DNS.

## Hors scope (volontairement)
Pas de resources limits ni de changement certresolver.

## Non vérifié
Pas de déploiement possible depuis cet environnement : validation limitée à `docker compose config` (parser compose-go). `docker stack deploy` (parser CLI classique) supporte la même syntaxe `${VAR:?err}` d'après la doc, mais le premier deploy réel fera foi.