### PR TITLE
feat(admin): génération et suivi des lots de codes (2/3)

### DIFF
--- a/assets/scripts/admin/copy-to-clipboard.js
+++ b/assets/scripts/admin/copy-to-clipboard.js
@@ -1,0 +1,68 @@
+/**
+ * Copy-to-clipboard for any admin element carrying data-copy-value.
+ *
+ * Plain delegated listener rather than a Stimulus controller: the admin pages
+ * load EasyAdmin's own Stimulus application, not the app's, so a controller
+ * dropped in assets/controllers would never boot here.
+ */
+document.addEventListener('click', (event) => {
+    const button = event.target.closest('[data-copy-value]');
+
+    if (null === button) {
+        return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    copy(button.dataset.copyValue).then((copied) => feedback(button, copied));
+});
+
+async function copy(text) {
+    // navigator.clipboard only exists in a secure context: keep the legacy
+    // path so the button still works over plain http (local, tunnels…)
+    if (navigator.clipboard && window.isSecureContext) {
+        try {
+            await navigator.clipboard.writeText(text);
+
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    const textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    let copied = false;
+    try {
+        copied = document.execCommand('copy');
+    } catch {
+        copied = false;
+    }
+
+    textarea.remove();
+
+    return copied;
+}
+
+function feedback(button, copied) {
+    if (button.dataset.copyBusy) {
+        return;
+    }
+
+    const original = button.innerHTML;
+    button.dataset.copyBusy = '1';
+    button.innerHTML = copied
+        ? '<i class="fa fa-check text-success"></i>'
+        : '<i class="fa fa-xmark text-danger"></i>';
+
+    window.setTimeout(() => {
+        button.innerHTML = original;
+        delete button.dataset.copyBusy;
+    }, 1200);
+}

--- a/src/Controller/Admin/AdminBoosterCodeBatchController.php
+++ b/src/Controller/Admin/AdminBoosterCodeBatchController.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Entity\Booster;
+use App\Entity\BoosterCode;
+use App\Repository\BoosterCodeRepository;
+use App\Service\Booster\BoosterCodeGenerator;
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Batch generation of redeemable codes. A batch is not an entity: the codes
+ * share a free-form label, which is enough to list, export and revoke them
+ * together — reusing a label simply grows the batch.
+ */
+class AdminBoosterCodeBatchController extends AbstractController
+{
+    private const int MAX_BATCH_SIZE = 1000;
+
+    public function __construct(
+        private readonly AdminUrlGenerator $adminUrlGenerator,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly BoosterCodeGenerator $boosterCodeGenerator,
+        private readonly BoosterCodeRepository $boosterCodeRepository,
+    ) {
+    }
+
+    /**
+     * $batch comes from the request attributes, not the query string: a custom
+     * admin route is reached through the dashboard, which re-injects its
+     * parameters as route attributes (see EA's AdminRouterSubscriber).
+     */
+    #[Route('/admin/booster-codes/batch', name: 'admin_booster_codes_batch')]
+    public function __invoke(Request $request, ?string $batch = null): Response
+    {
+        // The template extends the EasyAdmin layout, which needs the admin
+        // context: a direct hit bounces through the dashboard (same trick as
+        // the card batch page).
+        if (!$request->attributes->has(EA::CONTEXT_REQUEST_ATTRIBUTE)) {
+            return $this->redirect(
+                $this->adminUrlGenerator->setRoute('admin_booster_codes_batch', $request->query->all())->generateUrl(),
+            );
+        }
+
+        $form = $this->buildForm();
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            /** @var array{booster: Booster, batchLabel: string, count: int, quantity: int, maxUses: int|null, expiresAt: \DateTimeImmutable|null} $data */
+            $data = $form->getData();
+
+            foreach ($this->boosterCodeGenerator->generateBatch($data['count']) as $code) {
+                $this->entityManager->persist(
+                    new BoosterCode()
+                        ->setCode($code)
+                        ->setBooster($data['booster'])
+                        ->setBatchLabel($data['batchLabel'])
+                        ->setQuantity($data['quantity'])
+                        ->setMaxUses($data['maxUses'])
+                        ->setExpiresAt($data['expiresAt']),
+                );
+            }
+
+            $this->entityManager->flush();
+
+            $this->addFlash('success', \sprintf(
+                '%d code(s) généré(s) dans le lot « %s ».',
+                $data['count'],
+                $data['batchLabel'],
+            ));
+
+            return $this->redirect(
+                $this->adminUrlGenerator->setRoute('admin_booster_codes_batch', ['batch' => $data['batchLabel']])->generateUrl(),
+            );
+        }
+
+        return $this->render('admin/booster_code_batch.html.twig', [
+            'form' => $form->createView(),
+            'batchLabel' => $batch,
+            'batchCodes' => null !== $batch ? $this->boosterCodeRepository->findByBatch($batch) : [],
+        ]);
+    }
+
+    /**
+     * CSV of a whole batch — what actually gets pasted into a Discord DM or a
+     * giveaway sheet.
+     */
+    #[Route('/admin/booster-codes/batch/export', name: 'admin_booster_codes_batch_export')]
+    public function export(Request $request): Response
+    {
+        $batchLabel = $request->query->getString('batch');
+        $codes = '' !== $batchLabel ? $this->boosterCodeRepository->findByBatch($batchLabel) : [];
+
+        $handle = fopen('php://temp', 'r+b');
+        \assert(false !== $handle);
+
+        fputcsv($handle, ['code', 'booster', 'packs', 'max_uses', 'expire_le', 'lot'], ';', '"', '');
+
+        foreach ($codes as $code) {
+            fputcsv($handle, [
+                $code->getFormattedCode(),
+                $code->getBooster()->getDisplayName(),
+                $code->getQuantity(),
+                $code->getMaxUses() ?? 'illimité',
+                $code->getExpiresAt()?->setTimezone(new \DateTimeZone('Europe/Paris'))->format('d/m/Y H:i') ?? '',
+                $code->getBatchLabel() ?? '',
+            ], ';', '"', '');
+        }
+
+        rewind($handle);
+        $response = new Response((string) stream_get_contents($handle));
+        fclose($handle);
+
+        $response->headers->set('Content-Type', 'text/csv; charset=utf-8');
+        $response->headers->set(
+            'Content-Disposition',
+            $response->headers->makeDisposition('attachment', \sprintf('codes-%s.csv', $this->slugifyBatchLabel($batchLabel))),
+        );
+
+        return $response;
+    }
+
+    /**
+     * @return FormInterface<array{booster: Booster, batchLabel: string, count: int, quantity: int, maxUses: int|null, expiresAt: \DateTimeImmutable|null}|null>
+     */
+    private function buildForm(): FormInterface
+    {
+        return $this->createFormBuilder()
+            ->add('booster', EntityType::class, [
+                'class' => Booster::class,
+                'choice_label' => 'displayName',
+                'label' => 'Booster offert',
+                'help' => 'Un pack non récupérable sur le hub reste distribuable par code — c\'est le but.',
+            ])
+            ->add('batchLabel', TextType::class, [
+                'label' => 'Libellé du lot',
+                'help' => 'Sert à retrouver, exporter et révoquer les codes ensemble. Réutiliser un libellé agrandit le lot existant.',
+                'constraints' => [new Assert\NotBlank(), new Assert\Length(max: 100)],
+            ])
+            ->add('count', IntegerType::class, [
+                'label' => 'Nombre de codes',
+                'data' => 10,
+                'constraints' => [new Assert\Range(min: 1, max: self::MAX_BATCH_SIZE)],
+            ])
+            ->add('quantity', IntegerType::class, [
+                'label' => 'Packs crédités par code',
+                'data' => 1,
+                'constraints' => [new Assert\Range(min: 1, max: 100)],
+            ])
+            ->add('maxUses', IntegerType::class, [
+                'label' => 'Utilisations par code',
+                'required' => false,
+                'data' => 1,
+                'help' => '1 = code nominatif. Vide = illimité. Dans tous les cas, un joueur ne peut utiliser un code qu\'une fois.',
+                'constraints' => [new Assert\Range(min: 1, max: 100000)],
+            ])
+            ->add('expiresAt', DateTimeType::class, [
+                'label' => 'Expire le',
+                'required' => false,
+                'widget' => 'single_text',
+                'input' => 'datetime_immutable',
+                'view_timezone' => 'Europe/Paris',
+                'model_timezone' => 'UTC',
+                'help' => 'Heure de Paris. Vide = pas d\'expiration.',
+            ])
+            ->getForm()
+        ;
+    }
+
+    private function slugifyBatchLabel(string $batchLabel): string
+    {
+        $slug = trim((string) preg_replace('/[^a-z0-9]+/i', '-', $batchLabel), '-');
+
+        return '' !== $slug ? mb_strtolower($slug) : 'lot';
+    }
+}

--- a/src/Controller/Admin/AdminBoosterCodeBatchController.php
+++ b/src/Controller/Admin/AdminBoosterCodeBatchController.php
@@ -9,8 +9,7 @@ use App\Entity\BoosterCode;
 use App\Repository\BoosterCodeRepository;
 use App\Service\Booster\BoosterCodeGenerator;
 use Doctrine\ORM\EntityManagerInterface;
-use EasyCorp\Bundle\EasyAdminBundle\Config\Option\EA;
-use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
@@ -19,43 +18,32 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * Batch generation of redeemable codes. A batch is not an entity: the codes
  * share a free-form label, which is enough to list, export and revoke them
  * together — reusing a label simply grows the batch.
+ *
+ * Registered as a real admin route (#[AdminRoute], path appended to the
+ * dashboard's): the pages get plain URLs — /admin/booster-codes/batch — and
+ * the admin context, without the legacy ?routeName= redirect.
  */
+#[AdminRoute(path: '/booster-codes', name: 'booster_codes')]
 class AdminBoosterCodeBatchController extends AbstractController
 {
     private const int MAX_BATCH_SIZE = 1000;
 
     public function __construct(
-        private readonly AdminUrlGenerator $adminUrlGenerator,
         private readonly EntityManagerInterface $entityManager,
         private readonly BoosterCodeGenerator $boosterCodeGenerator,
         private readonly BoosterCodeRepository $boosterCodeRepository,
     ) {
     }
 
-    /**
-     * $batch comes from the request attributes, not the query string: a custom
-     * admin route is reached through the dashboard, which re-injects its
-     * parameters as route attributes (see EA's AdminRouterSubscriber).
-     */
-    #[Route('/admin/booster-codes/batch', name: 'admin_booster_codes_batch')]
-    public function __invoke(Request $request, ?string $batch = null): Response
+    #[AdminRoute(path: '/batch', name: 'batch')]
+    public function __invoke(Request $request): Response
     {
-        // The template extends the EasyAdmin layout, which needs the admin
-        // context: a direct hit bounces through the dashboard (same trick as
-        // the card batch page).
-        if (!$request->attributes->has(EA::CONTEXT_REQUEST_ATTRIBUTE)) {
-            return $this->redirect(
-                $this->adminUrlGenerator->setRoute('admin_booster_codes_batch', $request->query->all())->generateUrl(),
-            );
-        }
-
         $form = $this->buildForm();
         $form->handleRequest($request);
 
@@ -83,15 +71,15 @@ class AdminBoosterCodeBatchController extends AbstractController
                 $data['batchLabel'],
             ));
 
-            return $this->redirect(
-                $this->adminUrlGenerator->setRoute('admin_booster_codes_batch', ['batch' => $data['batchLabel']])->generateUrl(),
-            );
+            return $this->redirectToRoute('admin_booster_codes_batch', ['batch' => $data['batchLabel']]);
         }
+
+        $batchLabel = $request->query->getString('batch');
 
         return $this->render('admin/booster_code_batch.html.twig', [
             'form' => $form->createView(),
-            'batchLabel' => $batch,
-            'batchCodes' => null !== $batch ? $this->boosterCodeRepository->findByBatch($batch) : [],
+            'batchLabel' => '' !== $batchLabel ? $batchLabel : null,
+            'batchCodes' => '' !== $batchLabel ? $this->boosterCodeRepository->findByBatch($batchLabel) : [],
         ]);
     }
 
@@ -99,7 +87,7 @@ class AdminBoosterCodeBatchController extends AbstractController
      * CSV of a whole batch — what actually gets pasted into a Discord DM or a
      * giveaway sheet.
      */
-    #[Route('/admin/booster-codes/batch/export', name: 'admin_booster_codes_batch_export')]
+    #[AdminRoute(path: '/batch/export', name: 'batch_export')]
     public function export(Request $request): Response
     {
         $batchLabel = $request->query->getString('batch');

--- a/src/Controller/Admin/BoosterCodeCrudController.php
+++ b/src/Controller/Admin/BoosterCodeCrudController.php
@@ -95,7 +95,9 @@ class BoosterCodeCrudController extends AbstractReadOnlyCrudController
     public function configureFields(string $pageName): iterable
     {
         // computed getters: no column to ORDER BY behind them
-        yield TextField::new('formattedCode')->setLabel('Code')->setSortable(false);
+        yield TextField::new('formattedCode')->setLabel('Code')->setSortable(false)
+            ->setTemplatePath('admin/field/booster_code.html.twig')
+        ;
         yield AssociationField::new('booster')->setLabel('Booster');
         yield IntegerField::new('quantity')->setLabel('Packs');
         yield TextField::new('usageLabel')->setLabel('Utilisations')->setSortable(false);

--- a/src/Controller/Admin/BoosterCodeCrudController.php
+++ b/src/Controller/Admin/BoosterCodeCrudController.php
@@ -54,7 +54,7 @@ class BoosterCodeCrudController extends AbstractReadOnlyCrudController
             ->setSearchFields(['code', 'batchLabel', 'booster.name'])
             ->setTimezone('Europe/Paris')
             ->setPaginatorPageSize(50)
-            ->setHelp(Crud::PAGE_INDEX, 'Les codes se créent depuis « Générer des codes ». Ici tu consultes leur consommation et tu peux les révoquer.')
+            ->setHelp(Crud::PAGE_INDEX, 'Les codes se créent depuis « Générer des codes ». Pour en révoquer (ou réactiver), coche les lignes concernées : les boutons apparaissent en bas de la liste. Un code révoqué garde son historique — on ne les supprime pas.')
         ;
     }
 

--- a/src/Controller/Admin/BoosterCodeCrudController.php
+++ b/src/Controller/Admin/BoosterCodeCrudController.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Entity\BoosterCode;
+use Doctrine\ORM\EntityManagerInterface;
+use EasyCorp\Bundle\EasyAdminBundle\Attribute\AdminRoute;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
+use EasyCorp\Bundle\EasyAdminBundle\Dto\BatchActionDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\BooleanFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\DateTimeFilter;
+use EasyCorp\Bundle\EasyAdminBundle\Filter\TextFilter;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+/**
+ * Codes are generated from the batch page, never hand-written: this CRUD is
+ * consultation plus revocation. Revoking keeps the row and its redemption
+ * history — a deleted code would take the audit trail with it.
+ *
+ * @extends AbstractReadOnlyCrudController<BoosterCode>
+ */
+class BoosterCodeCrudController extends AbstractReadOnlyCrudController
+{
+    public function __construct(
+        private readonly EntityManagerInterface $entityManager,
+    ) {
+    }
+
+    public static function getEntityFqcn(): string
+    {
+        return BoosterCode::class;
+    }
+
+    #[\Override]
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Code')
+            ->setEntityLabelInPlural('Codes')
+            ->setDefaultSort(['createdAt' => 'DESC'])
+            ->setSearchFields(['code', 'batchLabel', 'booster.name'])
+            ->setTimezone('Europe/Paris')
+            ->setPaginatorPageSize(50)
+            ->setHelp(Crud::PAGE_INDEX, 'Les codes se créent depuis « Générer des codes ». Ici tu consultes leur consommation et tu peux les révoquer.')
+        ;
+    }
+
+    #[\Override]
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters
+            ->add('booster')
+            ->add(TextFilter::new('batchLabel', 'Lot'))
+            ->add(BooleanFilter::new('disabled', 'Révoqué'))
+            ->add(DateTimeFilter::new('expiresAt', 'Expiration'))
+        ;
+    }
+
+    #[\Override]
+    public function configureActions(Actions $actions): Actions
+    {
+        return parent::configureActions($actions)
+            ->addBatchAction(
+                Action::new('revokeCodes', 'Révoquer')
+                    ->linkToCrudAction('revokeCodes')
+                    ->addCssClass('btn btn-danger')
+                    ->setIcon('fa fa-ban'),
+            )
+            ->addBatchAction(
+                Action::new('restoreCodes', 'Réactiver')
+                    ->linkToCrudAction('restoreCodes')
+                    ->addCssClass('btn btn-secondary')
+                    ->setIcon('fa fa-rotate-left'),
+            )
+        ;
+    }
+
+    /**
+     * @SuppressWarnings("PHPMD.UnusedFormalParameter")
+     */
+    #[\Override]
+    public function configureFields(string $pageName): iterable
+    {
+        // computed getters: no column to ORDER BY behind them
+        yield TextField::new('formattedCode')->setLabel('Code')->setSortable(false);
+        yield AssociationField::new('booster')->setLabel('Booster');
+        yield IntegerField::new('quantity')->setLabel('Packs');
+        yield TextField::new('usageLabel')->setLabel('Utilisations')->setSortable(false);
+        yield DateTimeField::new('expiresAt')->setLabel('Expire le');
+        yield BooleanField::new('disabled')->setLabel('Révoqué')->renderAsSwitch(false);
+        yield TextField::new('batchLabel')->setLabel('Lot');
+        yield DateTimeField::new('createdAt')->setLabel('Créé le')->onlyOnDetail();
+        yield Field::new('id')->setLabel('Identifiant')->onlyOnDetail();
+    }
+
+    /**
+     * @param AdminContext<BoosterCode>   $context
+     * @param BatchActionDto<BoosterCode> $batchActionDto
+     */
+    #[AdminRoute]
+    public function revokeCodes(AdminContext $context, BatchActionDto $batchActionDto): Response
+    {
+        return $this->applyRevocationBatch($context, $batchActionDto, true, 'révoqué(s)');
+    }
+
+    /**
+     * @param AdminContext<BoosterCode>   $context
+     * @param BatchActionDto<BoosterCode> $batchActionDto
+     */
+    #[AdminRoute]
+    public function restoreCodes(AdminContext $context, BatchActionDto $batchActionDto): Response
+    {
+        return $this->applyRevocationBatch($context, $batchActionDto, false, 'réactivé(s)');
+    }
+
+    /**
+     * Same guards as EasyAdmin's native batchDelete: reject a posted FQCN that
+     * does not target this CRUD, then check the CSRF token bound to the action
+     * AND the FQCN.
+     *
+     * @param AdminContext<BoosterCode>   $context
+     * @param BatchActionDto<BoosterCode> $batchActionDto
+     */
+    private function applyRevocationBatch(AdminContext $context, BatchActionDto $batchActionDto, bool $disabled, string $successLabel): Response
+    {
+        if (BoosterCode::class !== $batchActionDto->getEntityFqcn()) {
+            throw new BadRequestHttpException();
+        }
+
+        if (!$this->isCsrfTokenValid('ea-batch-action-' . $batchActionDto->getName() . '-' . $batchActionDto->getEntityFqcn(), $batchActionDto->getCsrfToken())) {
+            return $this->redirectToRoute($context->getDashboardRouteName());
+        }
+
+        $updated = 0;
+        foreach ($batchActionDto->getEntityIds() as $entityId) {
+            $boosterCode = $this->entityManager->find(BoosterCode::class, $entityId);
+            if ($boosterCode instanceof BoosterCode && $disabled !== $boosterCode->isDisabled()) {
+                $boosterCode->setDisabled($disabled);
+                ++$updated;
+            }
+        }
+        $this->entityManager->flush();
+
+        $this->addFlash('success', \sprintf('%d code%s %s.', $updated, $updated > 1 ? 's' : '', $successLabel));
+
+        return $this->redirect($context->getRequest()->headers->get('referer') ?? '/admin');
+    }
+}

