### PR TITLE
fix(auth): durcissement du flow JWT (expiré, token étranger, auto-création)

### DIFF
--- a/src/EventListener/JwtExpired.php
+++ b/src/EventListener/JwtExpired.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Service\Security\RefreshTokenRedirector;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTExpiredEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+/**
+ * The bundle routes ExpiredTokenException to JWT_EXPIRED, not JWT_INVALID:
+ * without this listener an expired token gets the raw 401 JSON response. In
+ * practice the auth cookie usually dies together with the token (same 900s
+ * lifetime), so the browser stops sending it and falls into the JwtNotFound
+ * path — this listener covers the remaining cases (clock skew, cookie set
+ * with a longer lifetime, replayed token).
+ */
+#[AsEventListener(event: Events::JWT_EXPIRED, method: 'onJwtExpired')]
+readonly class JwtExpired
+{
+    public function __construct(
+        private RefreshTokenRedirector $refreshTokenRedirector,
+    ) {
+    }
+
+    public function onJwtExpired(JWTExpiredEvent $event): void
+    {
+        $event->setResponse($this->refreshTokenRedirector->createRedirect($event->getRequest()));
+    }
+}

--- a/src/EventListener/JwtExpired.php
+++ b/src/EventListener/JwtExpired.php
@@ -9,14 +9,6 @@ use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTExpiredEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 
-/**
- * The bundle routes ExpiredTokenException to JWT_EXPIRED, not JWT_INVALID:
- * without this listener an expired token gets the raw 401 JSON response. In
- * practice the auth cookie usually dies together with the token (same 900s
- * lifetime), so the browser stops sending it and falls into the JwtNotFound
- * path — this listener covers the remaining cases (clock skew, cookie set
- * with a longer lifetime, replayed token).
- */
 #[AsEventListener(event: Events::JWT_EXPIRED, method: 'onJwtExpired')]
 readonly class JwtExpired
 {

--- a/src/EventListener/JwtInvalid.php
+++ b/src/EventListener/JwtInvalid.php
@@ -5,16 +5,27 @@ declare(strict_types=1);
 namespace App\EventListener;
 
 use App\Entity\DiscordUser;
+use App\Service\Security\RefreshTokenRedirector;
 use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTInvalidEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
 use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
+/**
+ * Auto-creates the DiscordUser the first time a valid token shows up for an
+ * unknown user (we trust the external token provider), then replays the
+ * original request. Every other invalid-token case redirects to the refresh
+ * endpoint: the cookie lives on the whole parent domain, so a token signed by
+ * another app must neither be parsed again (uncaught JWTDecodeFailureException,
+ * 500) nor replayed on the same URI (infinite redirect loop).
+ */
 #[AsEventListener(event: Events::JWT_INVALID, method: 'onJwtInvalid')]
 readonly class JwtInvalid
 {
@@ -22,10 +33,11 @@ readonly class JwtInvalid
         private EntityManagerInterface $entityManager,
         private TokenExtractorInterface $tokenExtractor,
         private JWTTokenManagerInterface $jwtManager,
+        private RefreshTokenRedirector $refreshTokenRedirector,
+        private LoggerInterface $logger,
     ) {
     }
 
-    /** Create the user blindfolded, we trust the token provider */
     public function onJwtInvalid(JWTInvalidEvent $event): void
     {
         $request = $event->getRequest();
@@ -33,26 +45,87 @@ readonly class JwtInvalid
             return;
         }
 
-        $token = $this->tokenExtractor->extract($request);
-        if (false === $token) {
+        if (!$event->getException()->getPrevious() instanceof UserNotFoundException) {
+            // Malformed token, invalid signature, missing id claim... nothing
+            // recoverable here: ask the auth app for a fresh token.
+            $this->logger->warning('Invalid JWT token, redirecting to the refresh endpoint.', [
+                'reason' => $event->getException()->getMessageKey(),
+            ]);
+            $event->setResponse($this->refreshTokenRedirector->createRedirect($request));
+
             return;
         }
 
-        $payload = $this->jwtManager->parse($token);
-        if ([] === $payload) {
+        $userData = $this->extractValidatedPayload($request);
+        if (null === $userData) {
+            $event->setResponse($this->refreshTokenRedirector->createRedirect($request));
+
             return;
         }
 
-        if ($event->getException()->getPrevious() instanceof UserNotFoundException) {
-            $user = new DiscordUser()
-                ->setDiscordId($payload['discordId'])
-                ->setUsername($payload['username'])
-                ->setRoles($payload['roles'])
-            ;
-            $this->entityManager->persist($user);
-            $this->entityManager->flush();
-        }
+        $user = new DiscordUser()
+            ->setDiscordId($userData['discordId'])
+            ->setUsername($userData['username'])
+            ->setRoles($userData['roles'])
+        ;
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
 
         $event->setResponse(new RedirectResponse($request->getUri()));
+    }
+
+    /**
+     * @return array{discordId: non-empty-string, username: non-empty-string, roles: list<string>}|null
+     */
+    private function extractValidatedPayload(Request $request): ?array
+    {
+        $token = $this->tokenExtractor->extract($request);
+        if (false === $token) {
+            $this->logger->warning('JWT user auto-creation aborted: no token found in the request.');
+
+            return null;
+        }
+
+        // On this path the token already decoded successfully during
+        // authentication (only the user lookup failed), so parsing it again
+        // cannot fail — the catch is defensive only.
+        try {
+            $payload = $this->jwtManager->parse($token);
+        } catch (JWTDecodeFailureException $exception) {
+            $this->logger->warning('JWT user auto-creation aborted: the token could not be parsed.', [
+                'reason' => $exception->getReason(),
+            ]);
+
+            return null;
+        }
+
+        $discordId = $payload['discordId'] ?? null;
+        $username = $payload['username'] ?? null;
+        $roles = $payload['roles'] ?? [];
+
+        if (!\is_string($discordId) || '' === $discordId
+            || !\is_string($username) || '' === $username
+            || !\is_array($roles)
+        ) {
+            $this->logger->warning('JWT payload rejected, user not created.', [
+                'claims' => array_keys($payload),
+            ]);
+
+            return null;
+        }
+
+        $checkedRoles = [];
+        foreach ($roles as $role) {
+            if (!\is_string($role)) {
+                $this->logger->warning('JWT payload rejected, the roles claim is not a list of strings.', [
+                    'claims' => array_keys($payload),
+                ]);
+
+                return null;
+            }
+            $checkedRoles[] = $role;
+        }
+
+        return ['discordId' => $discordId, 'username' => $username, 'roles' => $checkedRoles];
     }
 }

--- a/src/EventListener/JwtInvalid.php
+++ b/src/EventListener/JwtInvalid.php
@@ -103,7 +103,8 @@ readonly class JwtInvalid
         $username = $payload['username'] ?? null;
         $roles = $payload['roles'] ?? [];
 
-        if (!\is_string($discordId) || '' === $discordId
+        if (
+            !\is_string($discordId) || '' === $discordId
             || !\is_string($username) || '' === $username
             || !\is_array($roles)
         ) {

--- a/src/EventListener/JwtInvalid.php
+++ b/src/EventListener/JwtInvalid.php
@@ -18,14 +18,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\UserNotFoundException;
 
-/**
- * Auto-creates the DiscordUser the first time a valid token shows up for an
- * unknown user (we trust the external token provider), then replays the
- * original request. Every other invalid-token case redirects to the refresh
- * endpoint: the cookie lives on the whole parent domain, so a token signed by
- * another app must neither be parsed again (uncaught JWTDecodeFailureException,
- * 500) nor replayed on the same URI (infinite redirect loop).
- */
 #[AsEventListener(event: Events::JWT_INVALID, method: 'onJwtInvalid')]
 readonly class JwtInvalid
 {
@@ -46,8 +38,6 @@ readonly class JwtInvalid
         }
 
         if (!$event->getException()->getPrevious() instanceof UserNotFoundException) {
-            // Malformed token, invalid signature, missing id claim... nothing
-            // recoverable here: ask the auth app for a fresh token.
             $this->logger->warning('Invalid JWT token, redirecting to the refresh endpoint.', [
                 'reason' => $event->getException()->getMessageKey(),
             ]);
@@ -86,9 +76,6 @@ readonly class JwtInvalid
             return null;
         }
 
-        // On this path the token already decoded successfully during
-        // authentication (only the user lookup failed), so parsing it again
-        // cannot fail — the catch is defensive only.
         try {
             $payload = $this->jwtManager->parse($token);
         } catch (JWTDecodeFailureException $exception) {

--- a/src/EventListener/JwtNotFound.php
+++ b/src/EventListener/JwtNotFound.php
@@ -4,33 +4,21 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
+use App\Service\Security\RefreshTokenRedirector;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTNotFoundEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 #[AsEventListener(event: Events::JWT_NOT_FOUND, method: 'onJwtNotFound')]
 readonly class JwtNotFound
 {
     public function __construct(
-        #[Autowire(env: 'REFRESH_TOKEN_URL')]
-        private string $refreshTokenUrl,
-        private UrlGeneratorInterface $urlGenerator,
+        private RefreshTokenRedirector $refreshTokenRedirector,
     ) {
     }
 
     public function onJwtNotFound(JWTNotFoundEvent $event): void
     {
-        $request = $event->getRequest();
-
-        $targetPath = $this->urlGenerator->generate('homepage');
-        if ($request instanceof Request) {
-            $targetPath = urlencode($request->getUri());
-        }
-
-        $event->setResponse(new RedirectResponse($this->refreshTokenUrl . '?_target_path=' . $targetPath));
+        $event->setResponse($this->refreshTokenRedirector->createRedirect($event->getRequest()));
     }
 }

--- a/src/Service/Security/RefreshTokenRedirector.php
+++ b/src/Service/Security/RefreshTokenRedirector.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Security;
+
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+/**
+ * Builds the redirect to the external auth app refresh endpoint, carrying the
+ * originally requested URI as _target_path so the user lands back where they
+ * started once a fresh token has been issued.
+ */
+readonly class RefreshTokenRedirector
+{
+    public function __construct(
+        #[Autowire(env: 'REFRESH_TOKEN_URL')]
+        private string $refreshTokenUrl,
+        private UrlGeneratorInterface $urlGenerator,
+    ) {
+    }
+
+    public function createRedirect(?Request $request): RedirectResponse
+    {
+        $targetPath = $this->urlGenerator->generate('homepage');
+        if ($request instanceof Request) {
+            $targetPath = urlencode($request->getUri());
+        }
+
+        return new RedirectResponse($this->refreshTokenUrl . '?_target_path=' . $targetPath);
+    }
+}

--- a/src/Service/Security/RefreshTokenRedirector.php
+++ b/src/Service/Security/RefreshTokenRedirector.php
@@ -9,11 +9,6 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-/**
- * Builds the redirect to the external auth app refresh endpoint, carrying the
- * originally requested URI as _target_path so the user lands back where they
- * started once a fresh token has been issued.
- */
 readonly class RefreshTokenRedirector
 {
     public function __construct(

--- a/tests/Functional/JwtFlowTest.php
+++ b/tests/Functional/JwtFlowTest.php
@@ -11,10 +11,6 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
 
-/**
- * Hardening of the JWT cookie flow: expired, corrupted or unknown-user tokens
- * must all end in a redirect — never a raw 401 JSON response nor a 500.
- */
 final class JwtFlowTest extends WebTestCase
 {
     private const string EXISTING_DISCORD_ID = '188967649332428800';
@@ -51,8 +47,6 @@ final class JwtFlowTest extends WebTestCase
 
     public function testBadlySignedTokenRedirectsInsteadOfCrashing(): void
     {
-        // Valid header and payload, but a signature that cannot verify — the
-        // same shape as a token signed by another app sharing the domain.
         $token = $this->tokenManager()->create($this->existingUser());
         $parts = explode('.', $token);
         $parts[2] = str_repeat('A', \strlen($parts[2]));
@@ -92,8 +86,6 @@ final class JwtFlowTest extends WebTestCase
             ->setDiscordId(self::GHOST_DISCORD_ID)
             ->setUsername('Ghost')
         ;
-        // No username claim in the payload: the token decodes fine, the user
-        // lookup fails, but auto-creation must refuse the incomplete payload.
         $token = $this->tokenManager()->createFromPayload($ghost);
         $this->client->getCookieJar()->set(new Cookie('jwt', $token));
 

--- a/tests/Functional/JwtFlowTest.php
+++ b/tests/Functional/JwtFlowTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\DiscordUser;
+use App\Repository\DiscordUserRepository;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\Cookie;
+
+/**
+ * Hardening of the JWT cookie flow: expired, corrupted or unknown-user tokens
+ * must all end in a redirect — never a raw 401 JSON response nor a 500.
+ */
+final class JwtFlowTest extends WebTestCase
+{
+    private const string EXISTING_DISCORD_ID = '188967649332428800';
+
+    private const string GHOST_DISCORD_ID = '424242424242424242';
+
+    private KernelBrowser $client;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+    }
+
+    public function testExpiredTokenRedirectsToRefreshUrl(): void
+    {
+        $user = $this->existingUser();
+        $token = $this->tokenManager()->createFromPayload($user, ['exp' => time() - 3600]);
+        $this->client->getCookieJar()->set(new Cookie('jwt', $token));
+
+        $this->client->request('GET', '/boosters');
+
+        self::assertResponseRedirects($this->refreshUrl('http://localhost/boosters'));
+    }
+
+    public function testMalformedTokenRedirectsInsteadOfCrashing(): void
+    {
+        $this->client->getCookieJar()->set(new Cookie('jwt', 'not.a-real.jwt-token'));
+
+        $this->client->request('GET', '/boosters');
+
+        self::assertResponseRedirects($this->refreshUrl('http://localhost/boosters'));
+    }
+
+    public function testBadlySignedTokenRedirectsInsteadOfCrashing(): void
+    {
+        // Valid header and payload, but a signature that cannot verify — the
+        // same shape as a token signed by another app sharing the domain.
+        $token = $this->tokenManager()->create($this->existingUser());
+        $parts = explode('.', $token);
+        $parts[2] = str_repeat('A', \strlen($parts[2]));
+        $this->client->getCookieJar()->set(new Cookie('jwt', implode('.', $parts)));
+
+        $this->client->request('GET', '/boosters');
+
+        self::assertResponseRedirects($this->refreshUrl('http://localhost/boosters'));
+    }
+
+    public function testUnknownUserIsAutoCreatedThenRequestIsReplayed(): void
+    {
+        $ghost = new DiscordUser()
+            ->setDiscordId(self::GHOST_DISCORD_ID)
+            ->setUsername('Ghost')
+        ;
+        $token = $this->tokenManager()->createFromPayload($ghost, ['username' => 'Ghost']);
+        $this->client->getCookieJar()->set(new Cookie('jwt', $token));
+
+        $this->client->request('GET', '/boosters');
+
+        self::assertResponseRedirects('http://localhost/boosters');
+
+        $created = $this->userRepository()->find(self::GHOST_DISCORD_ID);
+        $this->assertInstanceOf(DiscordUser::class, $created);
+        $this->assertSame('Ghost', $created->getUsername());
+        $this->assertSame(['ROLE_USER'], $created->getRoles());
+
+        // Replaying the request with the same cookie now authenticates.
+        $this->client->followRedirect();
+        self::assertResponseIsSuccessful();
+    }
+
+    public function testTokenWithoutUsernameClaimDoesNotCreateUser(): void
+    {
+        $ghost = new DiscordUser()
+            ->setDiscordId(self::GHOST_DISCORD_ID)
+            ->setUsername('Ghost')
+        ;
+        // No username claim in the payload: the token decodes fine, the user
+        // lookup fails, but auto-creation must refuse the incomplete payload.
+        $token = $this->tokenManager()->createFromPayload($ghost);
+        $this->client->getCookieJar()->set(new Cookie('jwt', $token));
+
+        $this->client->request('GET', '/boosters');
+
+        self::assertResponseRedirects($this->refreshUrl('http://localhost/boosters'));
+        $this->assertNull($this->userRepository()->find(self::GHOST_DISCORD_ID));
+    }
+
+    private function existingUser(): DiscordUser
+    {
+        $user = $this->userRepository()->find(self::EXISTING_DISCORD_ID);
+
+        if (!$user instanceof DiscordUser) {
+            throw new \LogicException(\sprintf('Fixture user "%s" not found, load the alice fixtures first.', self::EXISTING_DISCORD_ID));
+        }
+
+        return $user;
+    }
+
+    private function userRepository(): DiscordUserRepository
+    {
+        return static::getContainer()->get(DiscordUserRepository::class);
+    }
+
+    private function tokenManager(): JWTTokenManagerInterface
+    {
+        return static::getContainer()->get(JWTTokenManagerInterface::class);
+    }
+
+    private function refreshUrl(string $targetUri): string
+    {
+        $refreshTokenUrl = $_ENV['REFRESH_TOKEN_URL'] ?? null;
+        \assert(\is_string($refreshTokenUrl));
+
+        return $refreshTokenUrl . '?_target_path=' . urlencode($targetUri);
+    }
+}


### PR DESCRIPTION
## Problème

Le flow JWT (cookie `jwt` sur `.barlito.fr`, tokens émis par l'app d'auth externe) avait quatre failles :

1. **Aucun listener sur `JWT_EXPIRED`** : le bundle route `ExpiredTokenException` vers `lexik_jwt_authentication.on_jwt_expired`, pas vers `JWT_INVALID`. Un token expiré encore transmis par le navigateur recevait donc le JSON 401 brut du bundle au lieu du redirect vers `REFRESH_TOKEN_URL`.
2. **500 permanent sur token indéchiffrable** (`JwtInvalid`) : le listener appelait `$this->jwtManager->parse($token)` inconditionnellement. Sur un token malformé ou signé avec une autre clé (le cookie vit sur tout `.barlito.fr` : une autre app du domaine peut en poser un), `parse()` lève `JWTDecodeFailureException`, qui n'étend **pas** `AuthenticationException` → 500 non catché, permanent tant que le cookie reste posé.
3. **Boucle de redirection infinie** (`JwtInvalid`) : le redirect final visait `$request->getUri()` quelle que soit l'exception. Dès que `previous` n'était pas `UserNotFoundException` (ex. `InvalidPayloadException` si le claim `discordId` manque), la même requête rejouait le même échec en boucle.
4. **Auto-création de user sans validation du payload** : accès non gardés à `$payload['discordId']`, `['username']`, `['roles']` → `TypeError`/500 si claim manquant, `roles` non-array persisté tel quel. Et aucune trace en log de ces rejets.

## Pourquoi le JSON 401 « expiré » n'a jamais été vu en prod

Hypothèse vérifiée autant que ce repo le permet : le cookie est posé par l'app d'auth externe avec une durée de vie alignée sur celle du token (900 s — c'est la valeur de `set_cookies.jwt.lifetime` dans `config/packages/lexik_jwt_authentication.yaml` de ce repo, et la doc projet indique « JWT token stored in cookie (lifetime: 900s) »). Quand le token expire, le cookie a expiré aussi : le navigateur ne l'envoie plus → `supports()` ne trouve pas de token → entry point → `JWT_NOT_FOUND` → redirect `JwtNotFound`. Le chemin `JWT_EXPIRED` était donc masqué en usage navigateur normal.

La durée exacte du cookie posé par l'app d'auth n'est pas vérifiable depuis ce repo (app séparée). Le listener `JwtExpired` reste nécessaire comme défense : skew d'horloge serveur/navigateur, cookie posé avec une durée supérieure au TTL du token, token rejoué hors navigateur (curl/scripts), ou changement de config côté auth.

## Fix

- **`src/Service/Security/RefreshTokenRedirector`** : factorise la construction du redirect `REFRESH_TOKEN_URL?_target_path=<URI demandée>` (comportement identique à l'ancien `JwtNotFound`), partagé par les trois listeners.
- **`src/EventListener/JwtExpired`** (nouveau) : `JWT_EXPIRED` → redirect refresh avec `_target_path`.
- **`src/EventListener/JwtNotFound`** : délègue au redirector, comportement inchangé.
- **`src/EventListener/JwtInvalid`** (réécrit) :
  - si `previous` n'est pas `UserNotFoundException` → warning en log + redirect refresh (plus de `parse()` sur un token indéchiffrable, plus de boucle sur l'URI courante) ;
  - note d'implémentation : contrairement à l'hypothèse initiale, l'exception de l'événement ne porte **pas** le payload (vérifié dans les sources lexik v3.2.0 : `ExpiredTokenException` et `BadCredentialsException`→`UserNotFoundException` sont sans payload ; seul le `previous` de `InvalidTokenException` — une `JWTDecodeFailureException` — l'expose, et ce n'est pas la branche qui nous intéresse). Le `parse()` est donc conservé, mais uniquement dans la branche `UserNotFound` — où le décodage a déjà réussi pendant l'authentification — et sous try/catch défensif ;
  - auto-création uniquement si le payload est complet : `discordId`/`username` strings non vides, `roles` liste de strings (claim absent toléré → `[]`, cohérent avec `JwtAuthenticated`) ; tout rejet est loggé en `warning` puis renvoyé vers le refresh ;
  - happy path inchangé : user créé (on fait confiance au provider de tokens) puis requête rejouée sur la même URI.

## Tests (`tests/Functional/JwtFlowTest`)

De vrais tokens signés posés dans le cookie `jwt` (même mécanique que `JwtAuthTrait`, base PostgreSQL + fixtures alice + dama) :

- token expiré (`exp` passé, signature valide) → redirect exact vers `REFRESH_TOKEN_URL?_target_path=...` ;
- token malformé → redirect (plus de 500) ;
- token à signature invalide (forme valide, signature qui ne vérifie pas — le cas « cookie d'une autre app ») → redirect (plus de 500) ;
- token valide d'un user inconnu → user auto-créé (username + roles du payload), redirect vers l'URI demandée, replay authentifié en 200 ;
- token valide sans claim `username` → aucun user créé, redirect refresh, pas de 500.

## Limites de vérification locale

Pas de PHP sur la machine de dev : ni PHPUnit, ni PHPStan, ni cs-fixer n'ont pu tourner localement — la CI de cette PR fait foi.
