### PR TITLE
fix(db): réaligne card.claimed_by avec la base + index composites manquants

### DIFF
--- a/migrations/Version20260805120000.php
+++ b/migrations/Version20260805120000.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Version20260618130000 hand-named the card.claimed_by index and foreign key
+ * (idx_card_claimed_by / fk_card_claimed_by) while the entity mapping expects
+ * the Doctrine-generated identifiers: the index name mismatch keeps
+ * doctrine:schema:validate permanently red and would make the next db.diff
+ * try to recreate it. Rename both to the names Doctrine derives from
+ * (table, columns) — IDX_/FK_161498D3296C217B — so the database matches the
+ * mapping exactly. Definitions are untouched (ON DELETE SET NULL stays).
+ */
+final class Version20260805120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Rename card.claimed_by index/FK to the Doctrine default names';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER INDEX IDX_CARD_CLAIMED_BY RENAME TO IDX_161498D3296C217B');
+        $this->addSql('ALTER TABLE card RENAME CONSTRAINT FK_CARD_CLAIMED_BY TO FK_161498D3296C217B');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER INDEX IDX_161498D3296C217B RENAME TO IDX_CARD_CLAIMED_BY');
+        $this->addSql('ALTER TABLE card RENAME CONSTRAINT FK_161498D3296C217B TO FK_CARD_CLAIMED_BY');
+    }
+}

--- a/migrations/Version20260805120000.php
+++ b/migrations/Version20260805120000.php
@@ -7,15 +7,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Version20260618130000 hand-named the card.claimed_by index and foreign key
- * (idx_card_claimed_by / fk_card_claimed_by) while the entity mapping expects
- * the Doctrine-generated identifiers: the index name mismatch keeps
- * doctrine:schema:validate permanently red and would make the next db.diff
- * try to recreate it. Rename both to the names Doctrine derives from
- * (table, columns) — IDX_/FK_161498D3296C217B — so the database matches the
- * mapping exactly. Definitions are untouched (ON DELETE SET NULL stays).
- */
 final class Version20260805120000 extends AbstractMigration
 {
     public function getDescription(): string

--- a/migrations/Version20260805121000.php
+++ b/migrations/Version20260805121000.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Composite indexes on the two most filtered column pairs:
+ * - card (extension_id, status): almost every CardRepository query filters on
+ *   both (findDrawablePool, findPublishedByExtension,
+ *   findExtensionIdsWithPublishedCards, findRandomCardId);
+ * - booster_claim (discord_user_id, claimed_at): the daily quota is a COUNT
+ *   on this pair (BoosterClaimRepository::countSince), executed on every hub
+ *   render — only a single-column index on discord_user_id existed.
+ * Names are the Doctrine-generated ones so the schema stays in sync with the
+ * ORM\Index declarations on the entities.
+ */
+final class Version20260805121000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add composite indexes card(extension_id, status) and booster_claim(discord_user_id, claimed_at)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE INDEX IDX_161498D3812D5EB7B00651C ON card (extension_id, status)');
+        $this->addSql('CREATE INDEX IDX_376FE897E3F3F7CE7CF00E05 ON booster_claim (discord_user_id, claimed_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_161498D3812D5EB7B00651C');
+        $this->addSql('DROP INDEX IDX_376FE897E3F3F7CE7CF00E05');
+    }
+}