--- a/src/Controller/Admin/BoosterCodeRedemptionCrudController.php
+++ b/src/Controller/Admin/BoosterCodeRedemptionCrudController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller\Admin;
+
+use App\Entity\BoosterCodeRedemption;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Filters;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
+use EasyCorp\Bundle\EasyAdminBundle\Field\IntegerField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+
+/**
+ * @extends AbstractReadOnlyCrudController<BoosterCodeRedemption>
+ */
+class BoosterCodeRedemptionCrudController extends AbstractReadOnlyCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return BoosterCodeRedemption::class;
+    }
+
+    #[\Override]
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Utilisation de code')
+            ->setEntityLabelInPlural('Utilisations de codes')
+            ->setDefaultSort(['redeemedAt' => 'DESC'])
+            ->setSearchFields(['discordUser.username', 'discordUser.discordId', 'boosterCode.code', 'boosterCode.batchLabel'])
+            ->setTimezone('Europe/Paris')
+            ->setHelp(Crud::PAGE_INDEX, 'Qui a utilisé quel code, et combien de packs ont été crédités.')
+        ;
+    }
+
+    #[\Override]
+    public function configureFilters(Filters $filters): Filters
+    {
+        return $filters->add('boosterCode');
+    }
+
+    /**
+     * @SuppressWarnings("PHPMD.UnusedFormalParameter")
+     */
+    #[\Override]
+    public function configureFields(string $pageName): iterable
+    {
+        yield DateTimeField::new('redeemedAt')->setLabel('Utilisé le');
+        yield TextField::new('discordUser.username')->setLabel('Joueur');
+        yield AssociationField::new('boosterCode')->setLabel('Code');
+        yield IntegerField::new('quantity')->setLabel('Packs crédités');
+        yield TextField::new('discordUser.discordId')->setLabel('Discord ID')->onlyOnDetail();
+        yield Field::new('id')->setLabel('Identifiant')->onlyOnDetail();
+    }
+}

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -67,6 +67,11 @@ class DashboardController extends AbstractDashboardController
         yield MenuItem::linkTo(ExtensionBannerCrudController::class, 'Bannières d\'univers', 'fa fa-image');
         yield MenuItem::linkTo(BoosterCrudController::class, 'Boosters', 'fa fa-box-open');
 
