### PR TITLE
feat(profil): page « Mes ouvertures » — historique paginé des pulls

### DIFF
--- a/src/Controller/OpeningHistoryController.php
+++ b/src/Controller/OpeningHistoryController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\DiscordUser;
+use App\Repository\BoosterOpeningRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+class OpeningHistoryController extends AbstractController
+{
+    /**
+     * Openings per page: 2 free claims a day means a page holds ~a week of
+     * regular play while staying light to render (each entry draws its cards).
+     */
+    private const int PER_PAGE = 12;
+
+    #[Route('/mes-ouvertures', name: 'opening_history')]
+    public function __invoke(
+        Request $request,
+        #[CurrentUser] DiscordUser $user,
+        BoosterOpeningRepository $boosterOpeningRepository,
+    ): Response {
+        $page = $request->query->getInt('page', 1);
+        $total = $boosterOpeningRepository->countByUser($user);
+        $lastPage = max(1, (int) ceil($total / self::PER_PAGE));
+
+        if ($page < 1 || $page > $lastPage) {
+            throw $this->createNotFoundException(\sprintf('Page %d is out of range.', $page));
+        }
+
+        return $this->render('pages/opening_history.html.twig', [
+            'openings' => $boosterOpeningRepository->findHistoryPage($user, $page, self::PER_PAGE),
+            'total' => $total,
+            'page' => $page,
+            'lastPage' => $lastPage,
+        ]);
+    }
+}

--- a/src/Repository/BoosterOpeningRepository.php
+++ b/src/Repository/BoosterOpeningRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\BoosterOpening;
+use App\Entity\DiscordUser;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -21,5 +22,49 @@ class BoosterOpeningRepository extends ServiceEntityRepository
     public function countAll(): int
     {
         return $this->count([]);
+    }
+
+    public function countByUser(DiscordUser $user): int
+    {
+        return $this->count(['discordUser' => $user]);
+    }
+
+    /**
+     * One page of the player's opening history, newest first, with everything
+     * the page renders (cards, their extension, the booster) fetch-joined.
+     *
+     * @return list<BoosterOpening>
+     */
+    public function findHistoryPage(DiscordUser $user, int $page, int $perPage): array
+    {
+        // paginate WITHOUT the collection join (LIMIT would slice card rows,
+        // not openings), then hydrate the collections on the fetched entities
+        $openings = $this->findBy(
+            ['discordUser' => $user],
+            ['openedAt' => 'DESC', 'id' => 'DESC'],
+            $perPage,
+            ($page - 1) * $perPage,
+        );
+
+        if ([] === $openings) {
+            return [];
+        }
+
+        $this->createQueryBuilder('o')
+            ->addSelect('oc', 'c', 'ce', 'b', 'be')
+            ->leftJoin('o.boosterOpeningCards', 'oc')
+            ->leftJoin('oc.card', 'c')
+            ->leftJoin('c.extension', 'ce')
+            ->join('o.booster', 'b')
+            ->join('b.extension', 'be')
+            ->where('o IN (:openings)')
+            ->setParameter('openings', $openings)
+            ->getQuery()
+            ->getResult()
+        ;
+
+        // same managed instances, collections now initialized: the first
+        // query's ordering still holds
+        return $openings;
     }
 }

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -37,6 +37,11 @@
                     <p class="chip-mono {{ totalOwned > 0 ? 'text-primary' : 'text-ink-dim' }}" data-testid="total-owned">
                         ◈ {{ totalOwned }} pack{{ totalOwned > 1 ? 's' }} en stock
                     </p>
+                    <a href="{{ path('opening_history') }}"
+                       class="chip-mono text-ink-dim transition-colors hover:text-primary"
+                       data-testid="history-link">
+                        ◎ Mes ouvertures ▸
+                    </a>
                 </div>
             </div>
         </section>

--- a/templates/pages/collection.html.twig
+++ b/templates/pages/collection.html.twig
@@ -46,6 +46,11 @@
                        class="border border-primary bg-black px-5 py-3.5 font-display text-[13px] font-bold uppercase tracking-[.15em] text-primary">
                         Ouvrir un pack ▸
                     </a>
+                    <a href="{{ path('opening_history') }}"
+                       class="chip-mono text-ink-dim transition-colors hover:text-primary"
+                       data-testid="history-link">
+                        ◎ Mes ouvertures ▸
+                    </a>
                 </div>
             </div>
         </section>

