### PR TITLE
refactor: centralise disponibilité des boosters et rang/libellés de rareté

### DIFF
--- a/src/Controller/BoosterController.php
+++ b/src/Controller/BoosterController.php
@@ -6,8 +6,8 @@ namespace App\Controller;
 
 use App\Entity\DiscordUser;
 use App\Repository\BoosterRepository;
-use App\Repository\CardRepository;
 use App\Repository\UserBoosterRepository;
+use App\Service\Booster\BoosterAvailabilityService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -26,8 +26,8 @@ class BoosterController extends AbstractController
         string $id,
         #[CurrentUser] DiscordUser $user,
         BoosterRepository $boosterRepository,
-        CardRepository $cardRepository,
         UserBoosterRepository $userBoosterRepository,
+        BoosterAvailabilityService $boosterAvailability,
     ): Response {
         // A malformed uuid must be a plain 404 instead of a Doctrine conversion error.
         $booster = Uuid::isValid($id) ? $boosterRepository->find($id) : null;
@@ -36,14 +36,9 @@ class BoosterController extends AbstractController
             throw $this->createNotFoundException();
         }
 
-        $drawableExtensionIds = array_flip($cardRepository->findExtensionIdsWithPublishedCards());
         $userBooster = $userBoosterRepository->findOneBy(['discordUser' => $user, 'booster' => $booster]);
 
-        if (
-            !isset($drawableExtensionIds[(string) $booster->getExtension()->getId()])
-            || null === $userBooster
-            || $userBooster->getQuantity() < 1
-        ) {
+        if (!$boosterAvailability->isOpenable($booster, $userBooster?->getQuantity() ?? 0)) {
             $this->addFlash('error', "Ce pack n'est pas ouvrable pour le moment.");
 
             return $this->redirectToRoute('boosters');

--- a/src/Controller/UniverseController.php
+++ b/src/Controller/UniverseController.php
@@ -15,6 +15,7 @@ use App\Repository\CardRepository;
 use App\Repository\ExtensionRepository;
 use App\Repository\UserBoosterRepository;
 use App\Repository\UserCardRepository;
+use App\Service\Booster\BoosterAvailabilityService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -41,6 +42,7 @@ class UniverseController extends AbstractController
         private readonly CardRepository $cardRepository,
         private readonly UserCardRepository $userCardRepository,
         private readonly UserBoosterRepository $userBoosterRepository,
+        private readonly BoosterAvailabilityService $boosterAvailability,
     ) {
     }
 
@@ -112,20 +114,18 @@ class UniverseController extends AbstractController
     }
 
     /**
-     * Same visibility rule as the hub: claimable boosters, plus non-claimable
-     * ones (event / code) the user actually owns copies of.
+     * Same visibility rule as the hub, via BoosterAvailabilityService:
+     * claimable boosters, plus non-claimable ones (event / code) the user
+     * actually owns copies of.
      *
      * @return list<Booster>
      */
     private function visibleBoosters(Extension $extension, DiscordUser $user): array
     {
-        $ownedCounts = $this->ownedBoosterCounts($user);
-
-        return array_values(array_filter(
+        return $this->boosterAvailability->filterVisible(
             $this->boosterRepository->findBy(['extension' => $extension], ['name' => 'ASC', 'id' => 'ASC']),
-            static fn (Booster $booster): bool => $booster->isClaimable()
-                || ($ownedCounts[(string) $booster->getId()] ?? 0) > 0,
-        ));
+            $this->ownedBoosterCounts($user),
+        );
     }
 
     /**

--- a/src/Controller/UniverseController.php
+++ b/src/Controller/UniverseController.php
@@ -155,14 +155,9 @@ class UniverseController extends AbstractController
      */
     private function sortRarestFirst(array $cards): array
     {
-        $rank = array_flip(array_map(
-            static fn (CardRarityEnum $rarity): string => $rarity->value,
-            CardRarityEnum::ascending(),
-        ));
-
         usort(
             $cards,
-            static fn (Card $a, Card $b): int => ($rank[$b->getRarity()->value] <=> $rank[$a->getRarity()->value])
+            static fn (Card $a, Card $b): int => CardRarityEnum::compareRarestFirst($a->getRarity(), $b->getRarity())
                 ?: $a->getName() <=> $b->getName(),
         );
 

--- a/src/Enum/Entity/CardRarityEnum.php
+++ b/src/Enum/Entity/CardRarityEnum.php
@@ -18,4 +18,40 @@ enum CardRarityEnum: string
     {
         return [self::COMMON, self::UNCOMMON, self::RARE, self::LEGENDARY];
     }
+
+    /**
+     * Ascending rarity rank (0 = COMMON … 3 = LEGENDARY), the single source
+     * for every rarity sort. Must stay consistent with ascending().
+     */
+    public function rank(): int
+    {
+        return match ($this) {
+            self::COMMON => 0,
+            self::UNCOMMON => 1,
+            self::RARE => 2,
+            self::LEGENDARY => 3,
+        };
+    }
+
+    /**
+     * Player-facing French label, consumed by PHP and Twig alike.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::COMMON => 'Commune',
+            self::UNCOMMON => 'Peu commune',
+            self::RARE => 'Rare',
+            self::LEGENDARY => 'Légendaire',
+        };
+    }
+
+    /**
+     * usort comparator for the catalog/pokédex order: rarest first. Name
+     * tiebreaks stay at the call sites.
+     */
+    public static function compareRarestFirst(self $a, self $b): int
+    {
+        return $b->rank() <=> $a->rank();
+    }
 }

