### PR TITLE
feat(front): teaser du prochain univers + polish homepage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
   - ManyToOne with Extension
 
 - **Extension**: Card sets/expansions
-  - Fields: name, description, status, imageName, visualConfig (JSON, set-level card visual defaults — including the shared foilTexture library pick; NO extension-level foil/mask uploads: masks must match each card's artwork, so they are per-card only)
+  - Fields: name, description, status, imageName, visualConfig (JSON, set-level card visual defaults — including the shared foilTexture library pick; NO extension-level foil/mask uploads: masks must match each card's artwork, so they are per-card only), upcoming (« next universe » teaser: at most ONE extension flagged — saving a flagged one from the admin clears the others; shows as a blurred tile on the homepage and /univers, drafts qualify)
   - OneToMany with Card, Booster and ExtensionBanner (universe page hero banners, position-ordered carousel)
 
 - **Booster**: Booster packs containing cards

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
   - ManyToOne with Extension
 
 - **Extension**: Card sets/expansions
-  - Fields: name, description, status, imageName, visualConfig (JSON, set-level card visual defaults — including the shared foilTexture library pick; NO extension-level foil/mask uploads: masks must match each card's artwork, so they are per-card only), upcoming (« next universe » teaser: at most ONE extension flagged — saving a flagged one from the admin clears the others; shows as a blurred tile on the homepage and /univers, drafts qualify)
+  - Fields: name, description, status, imageName, visualConfig (JSON, set-level card visual defaults — including the shared foilTexture library pick; NO extension-level foil/mask uploads: masks must match each card's artwork, so they are per-card only), upcoming (« next universe » teaser: at most ONE extension flagged — saving a flagged one from the admin clears the others; shows as a blurred tile on the homepage and /univers while the extension is still DRAFT — published ones already have their own tile)
   - OneToMany with Card, Booster and ExtensionBanner (universe page hero banners, position-ordered carousel)
 
 - **Booster**: Booster packs containing cards

--- a/migrations/Version20260809120000.php
+++ b/migrations/Version20260809120000.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * "Next universe" teaser: at most one extension is flagged upcoming and shows
+ * up as a blurred tile on the homepage / universe index.
+ */
+final class Version20260809120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add extension.upcoming flag';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE extension ADD upcoming BOOLEAN DEFAULT false NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE extension DROP upcoming');
+    }
+}

--- a/src/Controller/Admin/ExtensionCrudController.php
+++ b/src/Controller/Admin/ExtensionCrudController.php
@@ -82,7 +82,7 @@ class ExtensionCrudController extends AbstractGuardedCrudController
         ;
         yield BooleanField::new('upcoming')
             ->setLabel('Prochain univers (teaser)')
-            ->setHelp('Affiche l\'univers en tuile floutée « À suivre » sur l\'accueil et /univers. Un seul univers peut porter le flag : l\'activer ici le retire automatiquement des autres.')
+            ->setHelp('Affiche l\'univers en tuile floutée « À suivre » sur l\'accueil et /univers, tant qu\'il est en brouillon (publié, il a déjà sa tuile). Un seul univers peut porter le flag : l\'activer ici le retire automatiquement des autres.')
         ;
         yield ImageField::new('imageName')
             ->setLabel('Image')

--- a/src/Controller/Admin/ExtensionCrudController.php
+++ b/src/Controller/Admin/ExtensionCrudController.php
@@ -11,11 +11,13 @@ use App\Entity\Booster;
 use App\Entity\Card;
 use App\Entity\Extension;
 use App\Enum\Entity\ExtensionStatusEnum;
+use App\Repository\ExtensionRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Assets;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Field\BooleanField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\Field;
 use EasyCorp\Bundle\EasyAdminBundle\Field\FormField;
@@ -30,6 +32,7 @@ class ExtensionCrudController extends AbstractGuardedCrudController
 {
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
+        private readonly ExtensionRepository $extensionRepository,
     ) {
     }
 
@@ -77,6 +80,10 @@ class ExtensionCrudController extends AbstractGuardedCrudController
             ->setLabel('Statut')
             ->setChoices(ExtensionStatusEnum::cases())
         ;
+        yield BooleanField::new('upcoming')
+            ->setLabel('Prochain univers (teaser)')
+            ->setHelp('Affiche l\'univers en tuile floutée « À suivre » sur l\'accueil et /univers. Un seul univers peut porter le flag : l\'activer ici le retire automatiquement des autres.')
+        ;
         yield ImageField::new('imageName')
             ->setLabel('Image')
             ->setBasePath('/uploads/extensions')
@@ -97,6 +104,31 @@ class ExtensionCrudController extends AbstractGuardedCrudController
         ;
         yield from VisualConfigFields::fields(isOverride: false);
         yield Field::new('visualConfigJson')->setLabel('Config visuelle (JSON)')->onlyOnDetail();
+    }
+
+    #[\Override]
+    public function persistEntity(EntityManagerInterface $entityManager, object $entityInstance): void
+    {
+        parent::persistEntity($entityManager, $entityInstance);
+        $this->enforceSingleUpcoming($entityInstance);
+    }
+
+    #[\Override]
+    public function updateEntity(EntityManagerInterface $entityManager, object $entityInstance): void
+    {
+        parent::updateEntity($entityManager, $entityInstance);
+        $this->enforceSingleUpcoming($entityInstance);
+    }
+
+    /**
+     * Runs AFTER the save (the id is generated on persist): the freshly
+     * flagged extension is the only one allowed to keep the flag.
+     */
+    private function enforceSingleUpcoming(object $entityInstance): void
+    {
+        if ($entityInstance instanceof Extension && $entityInstance->isUpcoming()) {
+            $this->extensionRepository->clearUpcomingExcept($entityInstance);
+        }
     }
 
     #[\Override]

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Enum\Entity\CardStatusEnum;
+use App\Repository\BoosterOpeningCardRepository;
 use App\Repository\BoosterOpeningRepository;
 use App\Repository\CardRepository;
 use App\Repository\ExtensionRepository;
