### PR TITLE
chore(prod): bascule le domaine de prod sur ytcg.youlz.fr

### DIFF
--- a/.env
+++ b/.env
@@ -31,10 +31,13 @@ APP_VERSION=dev
 ###< App release version ###
 
 ###> Project external URLS ###
-REFRESH_TOKEN_URL='https://yc.barlito.fr/refresh_token'
-LOGOUT_URL='https://yc.barlito.fr/logout'
+# youl-coin doit être servi sous youlz.fr : un cookie ne peut être posé que sur
+# le domaine qui répond. Tant que l'auth ne répond qu'en barlito.fr, le JWT
+# n'atteint jamais ytcg.youlz.fr et la connexion boucle.
+REFRESH_TOKEN_URL='https://yc.youlz.fr/refresh_token'
+LOGOUT_URL='https://yc.youlz.fr/logout'
 ###< Project external URLS ###
 
 ###> lexik/jwt-authentication-bundle ###
-JWT_COOKIE_DOMAIN=.barlito.fr
+JWT_COOKIE_DOMAIN=.youlz.fr
 ###< lexik/jwt-authentication-bundle ###

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ make doctrine.migrate
 make doctrine.load_fixtures
 ```
 
-App: `ytcg.local.barlito.fr` — Adminer: `ytcg-adminer.local.barlito.fr` (prod: `ytcg.barlito.fr`).
+App: `ytcg.local.barlito.fr` — Adminer: `ytcg-adminer.local.barlito.fr` (prod: `ytcg.youlz.fr`, l'ancien `ytcg.barlito.fr` redirige en 301).
 
 Discord OAuth needs `OAUTH_DISCORD_CLIENT_ID` / `OAUTH_DISCORD_CLIENT_SECRET` in your env (see `.env` for the full list: `DATABASE_URL`, `JWT_*`, `APP_SECRET`, …).
 

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -33,13 +33,29 @@ services:
 
                 - traefik.http.services.ytcg.loadbalancer.server.port=80
 
-                - traefik.http.routers.ytcg.rule=Host(`ytcg.barlito.fr`)
+                - traefik.http.routers.ytcg.rule=Host(`ytcg.youlz.fr`)
                 - traefik.http.routers.ytcg.entrypoints=http
 
-                - traefik.http.routers.ytcg-secure.rule=Host(`ytcg.barlito.fr`)
+                - traefik.http.routers.ytcg-secure.rule=Host(`ytcg.youlz.fr`)
                 - traefik.http.routers.ytcg-secure.entrypoints=https
                 - traefik.http.routers.ytcg-secure.tls=true
                 - traefik.http.routers.ytcg-secure.tls.certresolver=letsencrypt
+
+                # Ancien domaine : 301 vers youlz.fr. Le `$$` échappe
+                # l'interpolation de variables de docker stack deploy.
+                - traefik.http.middlewares.ytcg-legacy.redirectregex.regex=^https?://ytcg\.barlito\.fr/(.*)
+                - traefik.http.middlewares.ytcg-legacy.redirectregex.replacement=https://ytcg.youlz.fr/$${1}
+                - traefik.http.middlewares.ytcg-legacy.redirectregex.permanent=true
+
+                - traefik.http.routers.ytcg-legacy.rule=Host(`ytcg.barlito.fr`)
+                - traefik.http.routers.ytcg-legacy.entrypoints=http
+                - traefik.http.routers.ytcg-legacy.middlewares=ytcg-legacy
+
+                - traefik.http.routers.ytcg-legacy-secure.rule=Host(`ytcg.barlito.fr`)
+                - traefik.http.routers.ytcg-legacy-secure.entrypoints=https
+                - traefik.http.routers.ytcg-legacy-secure.tls=true
+                - traefik.http.routers.ytcg-legacy-secure.tls.certresolver=letsencrypt
+                - traefik.http.routers.ytcg-legacy-secure.middlewares=ytcg-legacy
         networks:
             - traefik_traefik_proxy
             - ytcg_internal


### PR DESCRIPTION
## Ce que ça change

- `docker-compose-prod.yml` : le routeur Traefik sert désormais `ytcg.youlz.fr`. `ytcg.barlito.fr` reste routé mais renvoie un **301** vers le nouveau domaine (liens et favoris préservés).
- `.env` : `JWT_COOKIE_DOMAIN` passe à `.youlz.fr`, `REFRESH_TOKEN_URL` / `LOGOUT_URL` pointent sur `yc.youlz.fr`.
- `README.md` : URL de prod à jour.

Le DNS est déjà prêt : `*.youlz.fr` résout vers 51.68.154.52 (le serveur).

## ⚠️ Ne pas déployer seul

Un cookie ne peut être posé que par le domaine qui répond à la requête. Le JWT est émis par **youl-coin**, servi aujourd'hui uniquement sur `yc.barlito.fr` : un navigateur sur `ytcg.youlz.fr` ne recevra donc jamais ce cookie et la connexion bouclera indéfiniment entre les deux domaines.

Il faut donc, **avant ou en même temps** que ce déploiement, côté `youl-coin-api` :

1. ajouter `yc.youlz.fr` aux règles Traefik (`Host(\`yc.barlito.fr\`) || Host(\`yc.youlz.fr\`)`) ;
2. passer `JWT_COOKIE_DOMAIN` à `.youlz.fr` ;
3. ajouter `https://yc.youlz.fr/connect/discord/check` aux redirect URIs de l'application Discord.

Le firewall `main` de youl-coin fonctionne en session + remember_me, pas avec ce cookie JWT : son propre admin n'est pas impacté par le changement de domaine du cookie.

## Vérifications

- 274 tests verts.
- `docker compose config` valide le fichier ; le `$$` échappe bien l'interpolation de `docker stack deploy` dans la règle de redirection.
- Le dev local n'est pas touché : `.env.dev` surcharge les trois variables avec les valeurs `.local.barlito.fr`.