--- a/src/Enum/Entity/CardRarityEnum.php
+++ b/src/Enum/Entity/CardRarityEnum.php
@@ -20,8 +20,7 @@ enum CardRarityEnum: string
     }
 
     /**
-     * Ascending rarity rank (0 = COMMON … 3 = LEGENDARY), the single source
-     * for every rarity sort. Must stay consistent with ascending().
+     * Ascending rank (0 = COMMON … 3 = LEGENDARY); must stay consistent with ascending().
      */
     public function rank(): int
     {
@@ -47,8 +46,7 @@ enum CardRarityEnum: string
     }
 
     /**
-     * usort comparator for the catalog/pokédex order: rarest first. Name
-     * tiebreaks stay at the call sites.
+     * Rarest-first usort comparator; name tiebreaks stay at the call sites.
      */
     public static function compareRarestFirst(self $a, self $b): int
     {

--- a/src/Repository/CardRepository.php
+++ b/src/Repository/CardRepository.php
@@ -127,18 +127,13 @@ class CardRepository extends ServiceEntityRepository
             ->getArrayResult()
         ;
 
-        $rank = [];
-        foreach (CardRarityEnum::ascending() as $index => $rarity) {
-            $rank[$rarity->value] = $index;
-        }
-
         $covers = [];
         $bestKeys = [];
         foreach ($rows as $row) {
             $extensionId = (string) $row['extensionId'];
-            $rarityValue = $row['rarity'] instanceof CardRarityEnum ? $row['rarity']->value : $row['rarity'];
+            $rarity = $row['rarity'] instanceof CardRarityEnum ? $row['rarity'] : CardRarityEnum::tryFrom($row['rarity']);
             // rarest first, then name ascending: comparable sort keys
-            $key = [-($rank[$rarityValue] ?? -1), $row['name']];
+            $key = [-($rarity?->rank() ?? -1), $row['name']];
 
             if (!isset($bestKeys[$extensionId]) || $key < $bestKeys[$extensionId]) {
                 $bestKeys[$extensionId] = $key;

--- a/src/Repository/UserCardRepository.php
+++ b/src/Repository/UserCardRepository.php
@@ -51,13 +51,9 @@ class UserCardRepository extends ServiceEntityRepository
 
         // Rarity is a string-backed enum (alphabetical ≠ rarity order), so rank it
         // in PHP: rarest first, ties broken by name. The owned set is small.
-        $rank = array_flip(array_map(
-            static fn (CardRarityEnum $rarity): string => $rarity->value,
-            CardRarityEnum::ascending(),
-        ));
         usort(
             $cards,
-            static fn (UserCard $a, UserCard $b): int => ($rank[$b->getCard()->getRarity()->value] <=> $rank[$a->getCard()->getRarity()->value])
+            static fn (UserCard $a, UserCard $b): int => CardRarityEnum::compareRarestFirst($a->getCard()->getRarity(), $b->getCard()->getRarity())
                 ?: $a->getCard()->getName() <=> $b->getCard()->getName(),
         );
 

--- a/src/Service/Booster/BoosterAvailabilityService.php
+++ b/src/Service/Booster/BoosterAvailabilityService.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Entity\Booster;
+use App\Enum\Entity\ExtensionStatusEnum;
+use App\Repository\CardRepository;
+
+/**
+ * Single source of truth for booster availability: which boosters a user can
+ * see, claim and open. Controllers, components and services must go through
+ * these predicates instead of re-implementing the rules locally.
+ */
+final readonly class BoosterAvailabilityService
+{
+    public function __construct(
+        private CardRepository $cardRepository,
+    ) {
+    }
+
+    /**
+     * Hub/universe visibility: a non-claimable booster (event/code
+     * distribution) is hidden from everyone except the users who already own
+     * copies — they still need to see it (and its drop rates) to open theirs.
+     *
+     * @param array<string, int> $ownedCounts booster id => owned quantity
+     */
+    public function isVisible(Booster $booster, array $ownedCounts): bool
+    {
+        return $booster->isClaimable() || ($ownedCounts[(string) $booster->getId()] ?? 0) > 0;
+    }
+
+    /**
+     * @param list<Booster>      $boosters
+     * @param array<string, int> $ownedCounts booster id => owned quantity
+     *
+     * @return list<Booster>
+     */
+    public function filterVisible(array $boosters, array $ownedCounts): array
+    {
+        return array_values(array_filter(
+            $boosters,
+            fn (Booster $booster): bool => $this->isVisible($booster, $ownedCounts),
+        ));
+    }
+
+    /**
+     * Claim guard, first half: an event/code-only booster cannot be claimed
+     * on the hub, whoever asks.
+     */
+    public function isClaimable(Booster $booster): bool
+    {
+        return $booster->isClaimable();
+    }
+
+    /**
+     * Claim guard, second half: a booster over an unpublished extension is
+     * not available at all (its uuid can leak, it must stay unclaimable).
+     */
+    public function hasPublishedExtension(Booster $booster): bool
+    {
+        return ExtensionStatusEnum::PUBLISHED === $booster->getExtension()->getStatus();
+    }
+
+    /**
+     * A booster is drawable when its extension has at least one published,
+     * still drawable card (a claimed 1/1 unique doesn't count): otherwise it
+     * is surfaced as "à venir" instead of letting the user hit a draw error.
+     */
+    public function isDrawable(Booster $booster): bool
+    {
+        return isset($this->drawableExtensionIds()[(string) $booster->getExtension()->getId()]);
+    }
+
+    /**
+     * Batch variant of isDrawable: one query for a whole booster list.
+     *
+     * @param list<Booster> $boosters
+     *
+     * @return array<string, true> booster id => true
+     */
+    public function drawableBoosterIds(array $boosters): array
+    {
+        $extensionIds = $this->drawableExtensionIds();
+
+        $drawable = [];
+        foreach ($boosters as $booster) {
+            if (isset($extensionIds[(string) $booster->getExtension()->getId()])) {
+                $drawable[(string) $booster->getId()] = true;
+            }
+        }
+
+        return $drawable;
+    }
+
+    /**
+     * A booster can be opened when it is drawable AND the user owns at least
+     * one unopened copy.
+     */
+    public function isOpenable(Booster $booster, int $ownedQuantity): bool
+    {
+        return $ownedQuantity >= 1 && $this->isDrawable($booster);
+    }
+
+    /**
+     * @return array<string, int> extension id => index (flipped id list, for O(1) lookups)
+     */
+    private function drawableExtensionIds(): array
+    {
+        return array_flip($this->cardRepository->findExtensionIdsWithPublishedCards());
+    }
+}

--- a/src/Service/Booster/BoosterAvailabilityService.php
+++ b/src/Service/Booster/BoosterAvailabilityService.php
@@ -9,9 +9,7 @@ use App\Enum\Entity\ExtensionStatusEnum;
 use App\Repository\CardRepository;
 
 /**
- * Single source of truth for booster availability: which boosters a user can
- * see, claim and open. Controllers, components and services must go through
- * these predicates instead of re-implementing the rules locally.
+ * Single source of truth for booster availability: visibility, claim and open rules.
  */
 final readonly class BoosterAvailabilityService
 {
@@ -21,10 +19,6 @@ final readonly class BoosterAvailabilityService
     }
 
     /**
-     * Hub/universe visibility: a non-claimable booster (event/code
-     * distribution) is hidden from everyone except the users who already own
-     * copies — they still need to see it (and its drop rates) to open theirs.
-     *
      * @param array<string, int> $ownedCounts booster id => owned quantity
      */
     public function isVisible(Booster $booster, array $ownedCounts): bool
@@ -46,29 +40,16 @@ final readonly class BoosterAvailabilityService
         ));
     }
 