+        yield MenuItem::section('Distribution');
+        yield MenuItem::linkToRoute('Générer des codes', 'fa fa-ticket', 'admin_booster_codes_batch');
+        yield MenuItem::linkTo(BoosterCodeCrudController::class, 'Codes', 'fa fa-key');
+        yield MenuItem::linkTo(BoosterCodeRedemptionCrudController::class, 'Utilisations de codes', 'fa fa-check-double');
+
         yield MenuItem::section('Économie (lecture seule)');
         yield MenuItem::linkTo(DiscordUserCrudController::class, 'Joueurs', 'fa fa-users');
         yield MenuItem::linkTo(BoosterOpeningCrudController::class, 'Ouvertures', 'fa fa-box-open');

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -54,7 +54,13 @@ class DashboardController extends AbstractDashboardController
         $adminCss = $this->assetMapper->getAsset('styles/admin/admin.css')
             ?? throw new \LogicException('Asset "styles/admin/admin.css" not found in the asset map.');
 
-        return parent::configureAssets()->addCssFile($adminCss->publicPath);
+        $copyJs = $this->assetMapper->getAsset('scripts/admin/copy-to-clipboard.js')
+            ?? throw new \LogicException('Asset "scripts/admin/copy-to-clipboard.js" not found in the asset map.');
+
+        return parent::configureAssets()
+            ->addCssFile($adminCss->publicPath)
+            ->addJsFile($copyJs->publicPath)
+        ;
     }
 
     #[\Override]