@@ -27,6 +28,7 @@ class BaseController extends AbstractController
         CardRepository $cardRepository,
         ExtensionRepository $extensionRepository,
         BoosterOpeningRepository $boosterOpeningRepository,
+        BoosterOpeningCardRepository $boosterOpeningCardRepository,
         CacheInterface $cache,
     ): Response {
         $pickDayCards = function (ItemInterface $item) use ($cardRepository): array {
@@ -62,6 +64,8 @@ class BaseController extends AbstractController
             'universesTotal' => \count($extensions),
             'cardsTotal' => array_sum(array_column($extensions, 'cardCount')),
             'packsOpenedCount' => $boosterOpeningRepository->countAll(),
+            'cardsPulledCount' => $boosterOpeningCardRepository->countPulledCards(),
+            'upcoming' => $extensionRepository->findUpcoming(),
         ]);
     }
 

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -58,6 +58,8 @@ class BaseController extends AbstractController
             'coverImage' => $coverImages[(string) $item['extension']->getId()] ?? null,
         ], array_reverse(\array_slice($extensions, -self::FEATURED_UNIVERSES)));
 
+        $upcoming = $extensionRepository->findUpcoming();
+
         return $this->render('pages/homepage.html.twig', [
             'cards' => $cards,
             'universes' => $featured,
@@ -65,7 +67,8 @@ class BaseController extends AbstractController
             'cardsTotal' => array_sum(array_column($extensions, 'cardCount')),
             'packsOpenedCount' => $boosterOpeningRepository->countAll(),
             'cardsPulledCount' => $boosterOpeningCardRepository->countPulledCards(),
-            'upcoming' => $extensionRepository->findUpcoming(),
+            'upcoming' => $upcoming,
+            'upcomingCover' => $upcoming ? $cardRepository->findTeaserCoverImageName($upcoming) : null,
         ]);
     }
 

--- a/src/Controller/UniverseController.php
+++ b/src/Controller/UniverseController.php
@@ -67,9 +67,12 @@ class UniverseController extends AbstractController
             ];
         }, $extensions);
 
+        $upcoming = $this->extensionRepository->findUpcoming();
+
         return $this->render('pages/universes.html.twig', [
             'universes' => $universes,
-            'upcoming' => $this->extensionRepository->findUpcoming(),
+            'upcoming' => $upcoming,
+            'upcomingCover' => $upcoming ? $this->cardRepository->findTeaserCoverImageName($upcoming) : null,
         ]);
     }
 