-    /**
-     * Claim guard, first half: an event/code-only booster cannot be claimed
-     * on the hub, whoever asks.
-     */
     public function isClaimable(Booster $booster): bool
     {
         return $booster->isClaimable();
     }
 
-    /**
-     * Claim guard, second half: a booster over an unpublished extension is
-     * not available at all (its uuid can leak, it must stay unclaimable).
-     */
     public function hasPublishedExtension(Booster $booster): bool
     {
         return ExtensionStatusEnum::PUBLISHED === $booster->getExtension()->getStatus();
     }
 
-    /**
-     * A booster is drawable when its extension has at least one published,
-     * still drawable card (a claimed 1/1 unique doesn't count): otherwise it
-     * is surfaced as "à venir" instead of letting the user hit a draw error.
-     */
     public function isDrawable(Booster $booster): bool
     {
         return isset($this->drawableExtensionIds()[(string) $booster->getExtension()->getId()]);
@@ -95,10 +76,6 @@ final readonly class BoosterAvailabilityService
         return $drawable;
     }
 
-    /**
-     * A booster can be opened when it is drawable AND the user owns at least
-     * one unopened copy.
-     */
     public function isOpenable(Booster $booster, int $ownedQuantity): bool
     {
         return $ownedQuantity >= 1 && $this->isDrawable($booster);

--- a/src/Service/Booster/BoosterClaimService.php
+++ b/src/Service/Booster/BoosterClaimService.php
@@ -47,9 +47,7 @@ final readonly class BoosterClaimService
     {
         // Server-side guards, not just UI: a forged live action must not claim
         // an event/code-only booster, nor one whose extension is unpublished
-        // (its uuid can leak — the booster simply isn't available). The
-        // predicates live in BoosterAvailabilityService; only the business
-        // exceptions belong here.
+        // (its uuid can leak — the booster simply isn't available).
         if (!$this->boosterAvailability->isClaimable($booster)) {
             throw new BoosterNotClaimableException(
                 \sprintf('Booster "%s" is not claimable (event/code distribution only).', $booster->getDisplayName()),

--- a/src/Service/Booster/BoosterClaimService.php
+++ b/src/Service/Booster/BoosterClaimService.php
@@ -7,7 +7,6 @@ namespace App\Service\Booster;
 use App\Entity\Booster;
 use App\Entity\BoosterClaim;
 use App\Entity\DiscordUser;
-use App\Enum\Entity\ExtensionStatusEnum;
 use App\Exception\Booster\BoosterNotClaimableException;
 use App\Exception\Booster\DailyClaimLimitReachedException;
 use Doctrine\DBAL\LockMode;
@@ -26,6 +25,7 @@ final readonly class BoosterClaimService
         private UserInventoryService $userInventoryService,
         private EntityManagerInterface $entityManager,
         private ClockInterface $clock,
+        private BoosterAvailabilityService $boosterAvailability,
     ) {
     }
 
@@ -47,15 +47,17 @@ final readonly class BoosterClaimService
     {
         // Server-side guards, not just UI: a forged live action must not claim
         // an event/code-only booster, nor one whose extension is unpublished
-        // (its uuid can leak — the booster simply isn't available).
-        if (!$booster->isClaimable()) {
+        // (its uuid can leak — the booster simply isn't available). The
+        // predicates live in BoosterAvailabilityService; only the business
+        // exceptions belong here.
+        if (!$this->boosterAvailability->isClaimable($booster)) {
             throw new BoosterNotClaimableException(
                 \sprintf('Booster "%s" is not claimable (event/code distribution only).', $booster->getDisplayName()),
                 'Ce pack ne peut pas être récupéré ici — il se gagne en event ou via un code.',
             );
         }
 
-        if (ExtensionStatusEnum::PUBLISHED !== $booster->getExtension()->getStatus()) {
+        if (!$this->boosterAvailability->hasPublishedExtension($booster)) {
             throw new BoosterNotClaimableException(
                 \sprintf('Booster "%s" belongs to an unpublished extension.', $booster->getDisplayName()),
                 'Ce pack n\'est pas disponible.',

--- a/src/Twig/CardRarityExtension.php
+++ b/src/Twig/CardRarityExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig;
+
+use App\Enum\Entity\CardRarityEnum;
+use Twig\Attribute\AsTwigFunction;
+
+/**
+ * Exposes the rarity scale to templates so the ranking and the French labels
+ * live in CardRarityEnum only (no more per-template label maps).
+ */
+final readonly class CardRarityExtension
+{
+    /**
+     * @return list<CardRarityEnum> rarities ordered from least to most rare
+     */
+    #[AsTwigFunction(name: 'card_rarities')]
+    public function cardRarities(): array
+    {
+        return CardRarityEnum::ascending();
+    }
+
+    /**
+     * Accepts raw strings too (drop-rate keys come from JSON); an unknown
+     * value falls back to itself, like the old per-template |default(rarity).
+     */
+    #[AsTwigFunction(name: 'rarity_label')]
+    public function rarityLabel(CardRarityEnum | string $rarity): string
+    {
+        if ($rarity instanceof CardRarityEnum) {
+            return $rarity->label();
+        }
+
+        return CardRarityEnum::tryFrom($rarity)?->label() ?? $rarity;
+    }
+}

--- a/src/Twig/CardRarityExtension.php
+++ b/src/Twig/CardRarityExtension.php
@@ -8,8 +8,7 @@ use App\Enum\Entity\CardRarityEnum;
 use Twig\Attribute\AsTwigFunction;
 
 /**
- * Exposes the rarity scale to templates so the ranking and the French labels
- * live in CardRarityEnum only (no more per-template label maps).
+ * Exposes the CardRarityEnum scale and labels to templates.
  */
 final readonly class CardRarityExtension
 {
@@ -23,8 +22,7 @@ final readonly class CardRarityExtension
     }
 
     /**
-     * Accepts raw strings too (drop-rate keys come from JSON); an unknown
-     * value falls back to itself, like the old per-template |default(rarity).
+     * Accepts raw strings (drop-rate keys come from JSON); an unknown value falls back to itself.
      */
     #[AsTwigFunction(name: 'rarity_label')]
     public function rarityLabel(CardRarityEnum | string $rarity): string

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -8,8 +8,8 @@ use App\Entity\Booster;
 use App\Entity\DiscordUser;
 use App\Exception\Booster\BoosterException;
 use App\Repository\BoosterRepository;
-use App\Repository\CardRepository;
 use App\Repository\UserBoosterRepository;
+use App\Service\Booster\BoosterAvailabilityService;
 use App\Service\Booster\BoosterClaimService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Uid\Uuid;
@@ -37,28 +37,24 @@ final class BoosterHub extends AbstractController
 
     public function __construct(
         private readonly BoosterRepository $boosterRepository,
-        private readonly CardRepository $cardRepository,
         private readonly UserBoosterRepository $userBoosterRepository,
+        private readonly BoosterAvailabilityService $boosterAvailability,
         private readonly BoosterClaimService $boosterClaimService,
     ) {
     }
 
     /**
-     * The hub list: a non-claimable booster (event/code distribution) is hidden
-     * from everyone except the users who already own copies — they still need
-     * to see it (and its drop rates) to open theirs.
+     * The hub list: the published boosters the user is allowed to see
+     * (claimable, or event/code ones they already own copies of).
      *
      * @return list<Booster>
      */
     public function getBoosters(): array
     {
-        $inventory = $this->getInventory();
-
-        return array_values(array_filter(
+        return $this->boosterAvailability->filterVisible(
             $this->boosterRepository->findPublished(),
-            static fn (Booster $booster): bool => $booster->isClaimable()
-                || ($inventory[(string) $booster->getId()] ?? 0) > 0,
-        ));
+            $this->getInventory(),
+        );
     }
 
     public function getRemainingClaims(): int
@@ -81,24 +77,15 @@ final class BoosterHub extends AbstractController
     }
 
     /**
-     * Booster ids whose extension has at least one published card, i.e. the
-     * boosters that can actually be opened. Boosters over an empty extension
-     * are surfaced as "à venir" rather than letting the user hit a draw error.
+     * Booster ids that can actually be opened (their extension has at least
+     * one published card). Boosters over an empty extension are surfaced as
+     * "à venir" rather than letting the user hit a draw error.
      *
      * @return array<string, true> booster id => true
      */
     public function getDrawableBoosterIds(): array
     {
-        $extensionIds = array_flip($this->cardRepository->findExtensionIdsWithPublishedCards());
-
-        $drawable = [];
-        foreach ($this->getBoosters() as $booster) {
-            if (isset($extensionIds[(string) $booster->getExtension()->getId()])) {
-                $drawable[(string) $booster->getId()] = true;
-            }
-        }
-
-        return $drawable;
+        return $this->boosterAvailability->drawableBoosterIds($this->getBoosters());
     }
 
     /**

--- a/src/Twig/Components/BoosterOpening.php
+++ b/src/Twig/Components/BoosterOpening.php
@@ -108,11 +108,10 @@ final class BoosterOpening extends AbstractController
     public function getExtensionCatalog(): array
     {
         $cards = $this->cardRepository->findPublishedByExtension($this->getBooster()->getExtension());
-        $rank = $this->rarityRanks();
 
         usort(
             $cards,
-            static fn (Card $a, Card $b): int => ($rank[$b->getRarity()->value] <=> $rank[$a->getRarity()->value])
+            static fn (Card $a, Card $b): int => CardRarityEnum::compareRarestFirst($a->getRarity(), $b->getRarity())
                 ?: $a->getName() <=> $b->getName(),
         );
 
@@ -248,17 +247,6 @@ final class BoosterOpening extends AbstractController
         $this->newCardIds = [];
         $this->revealOrder = [];
         $this->error = null;
-    }
-
-    /**
-     * @return array<string, int> rarity value => ascending rank
-     */
-    private function rarityRanks(): array
-    {
-        return array_flip(array_map(
-            static fn (CardRarityEnum $rarity): string => $rarity->value,
-            CardRarityEnum::ascending(),
-        ));
     }
 
     private function getDiscordUser(): DiscordUser

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -67,8 +67,8 @@
                             {% set drawable = drawableBoosterIds[booster.id]|default(false) %}
                             <article class="group relative flex flex-col rounded-2xl border border-hairline bg-surface p-4 transition duration-300 hover:-translate-y-1 hover:border-primary/40">
                                 {# centred eyebrow + booster name (packs.com header) — the eyebrow
-                                   carries the extension when the booster has its own name #}
-                                <p class="text-center font-mono text-[10px] font-bold uppercase tracking-[.2em] text-ink-dim">Cartes de{{ booster.name ? ' ' ~ booster.extension.name }}</p>
+                                   always names the extension, like displayName falls back to it #}
+                                <p class="text-center font-mono text-[10px] font-bold uppercase tracking-[.2em] text-ink-dim">Cartes de {{ booster.extension.name }}</p>
                                 <h3 class="mt-1 text-center font-display text-lg font-bold uppercase leading-tight tracking-[-0.02em] text-ink-strong">{{ booster.displayName }}</h3>
 
                                 {# tilted pack with a trading card peeking out behind it #}

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -66,8 +66,7 @@
                             {% set owned = inventory[booster.id]|default(0) %}
                             {% set drawable = drawableBoosterIds[booster.id]|default(false) %}
                             <article class="group relative flex flex-col rounded-2xl border border-hairline bg-surface p-4 transition duration-300 hover:-translate-y-1 hover:border-primary/40">
-                                {# centred eyebrow + booster name (packs.com header) — the eyebrow
-                                   always names the extension, like displayName falls back to it #}
+                                {# centred eyebrow + booster name (packs.com header) #}
                                 <p class="text-center font-mono text-[10px] font-bold uppercase tracking-[.2em] text-ink-dim">Cartes de {{ booster.extension.name }}</p>
                                 <h3 class="mt-1 text-center font-display text-lg font-bold uppercase leading-tight tracking-[-0.02em] text-ink-strong">{{ booster.displayName }}</h3>
 

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -61,7 +61,6 @@
                     {% set inventory = this.inventory %}
                     {% set remainingClaims = this.remainingClaims %}
                     {% set drawableBoosterIds = this.drawableBoosterIds %}
-                    {% set rarityLabels = { common: 'Commune', uncommon: 'Peu commune', rare: 'Rare', legendary: 'Légendaire' } %}
                     <div class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4" data-testid="boosters-grid">
                         {% for booster in this.boosters %}
                             {% set owned = inventory[booster.id]|default(0) %}
@@ -150,7 +149,7 @@
                                                         <div class="mb-1.5 flex flex-wrap items-baseline gap-x-2 font-mono text-[11px]">
                                                             <span class="text-ink-dim">Carte {{ loop.index }} ·</span>
                                                             {% for rarity, rate in slot.rates %}
-                                                                <span style="color: var(--rarity-{{ rarity }});">{{ rarityLabels[rarity]|default(rarity) }} {{ rate == rate|round ? rate|round : rate }}%</span>
+                                                                <span style="color: var(--rarity-{{ rarity }});">{{ rarity_label(rarity) }} {{ rate == rate|round ? rate|round : rate }}%</span>
                                                             {% endfor %}
                                                             {% if slot.holoChance > 0 %}
                                                                 <span class="text-magenta">✦ Holo {{ slot.holoChance }}%</span>

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -8,7 +8,6 @@
     {% set ownedCount = this.ownedCount %}
     {% set ownedCardIds = this.ownedCardIds %}
     {% set newCardIds = this.newCardIds %}
-    {% set rarityLabels = { common: 'Commune', uncommon: 'Peu commune', rare: 'Rare', legendary: 'Légendaire' } %}
     {% set raritySuffix = { rare: ' !', legendary: ' !!!' } %}
 
     <div class="opening opening--page"
@@ -63,7 +62,7 @@
                                  data-card-id="{{ reveal.card.id }}"
                                  data-rarity="{{ rarity }}"
                                  data-shiny="{{ rarity in ['rare', 'legendary'] ? '1' : '0' }}"
-                                 data-label="{{ rarityLabels[rarity]|default(rarity) }}{{ raritySuffix[rarity]|default('') }}">
+                                 data-label="{{ reveal.card.rarity.label }}{{ raritySuffix[rarity]|default('') }}">
                                 {# flip scene: back faces the player until they click to reveal the front #}
                                 <div class="opening__flip" data-booster-opening-target="flip">
                                     <div class="opening__flip-face opening__flip-front">
@@ -237,9 +236,9 @@
                                 </div>
                                 <p class="opening__card-name"{% if isPending %} data-reveal-name="{{ card.name }}"{% endif %}>{{ isOwned ? card.name : 'Non révélée' }}</p>
                                 {% if isOwned %}
-                                    <p class="opening__card-tier">{{ rarityLabels[rarity]|default(rarity) }}</p>
+                                    <p class="opening__card-tier">{{ card.rarity.label }}</p>
                                 {% elseif isPending %}
-                                    <p class="opening__card-tier" hidden data-reveal-tier="{{ rarityLabels[rarity]|default(rarity) }}"></p>
+                                    <p class="opening__card-tier" hidden data-reveal-tier="{{ card.rarity.label }}"></p>
                                 {% endif %}
                             </article>
                         {% endfor %}

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -53,13 +53,8 @@
         </section>
 
         {# ---------------------------------------------------------- Ticker #}
-        {# Paliers de rareté (source unique ticker + section Raretés) : doit suivre CardRarityEnum #}
-        {% set rarities = [
-            {label: 'Common', chip: 'C', color: 'var(--rarity-common)'},
-            {label: 'Uncommon', chip: 'U', color: 'var(--rarity-uncommon)'},
-            {label: 'Rare', chip: 'R', color: 'var(--rarity-rare)'},
-            {label: 'Legendary', chip: 'L', color: 'var(--rarity-legendary)'},
-        ] %}
+        {# Paliers de rareté (ticker + section Raretés) : directement CardRarityEnum, labels FR inclus #}
+        {% set rarities = card_rarities() %}
         {% set tickerItems = [
             "✦ %s packs ouverts"|format(packsOpenedCount|number_format(0, ',', ' ')),
             '✦ %d univers'|format(universesTotal),
@@ -184,11 +179,12 @@
                 {# Pas de « drop rate » global affiché : les vrais taux sont définis slot par slot, booster par booster #}
                 <div class="grid md:grid-cols-4">
                     {% for rarity in rarities %}
+                        {% set color = 'var(--rarity-' ~ rarity.value ~ ')' %}
                         <div class="px-5 py-8 {{ not loop.last ? 'md:border-r md:border-white/10' }}"
-                             style="border-top: 3px solid {{ rarity.color }}; background: linear-gradient(180deg, color-mix(in srgb, {{ rarity.color }} 9%, transparent), transparent);">
-                            <p class="chip-mono font-bold !tracking-[.2em]" style="color: {{ rarity.color }};">TIER {{ '%02d'|format(loop.index) }}</p>
+                             style="border-top: 3px solid {{ color }}; background: linear-gradient(180deg, color-mix(in srgb, {{ color }} 9%, transparent), transparent);">
+                            <p class="chip-mono font-bold !tracking-[.2em]" style="color: {{ color }};">TIER {{ '%02d'|format(loop.index) }}</p>
                             <p class="mt-4 font-display text-4xl font-bold uppercase tracking-[-0.04em] text-ink-strong">
-                                {{ rarity.chip }}<span class="text-2xl" style="color: {{ rarity.color }};"> · {{ rarity.label }}</span>
+                                {{ rarity.value|first|upper }}<span class="text-2xl" style="color: {{ color }};"> · {{ rarity.label }}</span>
                             </p>
                         </div>
                     {% endfor %}

--- a/templates/pages/universe.html.twig
+++ b/templates/pages/universe.html.twig
@@ -9,7 +9,6 @@
     {% set totalCount = catalog|length %}
     {% set percentage = totalCount > 0 ? ((ownedCount / totalCount) * 100)|round : 0 %}
     {% set banners = extension.banners|filter(banner => banner.imageName) %}
-    {% set rarityLabels = { common: 'Commune', uncommon: 'Peu commune', rare: 'Rare', legendary: 'Légendaire' } %}
 
     <main>
         {# --------------------------------------------- Héro / bannières #}

--- a/templates/pages/universe.html.twig
+++ b/templates/pages/universe.html.twig
@@ -129,7 +129,7 @@
                         {% for booster in boosters %}
                             {% set owned = ownedBoosterCounts[booster.id ~ '']|default(0) %}
                             <article class="group relative flex flex-col rounded-2xl border border-hairline bg-surface p-4 transition duration-300 hover:-translate-y-1 hover:border-primary/40">
-                                <p class="text-center font-mono text-[10px] font-bold uppercase tracking-[.2em] text-ink-dim">Cartes de{{ booster.name ? ' ' ~ booster.extension.name }}</p>
+                                <p class="text-center font-mono text-[10px] font-bold uppercase tracking-[.2em] text-ink-dim">Cartes de {{ booster.extension.name }}</p>
                                 <h3 class="mt-1 text-center font-display text-lg font-bold uppercase leading-tight tracking-[-0.02em] text-ink-strong">{{ booster.displayName }}</h3>
 
                                 <div class="relative mx-auto mt-4 flex h-52 w-full items-center justify-center">

--- a/tests/Unit/Enum/CardRarityEnumTest.php
+++ b/tests/Unit/Enum/CardRarityEnumTest.php
@@ -29,4 +29,35 @@ final class CardRarityEnumTest extends TestCase
             CardRarityEnum::ascending(),
         );
     }
+
+    public function testRankFollowsTheAscendingOrder(): void
+    {
+        // rank() and ascending() are two views of the same scale: lock them together
+        foreach (CardRarityEnum::ascending() as $index => $rarity) {
+            $this->assertSame($index, $rarity->rank());
+        }
+    }
+
+    public function testLabelExposesTheFrenchPlayerFacingNames(): void
+    {
+        $this->assertSame('Commune', CardRarityEnum::COMMON->label());
+        $this->assertSame('Peu commune', CardRarityEnum::UNCOMMON->label());
+        $this->assertSame('Rare', CardRarityEnum::RARE->label());
+        $this->assertSame('Légendaire', CardRarityEnum::LEGENDARY->label());
+    }
+
+    public function testCompareRarestFirstSortsFromLegendaryToCommon(): void
+    {
+        $rarities = [
+            CardRarityEnum::UNCOMMON,
+            CardRarityEnum::LEGENDARY,
+            CardRarityEnum::COMMON,
+            CardRarityEnum::RARE,
+        ];
+
+        usort($rarities, CardRarityEnum::compareRarestFirst(...));
+
+        $this->assertSame(array_reverse(CardRarityEnum::ascending()), $rarities);
+        $this->assertSame(0, CardRarityEnum::compareRarestFirst(CardRarityEnum::RARE, CardRarityEnum::RARE));
+    }
 }

--- a/tests/Unit/Service/BoosterAvailabilityServiceTest.php
+++ b/tests/Unit/Service/BoosterAvailabilityServiceTest.php
@@ -120,8 +120,7 @@ final class BoosterAvailabilityServiceTest extends TestCase
     }
 
     /**
-     * The uuid is normally Doctrine-generated; hand-built entities get one via
-     * reflection so the id-keyed maps have real keys to match on.
+     * The uuid is normally Doctrine-generated; hand-built entities get one via reflection.
      */
     private function withId(Booster | Extension $entity): Booster | Extension
     {

--- a/tests/Unit/Service/BoosterAvailabilityServiceTest.php
+++ b/tests/Unit/Service/BoosterAvailabilityServiceTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Booster;
+use App\Entity\Extension;
+use App\Enum\Entity\ExtensionStatusEnum;
+use App\Repository\CardRepository;
+use App\Service\Booster\BoosterAvailabilityService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Uid\Uuid;
+
+final class BoosterAvailabilityServiceTest extends TestCase
+{
+    public function testAClaimableBoosterIsVisibleEvenWithoutCopies(): void
+    {
+        $booster = $this->booster();
+
+        $this->assertTrue($this->service()->isVisible($booster, []));
+    }
+
+    public function testANonClaimableBoosterIsOnlyVisibleForOwners(): void
+    {
+        $booster = $this->booster()->setClaimable(false);
+        $service = $this->service();
+
+        $this->assertFalse($service->isVisible($booster, []));
+        $this->assertFalse($service->isVisible($booster, [(string) $booster->getId() => 0]));
+        $this->assertTrue($service->isVisible($booster, [(string) $booster->getId() => 1]));
+    }
+
+    public function testFilterVisibleKeepsClaimableAndOwnedBoostersAsAList(): void
+    {
+        $claimable = $this->booster();
+        $ownedEvent = $this->booster()->setClaimable(false);
+        $hiddenEvent = $this->booster()->setClaimable(false);
+
+        $visible = $this->service()->filterVisible(
+            [$hiddenEvent, $claimable, $ownedEvent],
+            [(string) $ownedEvent->getId() => 2],
+        );
+
+        // array_filter keys must be re-indexed: the result is a list
+        $this->assertSame([$claimable, $ownedEvent], $visible);
+    }
+
+    public function testIsClaimableDelegatesToTheBoosterFlag(): void
+    {
+        $service = $this->service();
+
+        $this->assertTrue($service->isClaimable($this->booster()));
+        $this->assertFalse($service->isClaimable($this->booster()->setClaimable(false)));
+    }
+
+    public function testHasPublishedExtensionRefusesADraftExtension(): void
+    {
+        $service = $this->service();
+
+        $this->assertTrue($service->hasPublishedExtension($this->booster()));
+        $this->assertFalse($service->hasPublishedExtension($this->booster(ExtensionStatusEnum::DRAFT)));
+    }
+
+    public function testIsDrawableRequiresTheExtensionToHavePublishedCards(): void
+    {
+        $drawable = $this->booster();
+        $empty = $this->booster();
+        $service = $this->service([(string) $drawable->getExtension()->getId()]);
+
+        $this->assertTrue($service->isDrawable($drawable));
+        $this->assertFalse($service->isDrawable($empty));
+    }
+
+    public function testDrawableBoosterIdsMapsBoostersOfDrawableExtensionsInOneBatch(): void
+    {
+        $drawable = $this->booster();
+        $sibling = $this->booster();
+        $sibling->setExtension($drawable->getExtension());
+        $empty = $this->booster();
+
+        $service = $this->service([(string) $drawable->getExtension()->getId()]);
+
+        $this->assertSame(
+            [(string) $drawable->getId() => true, (string) $sibling->getId() => true],
+            $service->drawableBoosterIds([$drawable, $sibling, $empty]),
+        );
+    }
+
+    public function testIsOpenableNeedsADrawableBoosterAndAtLeastOneOwnedCopy(): void
+    {
+        $booster = $this->booster();
+        $service = $this->service([(string) $booster->getExtension()->getId()]);
+
+        $this->assertTrue($service->isOpenable($booster, 1));
+        $this->assertFalse($service->isOpenable($booster, 0));
+        $this->assertFalse($this->service()->isOpenable($booster, 1));
+    }
+
+    /**
+     * @param list<string> $drawableExtensionIds
+     */
+    private function service(array $drawableExtensionIds = []): BoosterAvailabilityService
+    {
+        $cardRepository = $this->createStub(CardRepository::class);
+        $cardRepository->method('findExtensionIdsWithPublishedCards')->willReturn($drawableExtensionIds);
+
+        return new BoosterAvailabilityService($cardRepository);
+    }
+
+    private function booster(ExtensionStatusEnum $status = ExtensionStatusEnum::PUBLISHED): Booster
+    {
+        $extension = $this->withId(new Extension()->setName('Test ext')->setStatus($status));
+        \assert($extension instanceof Extension);
+
+        $booster = $this->withId(new Booster()->setExtension($extension));
+        \assert($booster instanceof Booster);
+
+        return $booster;
+    }
+
+    /**
+     * The uuid is normally Doctrine-generated; hand-built entities get one via
+     * reflection so the id-keyed maps have real keys to match on.
+     */
+    private function withId(Booster | Extension $entity): Booster | Extension
+    {
+        $property = new \ReflectionProperty($entity::class, 'id');
+        $property->setValue($entity, Uuid::v4());
+
+        return $entity;
+    }
+}

--- a/tests/Unit/Service/BoosterClaimServiceTest.php
+++ b/tests/Unit/Service/BoosterClaimServiceTest.php
@@ -132,10 +132,6 @@ final class BoosterClaimServiceTest extends TestCase
         $this->assertSame($resetTime, $service->getNextResetTime());
     }
 
-    /**
-     * The claim path only uses the pure predicates, never the card
-     * repository: a real service over a stubbed repository is enough.
-     */
     private function availability(): BoosterAvailabilityService
     {
         return new BoosterAvailabilityService($this->createStub(CardRepository::class));

--- a/tests/Unit/Service/BoosterClaimServiceTest.php
+++ b/tests/Unit/Service/BoosterClaimServiceTest.php
@@ -10,6 +10,8 @@ use App\Entity\Extension;
 use App\Enum\Entity\ExtensionStatusEnum;
 use App\Exception\Booster\BoosterNotClaimableException;
 use App\Exception\Booster\DailyClaimLimitReachedException;
+use App\Repository\CardRepository;
+use App\Service\Booster\BoosterAvailabilityService;
 use App\Service\Booster\BoosterClaimQuotaInterface;
 use App\Service\Booster\BoosterClaimService;
 use App\Service\Booster\UserInventoryService;
@@ -38,7 +40,7 @@ final class BoosterClaimServiceTest extends TestCase
         $entityManager->expects($this->once())->method('persist');
         $entityManager->expects($this->once())->method('flush');
 
-        $service = new BoosterClaimService($this->quotaWithRemaining(2), $inventory, $entityManager, $clock);
+        $service = new BoosterClaimService($this->quotaWithRemaining(2), $inventory, $entityManager, $clock, $this->availability());
 
         $claim = $service->claim($user, $booster);
 
@@ -60,6 +62,7 @@ final class BoosterClaimServiceTest extends TestCase
             $inventory,
             $entityManager,
             new MockClock('2026-06-10 12:00:00', 'UTC'),
+            $this->availability(),
         );
 
         $this->expectException(DailyClaimLimitReachedException::class);
@@ -77,6 +80,7 @@ final class BoosterClaimServiceTest extends TestCase
             $inventory,
             $this->createStub(EntityManagerInterface::class),
             new MockClock('2026-06-10 12:00:00', 'UTC'),
+            $this->availability(),
         );
 
         $this->expectException(BoosterNotClaimableException::class);
@@ -98,6 +102,7 @@ final class BoosterClaimServiceTest extends TestCase
             $inventory,
             $this->createStub(EntityManagerInterface::class),
             new MockClock('2026-06-10 12:00:00', 'UTC'),
+            $this->availability(),
         );
 
         try {
@@ -120,10 +125,20 @@ final class BoosterClaimServiceTest extends TestCase
             $this->createStub(UserInventoryService::class),
             $this->createStub(EntityManagerInterface::class),
             new MockClock('2026-06-10 12:00:00', 'UTC'),
+            $this->availability(),
         );
 
         $this->assertSame(1, $service->getRemainingClaims(new DiscordUser()));
         $this->assertSame($resetTime, $service->getNextResetTime());
+    }
+
+    /**
+     * The claim path only uses the pure predicates, never the card
+     * repository: a real service over a stubbed repository is enough.
+     */
+    private function availability(): BoosterAvailabilityService
+    {
+        return new BoosterAvailabilityService($this->createStub(CardRepository::class));
     }
 
     private function quotaWithRemaining(int $remaining): BoosterClaimQuotaInterface

--- a/tests/Unit/Twig/CardRarityExtensionTest.php
+++ b/tests/Unit/Twig/CardRarityExtensionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Twig;
+
+use App\Enum\Entity\CardRarityEnum;
+use App\Twig\CardRarityExtension;
+use PHPUnit\Framework\TestCase;
+
+final class CardRarityExtensionTest extends TestCase
+{
+    public function testCardRaritiesExposesTheAscendingScale(): void
+    {
+        $this->assertSame(CardRarityEnum::ascending(), new CardRarityExtension()->cardRarities());
+    }
+
+    public function testRarityLabelAcceptsEnumsAndRawStrings(): void
+    {
+        $extension = new CardRarityExtension();
+
+        $this->assertSame('Légendaire', $extension->rarityLabel(CardRarityEnum::LEGENDARY));
+        $this->assertSame('Peu commune', $extension->rarityLabel('uncommon'));
+        // unknown JSON keys fall back to the raw value instead of crashing the template
+        $this->assertSame('mythic', $extension->rarityLabel('mythic'));
+    }
+}


### PR DESCRIPTION
## Quoi

Refactorisation chirurgicale : centralisation de la règle de disponibilité des boosters et du classement/libellés de rareté. Zéro changement de comportement, hors les 2 bugs d'affichage listés plus bas.

### 1. `BoosterAvailabilityService` — la règle de disponibilité en un seul endroit

La règle « ce booster est-il visible / récupérable / ouvrable ? » était réimplémentée **5 fois** :

| Site | Règle dupliquée |
|---|---|
| `BoosterController::open()` | extension tirable + possession |
| `BoosterHub::getBoosters()` | claimable OU possédé |
| `BoosterHub::getDrawableBoosterIds()` | extension avec cartes publiées |
| `UniverseController::visibleBoosters()` | même règle que le hub |
| `BoosterClaimService::claim()` | claimable + extension publiée |

Les 5 sites consomment désormais les prédicats du service (`isVisible`/`filterVisible`, `isDrawable`/`drawableBoosterIds`, `isOpenable`, `isClaimable`, `hasPublishedExtension`). Les signatures prennent l'inventaire ou la liste déjà en main pour ne pas ajouter de requête ; `BoosterClaimService` garde ses exceptions métier et ne délègue que les prédicats.

### 2. `CardRarityEnum::rank()` / `label()` / `compareRarestFirst()`

- Le tri « rarest first » (`array_flip(array_map(...ascending()))` + `usort`) était réimplémenté **4 fois** (`UniverseController`, `BoosterOpening`, `UserCardRepository`, `CardRepository`) → remplacé par `rank()` et le comparateur statique `compareRarestFirst()` (le tiebreak par nom reste aux sites d'appel).
- Les libellés FR (Commune / Peu commune / Rare / Légendaire) étaient dupliqués dans **3 templates** → `label()` sur l'enum, exposé à Twig via `CardRarityExtension` (`rarity_label()`, `card_rarities()`). La copie **morte** de `universe.html.twig` est supprimée.
- Hors scope (inchangé) : la copie côté JS de `booster_opening_controller.js`.

### 3. Deux fixes d'affichage au passage

- **« Cartes de » orphelin** (hub + page univers) : quand le booster n'a pas de nom propre, l'eyebrow affichait « Cartes de » sans suite. Il nomme désormais toujours l'extension (même logique de repli que `Booster::getDisplayName()`).
- **Raretés homepage en anglais** : la section Raretés affichait Common / Uncommon / Rare / Legendary sur un site entièrement en français → labels FR de l'enum via `card_rarities()`.

## Tests

- `BoosterAvailabilityServiceTest` : tous les prédicats, entités construites à la main (uuid posé par réflexion).
- `CardRarityEnumTest` : `rank()` verrouillé sur `ascending()`, labels FR, comparateur.
- `CardRarityExtensionTest` : labels depuis enum et depuis clé JSON brute, repli sur la valeur inconnue.
- `BoosterClaimServiceTest` mis à jour (nouvelle dépendance).
- Vérifié par grep : aucun test fonctionnel n'asserte les rendus touchés (« Cartes de », labels EN homepage, `4 paliers.` reste vrai).

## Vérification

Environnement de travail sans PHP/vendor : relecture soignée, la CI (quality + tests) fait foi.