--- a/src/Entity/BoosterCode.php
+++ b/src/Entity/BoosterCode.php
@@ -95,6 +95,14 @@ class BoosterCode implements \Stringable
         return implode('-', str_split($this->code, 4));
     }
 
+    /**
+     * Consumption at a glance for the back-office: "3 / 10", "3 / ∞".
+     */
+    public function getUsageLabel(): string
+    {
+        return \sprintf('%d / %s', $this->uses, $this->maxUses ?? '∞');
+    }
+
     public function getBooster(): Booster
     {
         return $this->booster;

--- a/src/Repository/BoosterCodeRepository.php
+++ b/src/Repository/BoosterCodeRepository.php
@@ -36,6 +36,20 @@ class BoosterCodeRepository extends ServiceEntityRepository
     }
 
     /**
+     * @return list<BoosterCode>
+     */
+    public function findByBatch(string $batchLabel): array
+    {
+        return $this->createQueryBuilder('boosterCode')
+            ->andWhere('boosterCode.batchLabel = :batchLabel')
+            ->setParameter('batchLabel', $batchLabel)
+            ->orderBy('boosterCode.code', 'ASC')
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+
+    /**
      * Codes of the given list that already exist, so a generated batch can be
      * rerolled before hitting the unique index.
      *

--- a/templates/admin/booster_code_batch.html.twig
+++ b/templates/admin/booster_code_batch.html.twig
@@ -1,0 +1,59 @@
+{% extends '@EasyAdmin/page/content.html.twig' %}
+
+{% form_theme form '@EasyAdmin/crud/form_theme.html.twig' %}
+
+{% block content_title %}🎟️ Génération de codes{% endblock %}
+
+{% block main %}
+    <div style="max-width: 720px;">
+        <p>
+            Chaque code donne droit au booster choisi, <strong>sans toucher au quota
+            quotidien</strong> de récupération. Un joueur ne peut utiliser un code
+            qu'une seule fois, même sur un code à usages multiples. Un code dont
+            l'extension est encore en brouillon est refusé <em>sans être consommé</em> :
+            il redeviendra utilisable à la publication.
+        </p>
+
+        {{ form_start(form) }}
+            <div class="mb-3">{{ form_errors(form) }}</div>
+            <div class="mb-3">{{ form_row(form.booster) }}</div>
+            <div class="mb-3">{{ form_row(form.batchLabel) }}</div>
+            <div class="mb-3">{{ form_row(form.count) }}</div>
+            <div class="mb-3">{{ form_row(form.quantity) }}</div>
+            <div class="mb-3">{{ form_row(form.maxUses) }}</div>
+            <div class="mb-3">{{ form_row(form.expiresAt) }}</div>
+            <button type="submit" class="btn btn-primary">Générer les codes</button>
+        {{ form_end(form) }}
+
+        {% if batchLabel %}
+            <hr class="my-4">
+            <h2 class="h5">Lot « {{ batchLabel }} » — {{ batchCodes|length }} code(s)</h2>
+
+            {% if batchCodes is empty %}
+                <p>Aucun code sous ce libellé.</p>
+            {% else %}
+                <p>
+                    <a class="btn btn-secondary" href="{{ path('admin_booster_codes_batch_export', {batch: batchLabel}) }}">
+                        <i class="fa fa-download"></i> Télécharger le CSV
+                    </a>
+                </p>
+                <div style="max-height: 320px; overflow-y: auto;">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr><th>Code</th><th>Booster</th><th>Utilisations</th></tr>
+                        </thead>
+                        <tbody>
+                            {% for code in batchCodes %}
+                                <tr>
+                                    <td><code>{{ code.formattedCode }}</code></td>
+                                    <td>{{ code.booster.displayName }}</td>
+                                    <td>{{ code.uses }} / {{ code.maxUses ?? '∞' }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+        {% endif %}
+    </div>
+{% endblock %}

--- a/templates/admin/booster_code_batch.html.twig
+++ b/templates/admin/booster_code_batch.html.twig
@@ -32,10 +32,16 @@
             {% if batchCodes is empty %}
                 <p>Aucun code sous ce libellé.</p>
             {% else %}
-                <p>
+                <p class="d-flex gap-2">
                     <a class="btn btn-secondary" href="{{ path('admin_booster_codes_batch_export', {batch: batchLabel}) }}">
                         <i class="fa fa-download"></i> Télécharger le CSV
                     </a>
+                    {# one code per line: ready to paste into a message or a sheet #}
+                    <button type="button" class="btn btn-secondary"
+                            data-copy-value="{{ batchCodes|map(code => code.formattedCode)|join("\n") }}"
+                            title="Copier les codes, un par ligne">
+                        <i class="fa fa-copy"></i> Copier les {{ batchCodes|length }} codes
+                    </button>
                 </p>
                 <div style="max-height: 320px; overflow-y: auto;">
                     <table class="table table-striped">
@@ -45,7 +51,15 @@
                         <tbody>
                             {% for code in batchCodes %}
                                 <tr>
-                                    <td><code>{{ code.formattedCode }}</code></td>
+                                    <td class="text-nowrap">
+                                        <code>{{ code.formattedCode }}</code>
+                                        <button type="button" class="btn btn-link btn-sm p-0 ms-2 align-baseline"
+                                                data-copy-value="{{ code.formattedCode }}"
+                                                title="Copier le code"
+                                                aria-label="Copier le code {{ code.formattedCode }}">
+                                            <i class="fa fa-copy"></i>
+                                        </button>
+                                    </td>
                                     <td>{{ code.booster.displayName }}</td>
                                     <td>{{ code.uses }} / {{ code.maxUses ?? '∞' }}</td>
                                 </tr>

--- a/templates/admin/field/booster_code.html.twig
+++ b/templates/admin/field/booster_code.html.twig
@@ -1,0 +1,12 @@
+{# Code + copy button (listing and detail). The JS lives in
+   assets/scripts/admin/copy-to-clipboard.js, loaded by the dashboard. #}
+<span class="text-nowrap">
+    <code>{{ field.formattedValue }}</code>
+    <button type="button"
+            class="btn btn-link btn-sm p-0 ms-2 align-baseline"
+            data-copy-value="{{ field.formattedValue }}"
+            title="Copier le code"
+            aria-label="Copier le code {{ field.formattedValue }}">
+        <i class="fa fa-copy"></i>
+    </button>
+</span>

--- a/templates/admin/guide.html.twig
+++ b/templates/admin/guide.html.twig
@@ -36,6 +36,7 @@
                 <li><a href="#booster">Booster &amp; taux de drop</a></li>
                 <li><a href="#bannieres">Bannières d'univers</a></li>
                 <li><a href="#tailles">Récap : tailles d'images recommandées</a></li>
+                <li><a href="#codes">Codes de récupération</a></li>
                 <li><a href="#economie">Économie : les écrans de consultation</a></li>
                 <li><a href="#ne-pas-toucher">Ce qu'on ne touche jamais à la main</a></li>
             </ol>
@@ -182,7 +183,24 @@
             <tr><td>Bannière univers</td><td>Bannières d'univers</td><td>1920×640 min paysage</td><td>Texte de la page superposé en bas à gauche.</td></tr>
         </table>
 
-        <h2 id="economie">10. Économie : les écrans de consultation</h2>
+        <h2 id="codes">10. Codes de récupération</h2>
+        <p>
+            Un code donne un ou plusieurs exemplaires d'un booster <strong>sans consommer
+            le quota quotidien</strong> du joueur. C'est le canal pour les events, les
+            giveaways et les dédommagements — y compris pour les packs marqués
+            <strong>non récupérables</strong> sur le hub.
+        </p>
+        <ul>
+            <li><strong>Générer des codes</strong> : on choisit le booster, un libellé de lot, le nombre de codes, les packs crédités par code, les utilisations autorisées et une date d'expiration facultative. Le lot s'affiche ensuite sous le formulaire, avec un <strong>export CSV</strong>.</li>
+            <li><strong>Code nominatif</strong> = 1 utilisation. <strong>Code public</strong> (Discord, stream) = plusieurs utilisations, ou vide pour illimité. Dans tous les cas, <strong>un joueur ne peut utiliser un code qu'une seule fois</strong>.</li>
+            <li><strong>Libellé du lot</strong> : c'est la seule façon de retrouver un lot. Réutiliser le même libellé agrandit le lot existant (et son export).</li>
+            <li><strong>Révocation</strong> : dans « Codes », coche les lignes puis « Révoquer ». Le code reste en base avec son historique — on ne supprime jamais un code.</li>
+            <li><strong>Extension en brouillon</strong> : le code est refusé <em>sans être consommé</em>. On peut donc distribuer les codes avant la sortie, ils s'activeront à la publication.</li>
+            <li><strong>Expiration</strong> : saisie en heure de Paris.</li>
+        </ul>
+        <div class="tip">« Utilisations de codes » liste qui a utilisé quoi et combien de packs ont été crédités.</div>
+
+        <h2 id="economie">11. Économie : les écrans de consultation</h2>
         <p>
             La section <strong>« Économie (lecture seule) »</strong> du menu donne la visibilité
             sur ce que font les joueurs. Ces trois écrans n'ont <strong>ni création, ni édition,
@@ -197,11 +215,11 @@
         </table>
         <div class="tip">Les dates de ces écrans sont affichées en heure de Paris, comme la remise à zéro du quota.</div>
 
-        <h2 id="ne-pas-toucher">11. Ce qu'on ne touche jamais à la main</h2>
+        <h2 id="ne-pas-toucher">12. Ce qu'on ne touche jamais à la main</h2>
         <ul>
             <li><strong>Utilisateurs Discord et rôles</strong> : créés et synchronisés automatiquement à la connexion (JWT). Ne jamais créer/modifier en base.</li>
             <li><strong>Inventaires</strong> (cartes et boosters possédés) : alimentés par les claims et les ouvertures. Une retouche manuelle fausse les compteurs et l'historique.</li>
-            <li><strong>Historique d'ouverture</strong> (claims, openings, seed RNG) : c'est l'audit — chaque tirage est rejouable grâce à sa seed. Consultable dans la section « Économie » (<a href="#economie">§10</a>), jamais modifiable.</li>
+            <li><strong>Historique d'ouverture</strong> (claims, openings, seed RNG) : c'est l'audit — chaque tirage est rejouable grâce à sa seed. Consultable dans la section « Économie » (<a href="#economie">§11</a>), jamais modifiable.</li>
             <li><strong>claimedBy d'une carte unique</strong> : posé atomiquement par le premier tirage. Le vider rendrait l'unique tirable une deuxième fois.</li>
         </ul>
     </div>

--- a/tests/Functional/AdminBoosterCodeBatchTest.php
+++ b/tests/Functional/AdminBoosterCodeBatchTest.php
@@ -57,6 +57,33 @@ final class AdminBoosterCodeBatchTest extends WebTestCase
 
         // the batch is listed back, formatted, right under the form
         $this->assertStringContainsString($codes[0]->getFormattedCode(), $crawler->filter('body')->text());
+
+        // one copy button per code, plus one for the whole batch
+        $this->assertCount(
+            6,
+            $crawler->filter('[data-copy-value]'),
+            'Each code carries a copy button, and the batch has its own.',
+        );
+    }
+
+    public function testTheCodeListingOffersACopyButton(): void
+    {
+        $client = self::createClient();
+        $this->authenticateClient($client);
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $code = new BoosterCode()
+            ->setCode('ABCDEFGHJKLM')
+            ->setBooster($this->createBooster())
+            ->setBatchLabel('Copie ' . uniqid())
+        ;
+        $entityManager->persist($code);
+        $entityManager->flush();
+
+        $crawler = $client->request('GET', '/admin/booster-code?query=' . urlencode((string) $code->getBatchLabel()));
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(1, $crawler->filter('[data-copy-value="ABCD-EFGH-JKLM"]'));
     }
 
     public function testAnEmptyMaxUsesMeansUnlimited(): void

--- a/tests/Functional/AdminBoosterCodeBatchTest.php
+++ b/tests/Functional/AdminBoosterCodeBatchTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Booster;
+use App\Entity\BoosterCode;
+use App\Entity\Extension;
+use App\Enum\Entity\ExtensionStatusEnum;
+use App\Repository\BoosterCodeRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class AdminBoosterCodeBatchTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    public function testBatchGeneratesTheRequestedCodesAndListsThem(): void
+    {
+        $client = self::createClient();
+        $client->followRedirects();
+        $this->authenticateClient($client);
+
+        $booster = $this->createBooster();
+        $batchLabel = 'Gamescom ' . uniqid();
+
+        $crawler = $client->request('GET', '/admin/booster-codes/batch');
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->selectButton('Générer les codes')->form([
+            'form[booster]' => (string) $booster->getId(),
+            'form[batchLabel]' => $batchLabel,
+            'form[count]' => '5',
+            'form[quantity]' => '2',
+            'form[maxUses]' => '3',
+            'form[expiresAt]' => '2026-12-24T20:00',
+        ]);
+        $crawler = $client->submit($form);
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('5 code(s) généré(s)', $crawler->filter('body')->text());
+
+        /** @var list<BoosterCode> $codes */
+        $codes = self::getContainer()->get(BoosterCodeRepository::class)->findByBatch($batchLabel);
+        $this->assertCount(5, $codes);
+
+        foreach ($codes as $code) {
+            $this->assertSame($booster->getId(), $code->getBooster()->getId());
+            $this->assertSame(2, $code->getQuantity());
+            $this->assertSame(3, $code->getMaxUses());
+            $this->assertSame(0, $code->getUses());
+            $this->assertMatchesRegularExpression('/^[A-Z2-9]{12}$/', $code->getCode());
+            // typed in Paris time, stored in UTC
+            $this->assertSame('2026-12-24 19:00:00', $code->getExpiresAt()?->format('Y-m-d H:i:s'));
+        }
+
+        // the batch is listed back, formatted, right under the form
+        $this->assertStringContainsString($codes[0]->getFormattedCode(), $crawler->filter('body')->text());
+    }
+
+    public function testAnEmptyMaxUsesMeansUnlimited(): void
+    {
+        $client = self::createClient();
+        $client->followRedirects();
+        $this->authenticateClient($client);
+
+        $booster = $this->createBooster();
+        $batchLabel = 'Illimité ' . uniqid();
+
+        $crawler = $client->request('GET', '/admin/booster-codes/batch');
+        $form = $crawler->selectButton('Générer les codes')->form([
+            'form[booster]' => (string) $booster->getId(),
+            'form[batchLabel]' => $batchLabel,
+            'form[count]' => '1',
+            'form[quantity]' => '1',
+            'form[maxUses]' => '',
+        ]);
+        $client->submit($form);
+
+        $codes = self::getContainer()->get(BoosterCodeRepository::class)->findByBatch($batchLabel);
+        $this->assertCount(1, $codes);
+        $this->assertNull($codes[0]->getMaxUses());
+        $this->assertNull($codes[0]->getExpiresAt());
+    }
+
+    public function testBatchSizeIsCapped(): void
+    {
+        $client = self::createClient();
+        $client->followRedirects();
+        $this->authenticateClient($client);
+
+        $booster = $this->createBooster();
+        $batchLabel = 'Trop gros ' . uniqid();
+
+        $crawler = $client->request('GET', '/admin/booster-codes/batch');
+        $form = $crawler->selectButton('Générer les codes')->form([
+            'form[booster]' => (string) $booster->getId(),
+            'form[batchLabel]' => $batchLabel,
+            'form[count]' => '5000',
+            'form[quantity]' => '1',
+            'form[maxUses]' => '1',
+        ]);
+        $client->submit($form);
+
+        self::assertResponseIsSuccessful();
+        $this->assertSame([], self::getContainer()->get(BoosterCodeRepository::class)->findByBatch($batchLabel));
+    }
+
+    public function testExportReturnsTheBatchAsCsv(): void
+    {
+        $client = self::createClient();
+        $this->authenticateClient($client);
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $booster = $this->createBooster();
+        $batchLabel = 'Export ' . uniqid();
+
+        $code = new BoosterCode()
+            ->setCode('ABCDEFGHJKLM')
+            ->setBooster($booster)
+            ->setBatchLabel($batchLabel)
+        ;
+        $entityManager->persist($code);
+        $entityManager->flush();
+
+        $client->request('GET', '/admin/booster-codes/batch/export?batch=' . urlencode($batchLabel));
+
+        self::assertResponseIsSuccessful();
+        self::assertResponseHeaderSame('Content-Type', 'text/csv; charset=utf-8');
+
+        $csv = $client->getResponse()->getContent();
+        \assert(false !== $csv);
+        $this->assertStringContainsString('ABCD-EFGH-JKLM', $csv);
+        $this->assertStringContainsString($batchLabel, $csv);
+    }
+
+    public function testTheBatchPageIsAdminOnly(): void
+    {
+        $client = self::createClient();
+
+        $client->request('GET', '/admin/booster-codes/batch');
+
+        $this->assertNotSame(200, $client->getResponse()->getStatusCode());
+    }
+
+    private function createBooster(): Booster
+    {
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+
+        $extension = new Extension()
+            ->setName('Code batch extension ' . uniqid())
+            ->setDescription('Test')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $entityManager->persist($extension);
+
+        $booster = new Booster()
+            ->setExtension($extension)
+            ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]])
+        ;
+        $booster->setImageName('default_card.png');
+        $entityManager->persist($booster);
+        $entityManager->flush();
+
+        return $booster;
+    }
+}