--- a/migrations/Version20260805121000.php
+++ b/migrations/Version20260805121000.php
@@ -7,17 +7,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Composite indexes on the two most filtered column pairs:
- * - card (extension_id, status): almost every CardRepository query filters on
- *   both (findDrawablePool, findPublishedByExtension,
- *   findExtensionIdsWithPublishedCards, findRandomCardId);
- * - booster_claim (discord_user_id, claimed_at): the daily quota is a COUNT
- *   on this pair (BoosterClaimRepository::countSince), executed on every hub
- *   render — only a single-column index on discord_user_id existed.
- * Names are the Doctrine-generated ones so the schema stays in sync with the
- * ORM\Index declarations on the entities.
- */
 final class Version20260805121000 extends AbstractMigration
 {
     public function getDescription(): string

--- a/src/Entity/BoosterClaim.php
+++ b/src/Entity/BoosterClaim.php
@@ -15,6 +15,9 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
  * mutable counter to reset.
  */
 #[ORM\Entity(repositoryClass: BoosterClaimRepository::class)]
+// The daily quota is a COUNT on (user, claimed_at >= midnight) executed on
+// every hub render (BoosterClaimRepository::countSince): index the pair.
+#[ORM\Index(columns: ['discord_user_id', 'claimed_at'])]
 class BoosterClaim
 {
     use IdUuidTrait;

--- a/src/Entity/BoosterClaim.php
+++ b/src/Entity/BoosterClaim.php
@@ -15,8 +15,6 @@ use Gedmo\Timestampable\Traits\TimestampableEntity;
  * mutable counter to reset.
  */
 #[ORM\Entity(repositoryClass: BoosterClaimRepository::class)]
-// The daily quota is a COUNT on (user, claimed_at >= midnight) executed on
-// every hub render (BoosterClaimRepository::countSince): index the pair.
 #[ORM\Index(columns: ['discord_user_id', 'claimed_at'])]
 class BoosterClaim
 {

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -20,8 +20,6 @@ use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
 #[ORM\Entity(repositoryClass: CardRepository::class)]
-// Almost every card query filters on extension + status (draw pool, set
-// contents, published-extension lookups): index the pair.
 #[ORM\Index(columns: ['extension_id', 'status'])]
 class Card
 {
@@ -50,8 +48,7 @@ class Card
      * Owner of a one-of-one (unique) card. Null while unclaimed; set atomically
      * the first time the card is drawn (CardRepository::claimUnique). A claimed
      * unique is filtered out of the draw pool so it can never be drawn again.
-     * ON DELETE SET NULL frees the card if the owner is removed (matches the
-     * constraint created by Version20260618130000).
+     * ON DELETE SET NULL frees the card if the owner is removed.
      */
     #[ORM\ManyToOne]
     #[ORM\JoinColumn(name: 'claimed_by', referencedColumnName: 'discord_id', nullable: true, onDelete: 'SET NULL')]

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -20,6 +20,9 @@ use Vich\UploaderBundle\Mapping\Attribute as Vich;
 
 #[Vich\Uploadable]
 #[ORM\Entity(repositoryClass: CardRepository::class)]
+// Almost every card query filters on extension + status (draw pool, set
+// contents, published-extension lookups): index the pair.
+#[ORM\Index(columns: ['extension_id', 'status'])]
 class Card
 {
     use IdUuidTrait;

--- a/src/Entity/Card.php
+++ b/src/Entity/Card.php
@@ -47,9 +47,11 @@ class Card
      * Owner of a one-of-one (unique) card. Null while unclaimed; set atomically
      * the first time the card is drawn (CardRepository::claimUnique). A claimed
      * unique is filtered out of the draw pool so it can never be drawn again.
+     * ON DELETE SET NULL frees the card if the owner is removed (matches the
+     * constraint created by Version20260618130000).
      */
     #[ORM\ManyToOne]
-    #[ORM\JoinColumn(name: 'claimed_by', referencedColumnName: 'discord_id', nullable: true)]
+    #[ORM\JoinColumn(name: 'claimed_by', referencedColumnName: 'discord_id', nullable: true, onDelete: 'SET NULL')]
     private ?DiscordUser $claimedBy = null;
 
     /**


### PR DESCRIPTION
## Contexte

`doctrine:schema:validate` est rouge en permanence depuis `Version20260618130000` : cette migration manuscrite a créé `card.claimed_by` avec une FK `fk_card_claimed_by ... ON DELETE SET NULL` et un index `idx_card_claimed_by`, mais l'entité `Card` mappe le `JoinColumn` **sans** `onDelete` ni nom custom. Conséquence : un futur `make db.diff` générerait une migration qui **supprime le `ON DELETE SET NULL`** (qui est le bon comportement — libérer la carte unique si son propriétaire est supprimé).

## Choix d'alignement : l'entité sur la base, pas l'inverse

- `onDelete: 'SET NULL'` ajouté au `JoinColumn` de `Card::$claimedBy`.
- Le comparateur DBAL 4 ignore le **nom** des FK (comparaison par définition : colonnes/table/onUpdate/onDelete) mais compare les **index par nom**. Le nom d'une FK n'étant pas déclarable sur un `JoinColumn`, la migration `Version20260805120000` renomme côté base l'index **et** la contrainte vers les noms générés par Doctrine (`IDX_/FK_161498D3296C217B`) — définitions inchangées, schéma uniforme avec le reste des tables.
- Formule de nommage vérifiée par recoupement avec deux noms auto-générés existants dans les migrations (`IDX_376FE897E3F3F7CE`, `IDX_161498D3812D5EB`).

## Index composites ajoutés (`Version20260805121000`)

- **`card (extension_id, status)`** : quasi toutes les requêtes de `CardRepository` filtrent sur cette paire (`findDrawablePool`, `findPublishedByExtension`, `findExtensionIdsWithPublishedCards`, `findRandomCardId`…).
- **`booster_claim (discord_user_id, claimed_at)`** : le quota journalier est un `COUNT` sur cette paire (`BoosterClaimRepository::countSince`), exécuté à chaque rendu du hub ; seul l'index simple sur `discord_user_id` existait.

Déclarés via `#[ORM\Index]` sur les entités (sans nom → noms générés par Doctrine, identiques dans la migration manuscrite) pour que `schema:validate` et `db.diff` restent silencieux. Les index simples existants (`extension_id` seuls, `discord_user_id` seul) ne sont pas touchés : le comparateur ne les considère pas couverts par les composites (comparaison à nombre de colonnes égal).

## Validation

- SQL PostgreSQL (`ALTER INDEX ... RENAME`, `ALTER TABLE ... RENAME CONSTRAINT`) rejoué par la CI de test (stack Postgres, `make doctrine.migrate.ci`) ; `down()` symétriques.
- Non vérifié localement (pas de PHP/DB dans l'environnement) : `schema:validate`, `make quality` et la suite de tests — couverts par la CI.

## Hors scope

Aucun autre `onDelete` ajouté sur les autres FK (décision produit séparée).