--- a/src/Controller/UniverseController.php
+++ b/src/Controller/UniverseController.php
@@ -69,6 +69,7 @@ class UniverseController extends AbstractController
 
         return $this->render('pages/universes.html.twig', [
             'universes' => $universes,
+            'upcoming' => $this->extensionRepository->findUpcoming(),
         ]);
     }
 

--- a/src/Entity/Extension.php
+++ b/src/Entity/Extension.php
@@ -64,6 +64,13 @@ class Extension implements \Stringable
     private ?string $logoName = null;
 
     /**
+     * Teased as the next universe on the front (blurred tile). At most one
+     * extension carries the flag: saving it from the admin clears the others.
+     */
+    #[ORM\Column(options: ['default' => false])]
+    private bool $upcoming = false;
+
+    /**
      * Default visual configuration (glow / border / css class / holo preset)
      * applied to the extension's cards, each card may override individual
      * fields.
@@ -202,6 +209,18 @@ class Extension implements \Stringable
     public function getLogoName(): ?string
     {
         return $this->logoName;
+    }
+
+    public function isUpcoming(): bool
+    {
+        return $this->upcoming;
+    }
+
+    public function setUpcoming(bool $upcoming): static
+    {
+        $this->upcoming = $upcoming;
+
+        return $this;
     }
 
     public function getVisualConfig(): VisualConfig

--- a/src/Repository/BoosterOpeningCardRepository.php
+++ b/src/Repository/BoosterOpeningCardRepository.php
@@ -17,4 +17,16 @@ class BoosterOpeningCardRepository extends ServiceEntityRepository
     {
         parent::__construct($registry, BoosterOpeningCard::class);
     }
+
+    /**
+     * Every card ever pulled from a booster, duplicates and holos included.
+     */
+    public function countPulledCards(): int
+    {
+        return (int) $this->createQueryBuilder('oc')
+            ->select('COALESCE(SUM(oc.quantity + oc.holoQuantity), 0)')
+            ->getQuery()
+            ->getSingleScalarResult()
+        ;
+    }
 }