--- a/tests/Functional/AdminBoosterCodeRevokeTest.php
+++ b/tests/Functional/AdminBoosterCodeRevokeTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Booster;
+use App\Entity\BoosterCode;
+use App\Entity\Card;
+use App\Entity\Extension;
+use App\Enum\Entity\ExtensionStatusEnum;
+use App\Service\Booster\BoosterCodeGenerator;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Same flow as the card status batch actions: the CSRF token and the action
+ * URL are read on the listing button, then posted like EasyAdmin's JS does.
+ */
+final class AdminBoosterCodeRevokeTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private const string INDEX_URL = '/admin/booster-code';
+
+    private KernelBrowser $client;
+
+    private EntityManagerInterface $entityManager;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->authenticateClient($this->client);
+    }
+
+    public function testBatchRevokeOnlyDisablesSelectedCodes(): void
+    {
+        [$first, $second, $untouched] = $this->createCodes(3);
+
+        $this->submitBatchAction('revokeCodes', [$first, $second]);
+
+        self::assertResponseRedirects();
+        $this->assertDisabled(true, [$first, $second]);
+        $this->assertDisabled(false, [$untouched]);
+    }
+
+    public function testBatchRestoreReenablesRevokedCodes(): void
+    {
+        [$code] = $this->createCodes(1, disabled: true);
+
+        $this->submitBatchAction('restoreCodes', [$code]);
+
+        self::assertResponseRedirects();
+        $this->assertDisabled(false, [$code]);
+    }
+
+    public function testInvalidCsrfTokenChangesNothing(): void
+    {
+        [$code] = $this->createCodes(1);
+
+        $this->submitBatchAction('revokeCodes', [$code], csrfToken: 'forged-token');
+
+        self::assertResponseRedirects();
+        $this->assertDisabled(false, [$code]);
+    }
+
+    public function testMismatchedEntityFqcnIsRejected(): void
+    {
+        [$code] = $this->createCodes(1);
+
+        $this->submitBatchAction('revokeCodes', [$code], entityFqcn: Card::class);
+
+        self::assertResponseStatusCodeSame(400);
+        $this->assertDisabled(false, [$code]);
+    }
+
+    /**
+     * @param list<BoosterCode> $codes
+     */
+    private function submitBatchAction(string $actionName, array $codes, ?string $csrfToken = null, ?string $entityFqcn = null): void
+    {
+        $crawler = $this->client->request('GET', self::INDEX_URL);
+        self::assertResponseIsSuccessful();
+
+        // EA5 pretty URLs are kebab-case: revokeCodes -> /admin/booster-code/revoke-codes
+        $actionPath = strtolower((string) preg_replace('/([a-z])([A-Z])/', '$1-$2', $actionName));
+        $button = $crawler->filter(\sprintf('[data-action-batch="true"][data-action-url*="%s"]', $actionPath));
+        $this->assertCount(1, $button, \sprintf('Le bouton batch "%s" doit être présent sur le listing.', $actionName));
+
+        $entityFqcn ??= BoosterCode::class;
+        $csrfToken ??= (string) $button->attr('data-action-csrf-token');
+
+        $this->client->request('POST', (string) $button->attr('data-action-url'), [
+            'batchActionName' => $actionName,
+            'entityFqcn' => $entityFqcn,
+            'batchActionUrl' => (string) $button->attr('data-action-url'),
+            'batchActionCsrfToken' => $csrfToken,
+            'batchActionEntityIds' => array_map(static fn (BoosterCode $code): string => (string) $code->getId(), $codes),
+        ]);
+    }
+
+    /**
+     * @return list<BoosterCode>
+     */
+    private function createCodes(int $count, bool $disabled = false): array
+    {
+        $extension = new Extension()
+            ->setName('Revoke test extension ' . uniqid())
+            ->setDescription('Test')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($extension);
+
+        $booster = new Booster()
+            ->setExtension($extension)
+            ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]])
+        ;
+        $booster->setImageName('default_card.png');
+        $this->entityManager->persist($booster);
+
+        $generator = self::getContainer()->get(BoosterCodeGenerator::class);
+
+        $codes = [];
+        foreach (range(1, $count) as $ignored) {
+            $code = new BoosterCode()
+                ->setCode($generator->generate())
+                ->setBooster($booster)
+                ->setBatchLabel('Revoke test')
+                ->setDisabled($disabled)
+            ;
+            $this->entityManager->persist($code);
+            $codes[] = $code;
+        }
+        $this->entityManager->flush();
+
+        return $codes;
+    }
+
+    /**
+     * @param list<BoosterCode> $codes
+     */
+    private function assertDisabled(bool $expected, array $codes): void
+    {
+        $this->entityManager->clear();
+
+        foreach ($codes as $code) {
+            $this->assertSame(
+                $expected,
+                $this->entityManager->getRepository(BoosterCode::class)->find($code->getId())?->isDisabled(),
+            );
+        }
+    }
+}