--- a/templates/pages/opening_history.html.twig
+++ b/templates/pages/opening_history.html.twig
@@ -1,0 +1,142 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    YOUL TCG — Mes ouvertures
+{% endblock %}
+
+{% block body %}
+    <main>
+        {# ------------------------------------------------------------- Hero #}
+        <section class="relative border-b border-hairline px-6 py-10 lg:px-12">
+            <div class="glow-ambient" aria-hidden="true"></div>
+            <div class="relative mx-auto flex max-w-7xl flex-col gap-8 md:flex-row md:items-end md:justify-between">
+                <div>
+                    <p class="eyebrow">04 / Journal</p>
+                    <h1 class="mt-2 font-display text-4xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-5xl">
+                        Mes ouvertures
+                    </h1>
+                    <p class="mt-2 max-w-md text-sm text-ink-muted">
+                        Chaque pack que tu as ouvert, du plus récent au plus ancien.
+                    </p>
+                </div>
+
+                <div class="flex flex-col items-start gap-2.5 md:items-end">
+                    <div class="bg-primary px-5 py-3.5 text-black" data-testid="openings-total">
+                        <p class="font-mono text-[10px] font-bold tracking-[.2em]">PACKS OUVERTS</p>
+                        <p class="mt-1 font-display text-3xl font-bold leading-none">{{ total }}</p>
+                    </div>
+                    <a href="{{ path('boosters') }}" class="chip-mono text-ink-dim transition-colors hover:text-primary">
+                        ◂ Retour aux boosters
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        {# ---------------------------------------------------------- Journal #}
+        <section class="px-6 pb-24 pt-10 lg:px-12">
+            <div class="mx-auto max-w-7xl">
+                {% if openings is empty %}
+                    <div class="border border-dashed border-hairline px-8 py-20 text-center text-ink-dim" data-testid="empty-state">
+                        <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Aucune ouverture.</p>
+                        <p class="mt-3 text-sm">Ton journal se remplit à chaque pack ouvert. Va en chercher un, gros youl.</p>
+                        <a href="{{ path('boosters') }}" class="btn-arcade mt-8">Ouvrir un pack ▸</a>
+                    </div>
+                {% else %}
+                    <div class="flex flex-col gap-6" data-testid="openings-list">
+                        {% for opening in openings %}
+                            {% set best = opening.bestRarity %}
+                            {% set holoCount = opening.holoCount %}
+                            {% set cardCount = opening.drawnCardCount %}
+                            <article class="border border-hairline bg-surface p-5 md:p-6" data-testid="opening-entry">
+                                <header class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-2 border-b border-hairline pb-4">
+                                    <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                                        <h2 class="font-display text-lg font-bold uppercase tracking-[-0.02em] text-ink-strong">
+                                            {{ opening.booster.displayName }}
+                                        </h2>
+                                        <time datetime="{{ opening.openedAt|date('c') }}"
+                                              class="font-mono text-[11px] tracking-[.12em] text-ink-dim">
+                                            {{ opening.openedAt|date('d/m/Y · H:i', 'Europe/Paris') }}
+                                        </time>
+                                    </div>
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <span class="chip-mono border border-hairline px-2 py-1 text-ink-muted">
+                                            {{ cardCount }} carte{{ cardCount > 1 ? 's' }}
+                                        </span>
+                                        {% if best %}
+                                            <span class="chip-mono border px-2 py-1 font-bold"
+                                                  style="color: var(--rarity-{{ best.value }}); border-color: color-mix(in srgb, var(--rarity-{{ best.value }}) 55%, transparent);"
+                                                  data-testid="best-rarity">
+                                                ◆ {{ best.label }}
+                                            </span>
+                                        {% endif %}
+                                        {% if holoCount > 0 %}
+                                            <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black" data-testid="holo-count">
+                                                ✦ {{ holoCount }} holo{{ holoCount > 1 ? 's' }}
+                                            </span>
+                                        {% endif %}
+                                    </div>
+                                </header>
+
+                                {# drawnCards is sorted rarest first: the leading card IS the best pull #}
+                                <div class="mt-5 grid grid-cols-3 gap-4 sm:grid-cols-4 md:grid-cols-6 xl:grid-cols-8">
+                                    {% for drawn in opening.drawnCards %}
+                                        <div class="card-tile relative">
+                                            {# unique DOM id: the same card can appear in several openings on the page #}
+                                            {{ include('components/CardComponent.html.twig', {
+                                                card: drawn.card,
+                                                holo: drawn.holoQuantity > 0,
+                                                lazy: true,
+                                                id: 'opening-' ~ opening.id ~ '-' ~ drawn.card.id,
+                                            }) }}
+                                            <div class="card-tile__chips pointer-events-none absolute -right-1.5 -top-1.5 z-10 flex gap-1">
+                                                {% if drawn.quantity > 1 %}
+                                                    <span class="chip-mono bg-black/90 px-1.5 py-0.5 font-bold text-white">×{{ drawn.quantity }}</span>
+                                                {% endif %}
+                                                {% if drawn.holoQuantity > 0 %}
+                                                    <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-1.5 py-0.5 font-bold text-black">✦{{ drawn.holoQuantity }}</span>
+                                                {% endif %}
+                                            </div>
+                                            {% if loop.first and best %}
+                                                <span class="card-tile__chips pointer-events-none absolute -left-1.5 -top-1.5 z-10 chip-mono px-1.5 py-0.5 font-bold text-black"
+                                                      style="background: var(--rarity-{{ best.value }});"
+                                                      data-testid="best-pull">
+                                                    ★ Best
+                                                </span>
+                                            {% endif %}
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            </article>
+                        {% endfor %}
+                    </div>
+
+                    {% if lastPage > 1 %}
+                        <nav class="mt-10 flex items-center justify-center gap-4" aria-label="Pagination" data-testid="pagination">
+                            {% if page > 1 %}
+                                <a href="{{ path('opening_history', page > 2 ? { page: page - 1 } : {}) }}"
+                                   class="border border-hairline px-4 py-2 font-mono text-[11px] uppercase tracking-[.15em] text-ink-muted transition-colors hover:border-primary hover:text-primary"
+                                   data-testid="page-prev">
+                                    ◂ Plus récentes
+                                </a>
+                            {% else %}
+                                <span class="border border-hairline px-4 py-2 font-mono text-[11px] uppercase tracking-[.15em] text-ink-dim opacity-40">◂ Plus récentes</span>
+                            {% endif %}
+
+                            <span class="chip-mono text-ink-dim">page {{ page }} / {{ lastPage }}</span>
+
+                            {% if page < lastPage %}
+                                <a href="{{ path('opening_history', { page: page + 1 }) }}"
+                                   class="border border-hairline px-4 py-2 font-mono text-[11px] uppercase tracking-[.15em] text-ink-muted transition-colors hover:border-primary hover:text-primary"
+                                   data-testid="page-next">
+                                    Plus anciennes ▸
+                                </a>
+                            {% else %}
+                                <span class="border border-hairline px-4 py-2 font-mono text-[11px] uppercase tracking-[.15em] text-ink-dim opacity-40">Plus anciennes ▸</span>
+                            {% endif %}
+                        </nav>
+                    {% endif %}
+                {% endif %}
+            </div>
+        </section>
+    </main>
+{% endblock %}

--- a/tests/Functional/OpeningHistoryControllerTest.php
+++ b/tests/Functional/OpeningHistoryControllerTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Booster;
+use App\Entity\BoosterOpening;
+use App\Entity\BoosterOpeningCard;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+final class OpeningHistoryControllerTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private KernelBrowser $client;
+
+    private EntityManagerInterface $entityManager;
+
+    private DiscordUser $user;
+
+    private Extension $extension;
+
+    private Booster $booster;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->user = $this->authenticateClient($this->client);
+
+        $this->extension = new Extension()
+            ->setName('History extension ' . uniqid())
+            ->setDescription('Test extension')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($this->extension);
+
+        $this->booster = new Booster()
+            ->setName('Pack Journal ' . uniqid())
+            ->setExtension($this->extension)
+            ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]])
+        ;
+        $this->entityManager->persist($this->booster);
+        $this->entityManager->flush();
+    }
+
+    public function testRedirectsWhenNotAuthenticated(): void
+    {
+        // drop the jwt cookie set by setUp: anonymous visit
+        $this->client->getCookieJar()->clear();
+        $this->client->request('GET', '/mes-ouvertures');
+
+        $this->assertContains($this->client->getResponse()->getStatusCode(), [302, 307]);
+    }
+
+    public function testEmptyStateWhenNoOpening(): void
+    {
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('0', $crawler->filter('[data-testid="openings-total"]')->text());
+        $this->assertStringContainsString('Aucune ouverture.', $crawler->filter('[data-testid="empty-state"]')->text());
+        $this->assertCount(0, $crawler->filter('[data-testid="openings-list"]'));
+        $this->assertCount(0, $crawler->filter('[data-testid="pagination"]'));
+    }
+
+    public function testOpeningsAreListedNewestFirstWithTheirMeta(): void
+    {
+        $old = $this->createOpening(new \DateTimeImmutable('2026-01-05 10:00:00'), [
+            ['name' => 'Vieille commune ' . uniqid(), 'rarity' => CardRarityEnum::COMMON, 'quantity' => 2, 'holoQuantity' => 0],
+        ]);
+        $recent = $this->createOpening(new \DateTimeImmutable('2026-02-20 18:30:00'), [
+            ['name' => 'Commune récente ' . uniqid(), 'rarity' => CardRarityEnum::COMMON, 'quantity' => 1, 'holoQuantity' => 0],
+            ['name' => 'Légendaire récente ' . uniqid(), 'rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 1, 'holoQuantity' => 1],
+        ]);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('2', $crawler->filter('[data-testid="openings-total"]')->text());
+
+        $entries = $crawler->filter('[data-testid="opening-entry"]');
+        $this->assertCount(2, $entries);
+
+        // Newest first: the recent opening leads.
+        $first = $entries->first();
+        $this->assertStringContainsString($this->booster->getDisplayName(), $first->filter('h2')->text());
+        $this->assertStringContainsString('20/02/2026', $first->text());
+        $this->assertStringContainsString('2 cartes', $first->text());
+        $this->assertStringContainsString('Légendaire', $first->filter('[data-testid="best-rarity"]')->text());
+        $this->assertStringContainsString('1 holo', $first->filter('[data-testid="holo-count"]')->text());
+
+        $last = $entries->last();
+        $this->assertStringContainsString('05/01/2026', $last->text());
+        $this->assertStringContainsString('2 cartes', $last->text());
+        $this->assertCount(0, $last->filter('[data-testid="holo-count"]'));
+
+        // Rendered through CardComponent: the 3D controller is wired on each card.
+        $this->assertGreaterThan(0, $first->filter('.card[data-controller="card"]')->count());
+    }
+
+    public function testCardTilesCarryQuantityHoloAndBestPullChips(): void
+    {
+        $legendaryName = 'Best pull ' . uniqid();
+        $this->createOpening(new \DateTimeImmutable('2026-03-01 12:00:00'), [
+            ['name' => 'Doublon commun ' . uniqid(), 'rarity' => CardRarityEnum::COMMON, 'quantity' => 2, 'holoQuantity' => 1],
+            ['name' => $legendaryName, 'rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 1, 'holoQuantity' => 0],
+        ]);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $entry = $crawler->filter('[data-testid="opening-entry"]')->first();
+
+        // drawnCards sorts rarest first: the legendary opens the grid and wears the chip.
+        $firstTile = $entry->filter('.card-tile')->first();
+        $this->assertCount(1, $firstTile->filter(\sprintf('img[alt="%s"]', $legendaryName)));
+        $this->assertStringContainsString('Best', $firstTile->filter('[data-testid="best-pull"]')->text());
+        $this->assertCount(1, $entry->filter('[data-testid="best-pull"]'));
+
+        // The duplicated holo common shows both counters and renders its holo variant.
+        $duplicateTile = $entry->filter('.card-tile')->last();
+        $this->assertStringContainsString('×2', $duplicateTile->text());
+        $this->assertStringContainsString('✦1', $duplicateTile->text());
+        $this->assertCount(1, $duplicateTile->filter('.card.holo'));
+    }
+
+    public function testUnpublishedCardsStayInTheJournal(): void
+    {
+        $draftName = 'Carte dépubliée ' . uniqid();
+        $this->createOpening(new \DateTimeImmutable('2026-03-02 12:00:00'), [
+            ['name' => $draftName, 'rarity' => CardRarityEnum::RARE, 'quantity' => 1, 'holoQuantity' => 0, 'status' => CardStatusEnum::DRAFT],
+        ]);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(1, $crawler->filter(\sprintf('img[alt="%s"]', $draftName)));
+    }
+
+    public function testOnlyOwnOpeningsAreListed(): void
+    {
+        $otherUser = $this->entityManager->find(DiscordUser::class, '195659530363731968');
+        \assert($otherUser instanceof DiscordUser);
+
+        $foreignName = 'Carte des autres ' . uniqid();
+        $this->createOpening(new \DateTimeImmutable('2026-03-03 12:00:00'), [
+            ['name' => $foreignName, 'rarity' => CardRarityEnum::COMMON, 'quantity' => 1, 'holoQuantity' => 0],
+        ], $otherUser);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('0', $crawler->filter('[data-testid="openings-total"]')->text());
+        $this->assertCount(0, $crawler->filter(\sprintf('img[alt="%s"]', $foreignName)));
+    }
+
+    public function testHistoryIsPaginated(): void
+    {
+        // 13 openings: one over the page size of 12
+        for ($i = 1; $i <= 13; ++$i) {
+            $this->createOpening(new \DateTimeImmutable(\sprintf('2026-01-%02d 09:00:00', $i)), [
+                ['name' => \sprintf('Carte %02d %s', $i, uniqid()), 'rarity' => CardRarityEnum::COMMON, 'quantity' => 1, 'holoQuantity' => 0],
+            ]);
+        }
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+        self::assertResponseIsSuccessful();
+        $this->assertCount(12, $crawler->filter('[data-testid="opening-entry"]'));
+        // Page 1 holds the 13th..2nd openings; the oldest is pushed to page 2.
+        $this->assertStringContainsString('13/01/2026', $crawler->filter('[data-testid="opening-entry"]')->first()->text());
+        $this->assertStringContainsString('page 1 / 2', $crawler->filter('[data-testid="pagination"]')->text());
+        $this->assertCount(1, $crawler->filter('[data-testid="page-next"]'));
+        $this->assertCount(0, $crawler->filter('[data-testid="page-prev"]'));
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures?page=2');
+        self::assertResponseIsSuccessful();
+        $entries = $crawler->filter('[data-testid="opening-entry"]');
+        $this->assertCount(1, $entries);
+        $this->assertStringContainsString('01/01/2026', $entries->first()->text());
+        $this->assertCount(0, $crawler->filter('[data-testid="page-next"]'));
+        // the way back links to the bare url (no ?page=1 duplicate)
+        $this->assertSame('/mes-ouvertures', $crawler->filter('[data-testid="page-prev"]')->attr('href'));
+    }
+
+    public function testOutOfRangePagesAreNotFound(): void
+    {
+        $this->createOpening(new \DateTimeImmutable('2026-03-04 12:00:00'), [
+            ['name' => 'Carte seule ' . uniqid(), 'rarity' => CardRarityEnum::COMMON, 'quantity' => 1, 'holoQuantity' => 0],
+        ]);
+        $this->entityManager->flush();
+
+        $this->client->request('GET', '/mes-ouvertures?page=0');
+        self::assertResponseStatusCodeSame(404);
+
+        $this->client->request('GET', '/mes-ouvertures?page=2');
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testSameCardInTwoOpeningsKeepsDomIdsUnique(): void
+    {
+        $card = $this->createCard('Carte partagée ' . uniqid(), CardRarityEnum::COMMON);
+
+        foreach (['2026-03-05 10:00:00', '2026-03-06 10:00:00'] as $openedAt) {
+            $opening = new BoosterOpening($this->user, $this->booster, 1234, new \DateTimeImmutable($openedAt));
+            $this->entityManager->persist($opening);
+            $openingCard = new BoosterOpeningCard($opening, $card, 1, 0);
+            $opening->addBoosterOpeningCard($openingCard);
+            $this->entityManager->persist($openingCard);
+        }
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $ids = $crawler->filter('[data-testid="opening-entry"] .card')->extract(['id']);
+        $this->assertCount(2, $ids);
+        $this->assertSame($ids, array_unique($ids));
+    }
+
+    /**
+     * @param list<array{name: string, rarity: CardRarityEnum, quantity: int, holoQuantity: int, status?: CardStatusEnum}> $drawnCards
+     */
+    private function createOpening(\DateTimeImmutable $openedAt, array $drawnCards, ?DiscordUser $owner = null): BoosterOpening
+    {
+        $opening = new BoosterOpening($owner ?? $this->user, $this->booster, 1234, $openedAt);
+        $this->entityManager->persist($opening);
+
+        foreach ($drawnCards as $drawnCard) {
+            $card = $this->createCard($drawnCard['name'], $drawnCard['rarity'], $drawnCard['status'] ?? CardStatusEnum::PUBLISHED);
+            $openingCard = new BoosterOpeningCard($opening, $card, $drawnCard['quantity'], $drawnCard['holoQuantity']);
+            $opening->addBoosterOpeningCard($openingCard);
+            $this->entityManager->persist($openingCard);
+        }
+
+        return $opening;
+    }
+
+    private function createCard(string $name, CardRarityEnum $rarity, CardStatusEnum $status = CardStatusEnum::PUBLISHED): Card
+    {
+        $card = new Card()
+            ->setName($name)
+            ->setDescription('Test card')
+            ->setStatus($status)
+            ->setRarity($rarity)
+            ->setExtension($this->extension)
+        ;
+        $card->setImageName('default_card.png');
+        $this->entityManager->persist($card);
+
+        return $card;
+    }
+}


### PR DESCRIPTION
## Ce que ça fait

Nouvelle page authentifiée **`/mes-ouvertures`** (route `opening_history`) : le journal des ouvertures du joueur connecté, de la plus récente à la plus ancienne, paginé par 12.

Chaque entrée affiche :
- le nom du pack (`Booster::getDisplayName()`) et la date/heure (affichée en Europe/Paris, comme le reset du quota) ;
- des chips méta : nombre de cartes, meilleure rareté (colorée via `--rarity-*`), nombre de holos ;
- les cartes tirées rendues via `CardComponent` (rendu 3D auto par `data-controller="card"`), en petit format grille (3 → 8 colonnes selon le viewport), avec les chips `×N` / `✦N` de la collection ;
- le **best pull** en tête de grille avec un badge « ★ Best » (`getDrawnCards()` trie déjà rarest-first, la première carte EST le best pull).

Accès : lien « ◎ Mes ouvertures ▸ » sur le hub `/boosters` (sous les chips de quota) et sur le bandeau de `/collection`. Pas d'entrée dans la nav du header : c'est une sous-page profil, la nav principale est déjà chargée (et masquée sur mobile — problème connu, pas touché ici).

## Décisions prises

- **Route `/mes-ouvertures`** : URL française cohérente avec `/univers`, sans préfixe `/profil` (il n'existe pas encore de section profil ; on pourra y déplacer la route plus tard avec une redirection).
- **Pagination `?page=N` maison** (pas de bundle, pas de nouvelle dépendance) : nav Précédent / `page X / Y` / Suivant. Page hors bornes (`page=0`, au-delà de la dernière) → 404. Le lien retour vers la page 1 pointe sur l'URL nue (pas de `?page=1` dupliqué pour le SEO/cache).
- **Requêtes** : `findHistoryPage()` pagine d'abord SANS jointure de collection (un fetch-join + LIMIT découperait des lignes de cartes, pas des ouvertures), puis une seconde requête fetch-join `boosterOpeningCards` + `card` + `card.extension` + `booster` + `booster.extension` initialise les collections des mêmes instances managées. Pas de N+1 (vérifié au profiler : 14 requêtes pour une page de 12 ouvertures), et on ne charge jamais tout l'historique.
- **Les cartes dé-publiées restent affichées** : le journal est un audit, aucune condition de statut sur la jointure (testé).

## Pièges rencontrés

- **IDs DOM dupliqués** : `CardComponent` prend `card.id` comme id par défaut ; la même carte peut apparaître dans plusieurs ouvertures de la page. On passe un id explicite `opening-{openingId}-{cardId}` (testé).
- Le libellé du meilleur booster ne suffit pas à distinguer deux ouvertures : la date porte l'heure (`d/m/Y · H:i`).

## Tests

`tests/Functional/OpeningHistoryControllerTest.php` — 9 tests / 46 assertions : redirection anonyme, état vide, tri anté-chronologique + chips méta, chips quantité/holo + rendu holo, badge best pull unique sur la carte la plus rare, cartes dé-publiées toujours affichées, isolation par joueur, pagination (12+1 → 2 pages, liens, bornes 404), unicité des ids DOM.

- Suite complète : **348 tests OK** dans le conteneur.
- `make quality` : OK (phpcs, cs-fixer, phpstan 8, rector).
- `make tailwind.build` passé après les modifs de templates.
- Vérif visuelle Playwright (desktop + mobile 390px, pas de scroll horizontal, best pull et pagination OK) sur la base dev.