--- a/src/Repository/CardRepository.php
+++ b/src/Repository/CardRepository.php
@@ -108,6 +108,38 @@ class CardRepository extends ServiceEntityRepository
     }
 
     /**
+     * Cover artwork of the "next universe" teaser: the extension's rarest
+     * card, DRAFTS INCLUDED — a teased universe is unpublished, so its cards
+     * usually are too (the tile blurs the artwork anyway).
+     */
+    public function findTeaserCoverImageName(Extension $extension): ?string
+    {
+        /** @var list<array{rarity: CardRarityEnum|string, imageName: string, name: string}> $rows */
+        $rows = $this->createQueryBuilder('c')
+            ->select('c.rarity AS rarity', 'c.imageName AS imageName', 'c.name AS name')
+            ->andWhere('c.extension = :extension')
+            ->andWhere('c.imageName IS NOT NULL')
+            ->setParameter('extension', $extension)
+            ->getQuery()
+            ->getArrayResult()
+        ;
+
+        $cover = null;
+        $bestKey = null;
+        foreach ($rows as $row) {
+            $rarity = $row['rarity'] instanceof CardRarityEnum ? $row['rarity'] : CardRarityEnum::tryFrom($row['rarity']);
+            $key = [-($rarity?->rank() ?? -1), $row['name']];
+
+            if (null === $bestKey || $key < $bestKey) {
+                $bestKey = $key;
+                $cover = $row['imageName'];
+            }
+        }
+
+        return $cover;
+    }
+
+    /**
      * Cover artwork per extension: the image of each extension's rarest
      * published card (name as tiebreak, so the pick is deterministic). One
      * portable query, the "rarest" pick happens in PHP — no DISTINCT ON,

--- a/src/Repository/ExtensionRepository.php
+++ b/src/Repository/ExtensionRepository.php
@@ -22,12 +22,12 @@ class ExtensionRepository extends ServiceEntityRepository
     }
 
     /**
-     * The "next universe" teaser tile; draft extensions qualify (the whole
-     * point is teasing a universe BEFORE it is published).
+     * The "next universe" teaser tile. Drafts only: a published extension
+     * already has its own tile, teasing it too would duplicate it.
      */
     public function findUpcoming(): ?Extension
     {
-        return $this->findOneBy(['upcoming' => true]);
+        return $this->findOneBy(['upcoming' => true, 'status' => ExtensionStatusEnum::DRAFT]);
     }
 
     /**

--- a/src/Repository/ExtensionRepository.php
+++ b/src/Repository/ExtensionRepository.php
@@ -22,6 +22,32 @@ class ExtensionRepository extends ServiceEntityRepository
     }
 
     /**
+     * The "next universe" teaser tile; draft extensions qualify (the whole
+     * point is teasing a universe BEFORE it is published).
+     */
+    public function findUpcoming(): ?Extension
+    {
+        return $this->findOneBy(['upcoming' => true]);
+    }
+
+    /**
+     * At most one upcoming extension: called after saving a flagged one.
+     */
+    public function clearUpcomingExcept(Extension $extension): void
+    {
+        $this->createQueryBuilder('e')
+            ->update()
+            ->set('e.upcoming', ':off')
+            ->andWhere('e.upcoming = true')
+            ->andWhere('e.id != :kept')
+            ->setParameter('off', false)
+            ->setParameter('kept', $extension->getId())
+            ->getQuery()
+            ->execute()
+        ;
+    }
+
+    /**
      * hasClaimableBooster drives the LIVE badge on the universe tiles: an
      * universe is "live" only when at least one of its boosters is claimable.
      *

--- a/templates/pages/homepage.html.twig
+++ b/templates/pages/homepage.html.twig
@@ -62,6 +62,7 @@
         {% set rarities = card_rarities() %}
         {% set tickerItems = [
             "✦ %s packs ouverts"|format(packsOpenedCount|number_format(0, ',', ' ')),
+            "✦ %s cartes tirées"|format(cardsPulledCount|number_format(0, ',', ' ')),
             '✦ %d univers'|format(universesTotal),
             '✦ %d cartes à collectionner'|format(cardsTotal),
             '✦ 2 packs / jour',
@@ -109,7 +110,7 @@
                         Les <span class="text-primary">univers</span>.
                     </h2>
                     <div class="flex flex-col items-end gap-3">
-                        <span class="font-mono text-xs text-ink-dim">{{ '%02d'|format(universesTotal) }} LIVE / 01 SOON</span>
+                        <span class="font-mono text-xs text-ink-dim">{{ '%02d'|format(universesTotal) }} LIVE{{ upcoming ? ' / 01 SOON' }}</span>
                         <a href="{{ path('universes') }}" class="btn-ghost !px-4 !py-2 text-xs">Tous les univers ▸</a>
                     </div>
                 </div>
@@ -158,17 +159,7 @@
                     {% endfor %}
 
                     {# Tuile teaser : absorbe la 4e case du layout magazine #}
-                    <article class="relative min-h-[240px] overflow-hidden border border-dashed border-hairline bg-surface/50 opacity-60 md:col-span-2">
-                        <div class="absolute left-4 right-4 top-4">
-                            <span class="chip-mono bg-black/80 px-2 py-0.5 font-bold text-soon">▸ SOON</span>
-                        </div>
-                        <div class="absolute bottom-4 left-4 right-4">
-                            <h3 class="font-display text-[22px] font-bold uppercase leading-[.95] tracking-[-0.03em] text-white">
-                                Prochain univers
-                            </h3>
-                            <p class="mt-1.5 text-[11px] text-white/80">Annonce bientôt. Reste connecté.</p>
-                        </div>
-                    </article>
+                    {{ include('parts/_soon_tile.html.twig', { upcoming, class: 'min-h-[240px] md:col-span-2' }) }}
                 </div>
             </div>
         </section>
@@ -193,7 +184,6 @@
                             </p>
                         </div>
                     {% endfor %}
-                    </div>
                 </div>
             </div>
         </section>
@@ -207,8 +197,8 @@
                 </h2>
 
                 {% set roadmap = [
-                    {quarter: 'Q3 26', state: 'NOW', title: 'Ouverture de packs', color: 'var(--primary)'},
-                    {quarter: 'Q4 26', state: 'BUILDING', title: 'Échanges P2P', color: 'var(--magenta)'},
+                    {quarter: 'Q3 26', state: 'LIVE', title: 'Ouverture de packs', color: 'var(--live)'},
+                    {quarter: 'Q4 26', state: 'NOW', title: 'Échanges P2P', color: 'var(--primary)'},
                     {quarter: 'Q1 27', state: 'PLANNED', title: 'Mode Duel', color: 'var(--soon)'},
                     {quarter: '2027', state: 'VISION', title: 'Saisons ranked', color: 'var(--text-dim)'},
                 ] %}
@@ -220,21 +210,7 @@
                             <p class="mt-3 font-display text-2xl font-bold uppercase tracking-[-0.02em] text-ink-strong">{{ step.title }}</p>
                         </div>
                     {% endfor %}
-                    </div>
                 </div>
-            </div>
-        </section>
-
-        {# ------------------------------------------------------------- CTA #}
-        <section class="relative overflow-hidden bg-primary px-6 py-28 text-center text-black lg:px-14">
-            <div class="hazard-stripes absolute inset-0 opacity-15" aria-hidden="true"></div>
-            <div class="relative">
-                <h2 class="font-display text-7xl font-bold uppercase leading-[.9] tracking-[-0.05em] md:text-8xl">Press start.</h2>
-                <p class="mt-4 text-[17px] text-black/80">2 packs gratos par jour. Pas de CB. Juste Discord.</p>
-                <a href="{{ path('boosters') }}"
-                   class="notched-lg mt-8 inline-block bg-black px-9 py-4 font-display text-base font-bold uppercase tracking-[.15em] text-primary">
-                    Ouvrir un pack ▸
-                </a>
             </div>
         </section>
     </main>

--- a/templates/pages/universes.html.twig
+++ b/templates/pages/universes.html.twig
@@ -67,6 +67,10 @@
                         </div>
                     </a>
                 {% endfor %}
+
+                {% if upcoming %}
+                    {{ include('parts/_soon_tile.html.twig', { upcoming, class: 'h-72' }) }}
+                {% endif %}
             </div>
         </section>
     </main>

--- a/templates/parts/_soon_tile.html.twig
+++ b/templates/parts/_soon_tile.html.twig
@@ -4,9 +4,14 @@
          data-testid="soon-tile">
     {% if upcoming %}
         <div class="absolute inset-0 bg-gradient-to-br from-[#2a0f44] via-[#7a1f9c] to-magenta opacity-60" aria-hidden="true"></div>
-        {% if upcoming.imageName %}
+        {# même cascade que les tuiles univers : image extension → artwork de la
+           carte la plus rare (brouillons compris, upcomingCover) → gradient seul #}
+        {% set coverUrl = upcoming.imageName
+            ? vich_uploader_asset(upcoming)
+            : (upcomingCover|default ? asset('uploads/cards/' ~ upcomingCover)) %}
+        {% if coverUrl %}
             {# scale-110 : le flou tire les bords vers l'intérieur, on les pousse hors cadre #}
-            <img src="{{ vich_uploader_asset(upcoming) }}" alt="" loading="lazy" onerror="this.remove()"
+            <img src="{{ coverUrl }}" alt="" loading="lazy" onerror="this.remove()"
                  class="absolute inset-0 h-full w-full scale-110 object-cover object-top blur-lg" aria-hidden="true">
         {% endif %}
         <div class="absolute inset-0 bg-gradient-to-b from-black/30 via-transparent to-black/90" aria-hidden="true"></div>

--- a/templates/parts/_soon_tile.html.twig
+++ b/templates/parts/_soon_tile.html.twig
@@ -1,0 +1,23 @@
+{# « Prochain univers » : artwork flouté + nom quand un univers est flaggé
+   upcoming, sinon placeholder en pointillés. `class` porte le sizing de la grille. #}
+<article class="relative overflow-hidden {{ class|default('') }} {{ upcoming ? 'notched-corner bg-surface' : 'border border-dashed border-hairline bg-surface/50 opacity-60' }}"
+         data-testid="soon-tile">
+    {% if upcoming %}
+        <div class="absolute inset-0 bg-gradient-to-br from-[#2a0f44] via-[#7a1f9c] to-magenta opacity-60" aria-hidden="true"></div>
+        {% if upcoming.imageName %}
+            {# scale-110 : le flou tire les bords vers l'intérieur, on les pousse hors cadre #}
+            <img src="{{ vich_uploader_asset(upcoming) }}" alt="" loading="lazy" onerror="this.remove()"
+                 class="absolute inset-0 h-full w-full scale-110 object-cover object-top blur-lg" aria-hidden="true">
+        {% endif %}
+        <div class="absolute inset-0 bg-gradient-to-b from-black/30 via-transparent to-black/90" aria-hidden="true"></div>
+    {% endif %}
+    <div class="absolute left-4 right-4 top-4">
+        <span class="chip-mono bg-black/80 px-2 py-0.5 font-bold text-soon">▸ SOON</span>
+    </div>
+    <div class="absolute bottom-4 left-4 right-4">
+        <h3 class="font-display text-[22px] font-bold uppercase leading-[.95] tracking-[-0.03em] text-white">
+            {{ upcoming ? upcoming.name : 'Prochain univers' }}
+        </h3>
+        <p class="mt-1.5 text-[11px] text-white/80">{{ upcoming ? 'Annonce à suivre…' : 'Annonce bientôt. Reste connecté.' }}</p>
+    </div>
+</article>

--- a/tests/Functional/AdminExtensionCrudTest.php
+++ b/tests/Functional/AdminExtensionCrudTest.php
@@ -125,6 +125,45 @@ final class AdminExtensionCrudTest extends WebTestCase
         ], $saved->getVisualConfig()->toArray());
     }
 
+    public function testFlaggingUpcomingClearsTheFlagOnEveryOtherExtension(): void
+    {
+        $client = self::createClient();
+        $client->followRedirects();
+        $this->authenticateClient($client);
+
+        $entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $previous = new Extension()
+            ->setName('Ancien teaser ' . uniqid())
+            ->setDescription('Test')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+            ->setUpcoming(true)
+        ;
+        $next = new Extension()
+            ->setName('Nouveau teaser ' . uniqid())
+            ->setDescription('Test')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+        ;
+        $entityManager->persist($previous);
+        $entityManager->persist($next);
+        $entityManager->flush();
+
+        $crawler = $client->request('GET', \sprintf('%s/%s/edit', self::CRUD_URL, $next->getId()));
+        self::assertResponseIsSuccessful();
+
+        $form = $crawler->filter('form[name="Extension"]')->form();
+        $form['Extension[upcoming]']->tick();
+        $client->submit($form);
+        self::assertResponseIsSuccessful();
+
+        $entityManager->clear();
+        $savedNext = $entityManager->find(Extension::class, $next->getId());
+        $savedPrevious = $entityManager->find(Extension::class, $previous->getId());
+        $this->assertInstanceOf(Extension::class, $savedNext);
+        $this->assertInstanceOf(Extension::class, $savedPrevious);
+        $this->assertTrue($savedNext->isUpcoming());
+        $this->assertFalse($savedPrevious->isUpcoming(), 'Un seul univers peut porter le flag upcoming.');
+    }
+
     public function testClearingOneWidgetOnlyDropsItsOwnKey(): void
     {
         $client = self::createClient();

--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -6,8 +6,12 @@ namespace App\Tests\Functional;
 
 use App\Entity\Booster;
 use App\Entity\BoosterOpening;
+use App\Entity\BoosterOpeningCard;
+use App\Entity\Card;
 use App\Entity\DiscordUser;
 use App\Entity\Extension;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
 use App\Enum\Entity\ExtensionStatusEnum;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -63,8 +67,37 @@ final class HomepageTest extends WebTestCase
         self::assertResponseIsSuccessful();
         $ticker = $crawler->filter('[data-testid="ticker"]')->text();
         $this->assertStringContainsString('2 packs ouverts', $ticker);
+        // 2 openings × (2 normal + 1 holo): duplicates and holos all count
+        $this->assertStringContainsString('6 cartes tirées', $ticker);
         $this->assertStringContainsString('univers', $ticker);
         $this->assertStringContainsString('2 packs / jour', $ticker);
+    }
+
+    public function testSoonTileTeasesTheUpcomingExtension(): void
+    {
+        $this->authenticateClient($this->client);
+
+        $upcoming = new Extension()
+            ->setName('Univers teasé ' . uniqid())
+            ->setDescription('Encore secret')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+            ->setUpcoming(true)
+        ;
+        $upcoming->setImageName('teaser.png');
+        $this->entityManager->persist($upcoming);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        $tile = $crawler->filter('[data-testid="soon-tile"]');
+        $this->assertCount(1, $tile);
+        $this->assertStringContainsString($upcoming->getName(), $tile->text());
+        $this->assertStringContainsString('Annonce à suivre', $tile->text());
+        $this->assertStringContainsString('blur-lg', (string) $tile->filter('img')->attr('class'));
+        // a draft universe has no page yet: the teaser must not link anywhere
+        $this->assertCount(0, $tile->filter('a'));
+        $this->assertStringContainsString('01 SOON', $crawler->filter('#univers')->text());
     }
 
     public function testUniverseGridOnlyShowsPublishedExtensions(): void
@@ -183,8 +216,20 @@ final class HomepageTest extends WebTestCase
         $booster->setImageName('default_card.png');
         $this->entityManager->persist($booster);
 
+        // draft: the pulled card must not enter the homepage day-cards draw
+        $card = new Card()
+            ->setName('Homepage pulled card ' . uniqid())
+            ->setDescription('Test')
+            ->setExtension($extension)
+            ->setStatus(CardStatusEnum::DRAFT)
+            ->setRarity(CardRarityEnum::COMMON)
+        ;
+        $this->entityManager->persist($card);
+
         for ($i = 0; $i < $count; ++$i) {
-            $this->entityManager->persist(new BoosterOpening($user, $booster, $i + 1, new \DateTimeImmutable()));
+            $opening = new BoosterOpening($user, $booster, $i + 1, new \DateTimeImmutable());
+            $this->entityManager->persist($opening);
+            $this->entityManager->persist(new BoosterOpeningCard($opening, $card, 2, 1));
         }
 
         $this->entityManager->flush();

--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -100,6 +100,40 @@ final class HomepageTest extends WebTestCase
         $this->assertStringContainsString('01 SOON', $crawler->filter('#univers')->text());
     }
 
+    public function testSoonTileFallsBackToTheRarestCardArtwork(): void
+    {
+        $this->authenticateClient($this->client);
+
+        // no extension image: the tile must pick the rarest card's artwork,
+        // draft cards included (a teased universe is unpublished)
+        $upcoming = new Extension()
+            ->setName('Univers teasé sans image ' . uniqid())
+            ->setDescription('Encore secret')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+            ->setUpcoming(true)
+        ;
+        $this->entityManager->persist($upcoming);
+        foreach ([[CardRarityEnum::COMMON, 'teaser-common.png'], [CardRarityEnum::RARE, 'teaser-rare.png']] as [$rarity, $image]) {
+            $card = new Card()
+                ->setName('Teaser ' . $rarity->value . ' ' . uniqid())
+                ->setDescription('Test')
+                ->setExtension($upcoming)
+                ->setStatus(CardStatusEnum::DRAFT)
+                ->setRarity($rarity)
+            ;
+            $card->setImageName($image);
+            $this->entityManager->persist($card);
+        }
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/');
+
+        self::assertResponseIsSuccessful();
+        $img = $crawler->filter('[data-testid="soon-tile"] img');
+        $this->assertCount(1, $img);
+        $this->assertStringContainsString('/uploads/cards/teaser-rare.png', (string) $img->attr('src'));
+    }
+
     public function testUniverseGridOnlyShowsPublishedExtensions(): void
     {
         $this->authenticateClient($this->client);

--- a/tests/Functional/UniverseControllerTest.php
+++ b/tests/Functional/UniverseControllerTest.php
@@ -87,6 +87,18 @@ final class UniverseControllerTest extends WebTestCase
         $this->assertCount(0, $tile->filter('a'));
     }
 
+    public function testAPublishedExtensionIsNeverTeased(): void
+    {
+        // published = it already has its own tile; a teaser would duplicate it
+        $this->extension->setUpcoming(true);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/univers');
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(0, $crawler->filter('[data-testid="soon-tile"]'));
+    }
+
     public function testLiveBadgeOnlyShowsWithAClaimableBooster(): void
     {
         // a published universe whose only booster is event-only (non claimable)

--- a/tests/Functional/UniverseControllerTest.php
+++ b/tests/Functional/UniverseControllerTest.php
@@ -59,6 +59,34 @@ final class UniverseControllerTest extends WebTestCase
         );
     }
 
+    public function testSoonTileShowsOnlyWithAnUpcomingExtension(): void
+    {
+        $crawler = $this->client->request('GET', '/univers');
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(0, $crawler->filter('[data-testid="soon-tile"]'));
+
+        $upcoming = new Extension()
+            ->setName('Univers teasé ' . uniqid())
+            ->setDescription('Encore secret')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+            ->setUpcoming(true)
+        ;
+        $upcoming->setImageName('teaser.png');
+        $this->entityManager->persist($upcoming);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/univers');
+
+        self::assertResponseIsSuccessful();
+        $tile = $crawler->filter('[data-testid="soon-tile"]');
+        $this->assertCount(1, $tile);
+        $this->assertStringContainsString($upcoming->getName(), $tile->text());
+        $this->assertStringContainsString('blur-lg', (string) $tile->filter('img')->attr('class'));
+        // a draft universe has no page yet: the teaser must not link anywhere
+        $this->assertCount(0, $tile->filter('a'));
+    }
+
     public function testLiveBadgeOnlyShowsWithAClaimableBooster(): void
     {
         // a published universe whose only booster is event-only (non claimable)


### PR DESCRIPTION
Phase 5, tout sur le front public. Migration à jouer au déploiement (`extension.upcoming`).

## Ce que ça fait

### Teaser « prochain univers » (flag `upcoming`)

Nouveau booléen sur Extension, éditable dans l'admin (« Prochain univers (teaser) »). **Un seul univers peut porter le flag** : le poser sur un univers le retire automatiquement des autres (`clearUpcomingExcept`, déclenché après la sauvegarde EasyAdmin — l'id UUID n'existe qu'au persist).

Côté front, l'univers flaggé remplace le placeholder « Prochain univers / Annonce bientôt » de l'accueil et apparaît aussi en bout de grille sur `/univers` : **image floutée** (`blur-lg` + `scale-110` pour pousser les bords baveux hors cadre, CSS pur comme convenu), nom affiché en clair, badge `▸ SOON`, texte « Annonce à suivre… ». La tuile ne mène nulle part (l'univers n'a pas encore de page). Le compteur « XX LIVE / 01 SOON » de l'accueil devient dynamique.

**Brouillons uniquement** : une extension publiée a déjà sa tuile normale — la teaser en plus la dupliquerait (constaté au navigateur, d'où le fix dédié). Sans flag, le placeholder en pointillés reste tel quel.

### Ticker : cartes tirées

Nouvelle stat « ✦ N cartes tirées » à côté de « packs ouverts » : `SUM(quantity + holoQuantity)` sur `BoosterOpeningCard`, doublons et holos compris.

### Ménage homepage

- La section CTA jaune « Press start. » du bas disparaît (la page se termine sur la roadmap) ; le chip du héro reste.
- Roadmap recalée : Ouverture de packs passe en **LIVE** (vert), Échanges P2P prend le **NOW**.
- Deux `</div>` orphelins retirés (sections Raretés et Roadmap fermaient un div de trop chacune).

## Tests

- `HomepageTest` : le ticker compte les cartes tirées (2 ouvertures × 2 normales + 1 holo = 6), la tuile teaser rend nom + image floutée + « 01 SOON » sans lien.
- `UniverseControllerTest` : pas de tuile sans flag, tuile complète avec, jamais de tuile pour une extension publiée flaggée.
- `AdminExtensionCrudTest` : flagger un univers retire le flag de l'autre.

`make quality` et la suite complète (338 tests) au vert. Vérifié au navigateur (accueil + `/univers`) avec un univers flaggé et une image de test.