--- a/tests/Functional/AdminReadOnlyCrudTest.php
+++ b/tests/Functional/AdminReadOnlyCrudTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Tests\Functional;
 
 use App\Controller\Admin\BoosterClaimCrudController;
+use App\Controller\Admin\BoosterCodeCrudController;
+use App\Controller\Admin\BoosterCodeRedemptionCrudController;
 use App\Controller\Admin\BoosterOpeningCrudController;
 use App\Controller\Admin\DiscordUserCrudController;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -28,6 +30,8 @@ final class AdminReadOnlyCrudTest extends WebTestCase
         yield 'joueurs' => [DiscordUserCrudController::class];
         yield 'ouvertures' => [BoosterOpeningCrudController::class];
         yield 'recuperations' => [BoosterClaimCrudController::class];
+        yield 'codes' => [BoosterCodeCrudController::class];
+        yield 'utilisations-de-codes' => [BoosterCodeRedemptionCrudController::class];
     }
 
     /**
@@ -99,6 +103,8 @@ final class AdminReadOnlyCrudTest extends WebTestCase
             DiscordUserCrudController::class => '/admin/discord-user',
             BoosterOpeningCrudController::class => '/admin/booster-opening',
             BoosterClaimCrudController::class => '/admin/booster-claim',
+            BoosterCodeCrudController::class => '/admin/booster-code',
+            BoosterCodeRedemptionCrudController::class => '/admin/booster-code-redemption',
             default => throw new \LogicException('Unknown CRUD ' . $controllerFqcn),
         };
 

--- a/translations/EasyAdminBundle.fr.yaml
+++ b/translations/EasyAdminBundle.fr.yaml
@@ -1,0 +1,4 @@
+# EasyAdmin annonce « Cette action est irréversible » sur TOUTES les actions de
+# lot, alors que les nôtres se défont toutes (publier/brouillon, révoquer/
+# réactiver). Formulation neutre : elle reste vraie quelle que soit l'action.
+batch_action_modal.content: Confirme pour appliquer l'action aux éléments sélectionnés.


### PR DESCRIPTION
Empilée sur #133 (base = `feat/phase-4-booster-codes`) — à merger après elle.

## Ce que ça fait

**Générer des codes** (`/admin/booster-codes/batch`, menu « Distribution ») : booster, libellé de lot, nombre de codes, packs crédités par code, utilisations autorisées, expiration facultative. Le lot généré s'affiche sous le formulaire, avec un **export CSV**.

**Codes** : listing lecture seule, filtres (booster, lot, révoqué, expiration), recherche par code/lot/booster, colonne `utilisations 0 / 3` (ou `0 / ∞`). Actions de lot **Révoquer** / **Réactiver**.

**Utilisations de codes** : qui a utilisé quel code, quand, combien de packs crédités.

Le guide admin gagne une section 10 sur les codes (les sections suivantes sont renumérotées).

## Choix à valider

- **Le lot n'est pas une entité** : les codes partagent un libellé libre, suffisant pour lister/exporter/révoquer ensemble. Réutiliser un libellé agrandit le lot — c'est écrit dans l'aide du champ. Ça évite un second CRUD et des réglages hérités à maintenir.
- **Révoquer, jamais supprimer** : la ligne porte son historique d'utilisations.
- **Actions de lot plutôt qu'un lien par ligne** : elles apportent le token CSRF et la confirmation d'EasyAdmin, là où un lien GET de révocation serait forgeable. Mêmes gardes que `CardCrudController` (FQCN posté vérifié, puis CSRF).
- **Le paramètre `batch` transite par les attributs de requête** : une route admin custom passe par le dashboard, qui réinjecte ses `routeParams` en attributs et non en query string (`AdminRouterSubscriber`). C'est le seul point non évident du contrôleur, il est commenté.
- **Plafond de 1000 codes par lot**, `count`/`quantity`/`maxUses` bornés côté contraintes.

## Tests

9 tests fonctionnels ajoutés (génération et valeurs persistées, expiration Paris → UTC, maxUses vide = illimité, plafond de lot, export CSV, page réservée à l'admin, révocation/réactivation sélective, CSRF forgé sans effet, FQCN incohérent → 400) + les deux nouveaux CRUD ajoutés au test read-only existant.

`make quality` et `make phpunit` (322 tests) au vert. Écrans vérifiés au navigateur (formulaire, lot généré, listing, détail, utilisations, guide) : aucune erreur console.

## Suite

PR 3 — joueur : champ « J'ai un code » sur `/boosters`, avec rate limiter.