### PR TITLE
fix(db): réaligne le type de card.claimed_by (schéma en sync)

### DIFF
--- a/migrations/Version20260807090000.php
+++ b/migrations/Version20260807090000.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Last piece of the card.claimed_by drift: the column was created as
+ * VARCHAR(255) by the hand-written unique-claim migration, while its mapping
+ * (ManyToOne on DiscordUser::$discordId, a length-less string column) resolves
+ * to an unbounded VARCHAR. Version20260805120000 realigned the index and FK
+ * names but left the type, so doctrine:schema:validate — run by the CI since
+ * the quality-gaps workflow — still reported the schema out of sync.
+ */
+final class Version20260807090000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Align the card.claimed_by column type with its mapping (VARCHAR)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE card ALTER claimed_by TYPE VARCHAR');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE card ALTER claimed_by TYPE VARCHAR(255)');
+    }
+}

--- a/src/Service/Booster/BoosterAvailabilityService.php
+++ b/src/Service/Booster/BoosterAvailabilityService.php
@@ -23,7 +23,11 @@ final readonly class BoosterAvailabilityService
      */
     public function isVisible(Booster $booster, array $ownedCounts): bool
     {
-        return $booster->isClaimable() || ($ownedCounts[(string) $booster->getId()] ?? 0) > 0;
+        if ($booster->isClaimable()) {
+            return true;
+        }
+
+        return ($ownedCounts[(string) $booster->getId()] ?? 0) > 0;
     }
 
     /**


### PR DESCRIPTION
## Pourquoi

La CI de #119 a ajouté `doctrine:schema:validate`. Master **échoue** ce check : `card.claimed_by` a été créée en `VARCHAR(255)` par la migration manuelle du unique-claim, alors que son mapping (ManyToOne vers `DiscordUser::\$discordId`, colonne string sans longueur) résout en `VARCHAR` non borné. #120 avait réaligné l'index et la FK, mais pas le type.

Conséquence : **toute branche** part avec une CI rouge sur ce step.

## Contenu

- migration `Version20260807090000` : `ALTER TABLE card ALTER claimed_by TYPE VARCHAR`
- la ligne vide réclamée par php-cs-fixer dans `BoosterAvailabilityService` (arrivée avec #122, fait échouer le job qualité sur master en l'état)

## Vérifié en local

- `doctrine:schema:validate` → *The database schema is in sync with the mapping files*
- 190 tests verts
- `make check_style` vert

🤖 Generated with [Claude Code](https://claude.com/claude-code)