### PR TITLE
fix(front): garde les cartes uniques hors de la vitrine d'accueil

### DIFF
--- a/src/Repository/CardRepository.php
+++ b/src/Repository/CardRepository.php
@@ -154,6 +154,10 @@ class CardRepository extends ServiceEntityRepository
             ->join('c.extension', 'e')
             ->andWhere('c.status = :status')
             ->andWhere('e.status = :extensionStatus')
+            // one-of-ones stay out of the showcase: putting a 1/1 on the
+            // homepage spoils the hunt for a card nobody may have drawn yet,
+            // and contradicts the masking the universe and opening pages do
+            ->andWhere('c.uniqueFlag = false')
             ->setParameter('status', CardStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
             ->setParameter('extensionStatus', ExtensionStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
             ->orderBy('RANDOM()')

--- a/src/Repository/CardRepository.php
+++ b/src/Repository/CardRepository.php
@@ -154,9 +154,6 @@ class CardRepository extends ServiceEntityRepository
             ->join('c.extension', 'e')
             ->andWhere('c.status = :status')
             ->andWhere('e.status = :extensionStatus')
-            // one-of-ones stay out of the showcase: putting a 1/1 on the
-            // homepage spoils the hunt for a card nobody may have drawn yet,
-            // and contradicts the masking the universe and opening pages do
             ->andWhere('c.uniqueFlag = false')
             ->setParameter('status', CardStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
             ->setParameter('extensionStatus', ExtensionStatusEnum::PUBLISHED->value, ParameterType::INTEGER)

--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -6,8 +6,11 @@ namespace App\Tests\Functional;
 
 use App\Entity\Booster;
 use App\Entity\BoosterOpening;
+use App\Entity\Card;
 use App\Entity\DiscordUser;
 use App\Entity\Extension;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
 use App\Enum\Entity\ExtensionStatusEnum;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -144,6 +147,22 @@ final class HomepageTest extends WebTestCase
     public function testStaleDayCardsCacheIsRedrawn(): void
     {
         $this->authenticateClient($this->client);
+
+        // the showcase skips one-of-ones, and the fixtures hold few regular
+        // published cards: guarantee the three the redraw is expected to find
+        $extension = $this->createPublishedExtension('Redraw showcase ' . uniqid());
+        for ($i = 0; $i < 3; ++$i) {
+            $card = new Card()
+                ->setName('Redraw card ' . $i . ' ' . uniqid())
+                ->setDescription('Test')
+                ->setStatus(CardStatusEnum::PUBLISHED)
+                ->setRarity(CardRarityEnum::COMMON)
+                ->setExtension($extension)
+            ;
+            $card->setImageName('default_card.png');
+            $this->entityManager->persist($card);
+        }
+        $this->entityManager->flush();
 
         // Ids that no longer exist (e.g. fixtures reloaded since the cache
         // was built): the homepage must drop the cache and redraw.

--- a/tests/Integration/Repository/CardRepositoryHomepageTest.php
+++ b/tests/Integration/Repository/CardRepositoryHomepageTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Repository;
+
+use App\Entity\Card;
+use App\Entity\Extension;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use App\Repository\CardRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * The homepage showcase must never put a one-of-one on display: it would spoil
+ * a card nobody may have drawn yet, while the universe and opening pages go out
+ * of their way to mask exactly that.
+ */
+final class CardRepositoryHomepageTest extends KernelTestCase
+{
+    public function testTheShowcaseDrawsRegularCardsButNeverAUnique(): void
+    {
+        self::bootKernel();
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+
+        $extension = new Extension()
+            ->setName('Showcase test ' . uniqid())
+            ->setDescription('Test extension')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $entityManager->persist($extension);
+
+        $regular = $this->card($extension, 'Régulière');
+        $legendary = $this->card($extension, 'Légendaire')->setRarity(CardRarityEnum::LEGENDARY);
+        $unique = $this->card($extension, 'Unique')->setUnique(true);
+
+        foreach ([$regular, $legendary, $unique] as $card) {
+            $entityManager->persist($card);
+        }
+        $entityManager->flush();
+
+        // ask for far more than the catalogue holds: the draw is random, so the
+        // assertion only means something once every eligible card is returned
+        $drawn = self::getContainer()->get(CardRepository::class)->findRandomCardId(5000);
+        $drawn = array_map(strval(...), $drawn);
+
+        $this->assertContains((string) $regular->getId(), $drawn);
+        $this->assertContains(
+            (string) $legendary->getId(),
+            $drawn,
+            'Legendaries stay in: they exist in several copies and are the point of the showcase.',
+        );
+        $this->assertNotContains((string) $unique->getId(), $drawn);
+    }
+
+    private function card(Extension $extension, string $name): Card
+    {
+        $card = new Card()
+            ->setName($name . ' ' . uniqid())
+            ->setDescription('Test card')
+            ->setStatus(CardStatusEnum::PUBLISHED)
+            ->setRarity(CardRarityEnum::COMMON)
+            ->setExtension($extension)
+        ;
+        $card->setImageName('default_card.png');
+
+        return $card;
+    }
+}


### PR DESCRIPTION
## Le problème

L'accueil tire 3 cartes au hasard parmi **toutes** les cartes publiées, sans jamais regarder `uniqueFlag` :

```sql
WHERE c.status = PUBLISHED AND e.status = PUBLISHED ORDER BY RANDOM() LIMIT 3
```

Une **1/1 pouvait donc s'afficher en grand sur la page d'accueil**, et y rester toute la journée puisque le tirage est mis en cache jusqu'au lendemain. Le cas le plus gênant étant une unique **pas encore tirée** : on montre à tout le monde la carte que personne n'a trouvée.

C'était le seul écran à ne pas respecter la règle anti-spoiler appliquée partout ailleurs — la page univers masque les cartes non possédées derrière un dos de carte, l'ouverture masque les cartes fraîchement gagnées pour ne pas déflorer le reveal, et le statut d'une unique s'affiche sans révéler son détenteur.

## Le correctif

Un `andWhere('c.uniqueFlag = false')` sur le tirage de l'accueil.

**Les légendaires restent** (décision produit) : elles existent en plusieurs exemplaires, ne sont réservées à personne, et ce sont elles qui donnent envie d'ouvrir un pack.

## Tests

- nouveau test d'intégration : la vitrine renvoie bien la carte régulière **et** la légendaire, jamais l'unique. Vérifié non-vacuous — il échoue si on retire le filtre.
- `HomepageTest::testStaleDayCardsCacheIsRedrawn` attendait 3 cartes en s'appuyant sur la composition des fixtures, qui comptent peu de publiées non uniques : il fabrique désormais les siennes.

275 tests verts, PHPStan et cs-fixer propres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)