### PR TITLE
feat(profil): section « Ma chance » — stats de tirage personnelles

### DIFF
--- a/assets/controllers/stat_switcher_controller.js
+++ b/assets/controllers/stat_switcher_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Shows one stat panel at a time out of a server-rendered set, driven by a
+ * <select>. Everything is already in the DOM: switching packs costs no round
+ * trip, and the section keeps a constant height however many packs exist.
+ */
+export default class extends Controller {
+    static targets = ['select', 'panel'];
+
+    show() {
+        const selected = this.selectTarget.value;
+
+        this.panelTargets.forEach((panel) => {
+            panel.classList.toggle('hidden', panel.dataset.panelId !== selected);
+        });
+    }
+}

--- a/src/Controller/OpeningHistoryController.php
+++ b/src/Controller/OpeningHistoryController.php
@@ -6,6 +6,7 @@ namespace App\Controller;
 
 use App\Entity\DiscordUser;
 use App\Repository\BoosterOpeningRepository;
+use App\Service\Booster\OpeningLuckStatsProvider;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -25,6 +26,7 @@ class OpeningHistoryController extends AbstractController
         Request $request,
         #[CurrentUser] DiscordUser $user,
         BoosterOpeningRepository $boosterOpeningRepository,
+        OpeningLuckStatsProvider $openingLuckStatsProvider,
     ): Response {
         $page = $request->query->getInt('page', 1);
         $total = $boosterOpeningRepository->countByUser($user);
@@ -39,6 +41,7 @@ class OpeningHistoryController extends AbstractController
             'total' => $total,
             'page' => $page,
             'lastPage' => $lastPage,
+            'stats' => $openingLuckStatsProvider->getStats($user),
         ]);
     }
 }

--- a/src/Dto/BestPull.php
+++ b/src/Dto/BestPull.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Entity\Card;
+use App\Enum\Entity\CardRarityEnum;
+
+/**
+ * The player's proudest moment: the earliest pull of the rarest tier they
+ * ever reached (their first legendary, once they have one).
+ */
+final readonly class BestPull
+{
+    public function __construct(
+        public Card $card,
+        public CardRarityEnum $rarity,
+        public \DateTimeImmutable $openedAt,
+        public bool $holo,
+    ) {
+    }
+}

--- a/src/Dto/BoosterLuckStats.php
+++ b/src/Dto/BoosterLuckStats.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Entity\Booster;
+
+/**
+ * One booster's personal luck sheet: what the player actually pulled from
+ * THIS pack versus the drop rates the pack advertises today.
+ */
+final readonly class BoosterLuckStats
+{
+    /**
+     * @param array<string, array{observed: float, expected: float}> $rarityRows rarity value => shares in %, ascending rarity order
+     */
+    public function __construct(
+        public Booster $booster,
+        public int $openingCount,
+        public int $cardCount,
+        public float $observedHoloRate,
+        public float $expectedHoloRate,
+        public array $rarityRows,
+    ) {
+    }
+}

--- a/src/Dto/OpeningLuckStats.php
+++ b/src/Dto/OpeningLuckStats.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+/**
+ * Personal draw statistics, entirely computed by SQL aggregates: what the
+ * player opened, what came out, and how it compares to the advertised rates.
+ */
+final readonly class OpeningLuckStats
+{
+    /**
+     * @param array<string, int>     $rarityCounts rarity value => copies pulled, ascending rarity order, zeros included
+     * @param array<string, float>   $rarityShares rarity value => share of pulled copies in %
+     * @param list<BoosterLuckStats> $boosters     most-opened boosters first
+     */
+    public function __construct(
+        public int $openingCount,
+        public int $cardCount,
+        public int $holoCount,
+        public float $holoRate,
+        public array $rarityCounts,
+        public array $rarityShares,
+        public array $boosters,
+        public ?BestPull $bestPull,
+    ) {
+    }
+}

--- a/src/Repository/BoosterOpeningCardRepository.php
+++ b/src/Repository/BoosterOpeningCardRepository.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Repository;
 
 use App\Entity\BoosterOpeningCard;
+use App\Entity\DiscordUser;
+use App\Enum\Entity\CardRarityEnum;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -27,6 +29,119 @@ class BoosterOpeningCardRepository extends ServiceEntityRepository
             ->select('COALESCE(SUM(oc.quantity + oc.holoQuantity), 0)')
             ->getQuery()
             ->getSingleScalarResult()
+        ;
+    }
+
+    /**
+     * Copies the user pulled overall (quantity already includes the holo ones).
+     *
+     * @return array{cards: int, holos: int}
+     */
+    public function sumPulledForUser(DiscordUser $user): array
+    {
+        /** @var array{cards: int|string, holos: int|string} $row */
+        $row = $this->createQueryBuilder('oc')
+            ->select('COALESCE(SUM(oc.quantity), 0) AS cards', 'COALESCE(SUM(oc.holoQuantity), 0) AS holos')
+            ->join('oc.boosterOpening', 'o')
+            ->where('o.discordUser = :user')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getSingleResult()
+        ;
+
+        return ['cards' => (int) $row['cards'], 'holos' => (int) $row['holos']];
+    }
+
+    /**
+     * @return array<string, int> rarity value => copies pulled by this user
+     */
+    public function countPerRarityForUser(DiscordUser $user): array
+    {
+        /** @var list<array{rarity: CardRarityEnum|string, cards: int|string}> $rows */
+        $rows = $this->createQueryBuilder('oc')
+            ->select('c.rarity AS rarity', 'SUM(oc.quantity) AS cards')
+            ->join('oc.boosterOpening', 'o')
+            ->join('oc.card', 'c')
+            ->where('o.discordUser = :user')
+            ->setParameter('user', $user)
+            ->groupBy('c.rarity')
+            ->getQuery()
+            ->getArrayResult()
+        ;
+
+        $counts = [];
+
+        foreach ($rows as $row) {
+            $rarity = $row['rarity'] instanceof CardRarityEnum ? $row['rarity']->value : $row['rarity'];
+            $counts[$rarity] = (int) $row['cards'];
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Per-booster pull aggregate for the user, one row per (booster, rarity).
+     *
+     * @return array<string, array{cards: int, holos: int, rarities: array<string, int>}> keyed by booster id
+     */
+    public function aggregatePerBoosterForUser(DiscordUser $user): array
+    {
+        /** @var list<array{boosterId: string, rarity: CardRarityEnum|string, cards: int|string, holos: int|string}> $rows */
+        $rows = $this->createQueryBuilder('oc')
+            ->select(
+                'IDENTITY(o.booster) AS boosterId',
+                'c.rarity AS rarity',
+                'SUM(oc.quantity) AS cards',
+                'SUM(oc.holoQuantity) AS holos',
+            )
+            ->join('oc.boosterOpening', 'o')
+            ->join('oc.card', 'c')
+            ->where('o.discordUser = :user')
+            ->setParameter('user', $user)
+            ->groupBy('o.booster', 'c.rarity')
+            ->getQuery()
+            ->getArrayResult()
+        ;
+
+        $aggregated = [];
+
+        foreach ($rows as $row) {
+            $boosterId = $row['boosterId'];
+            $rarity = $row['rarity'] instanceof CardRarityEnum ? $row['rarity']->value : $row['rarity'];
+
+            $aggregated[$boosterId] ??= ['cards' => 0, 'holos' => 0, 'rarities' => []];
+            $aggregated[$boosterId]['cards'] += (int) $row['cards'];
+            $aggregated[$boosterId]['holos'] += (int) $row['holos'];
+            $aggregated[$boosterId]['rarities'][$rarity] = (int) $row['cards'];
+        }
+
+        return $aggregated;
+    }
+
+    /**
+     * The earliest pull of the rarest tier the user ever reached, with the
+     * card, opening and booster ready to display.
+     */
+    public function findBestPullForUser(DiscordUser $user): ?BoosterOpeningCard
+    {
+        // rank the enum column in DQL so "rarest first" happens in SQL, not in PHP
+        $rarityRank = 'CASE ' . implode(' ', array_map(
+            static fn (CardRarityEnum $rarity): string => \sprintf("WHEN c.rarity = '%s' THEN %d", $rarity->value, $rarity->rank()),
+            CardRarityEnum::ascending(),
+        )) . ' ELSE -1 END';
+
+        return $this->createQueryBuilder('oc')
+            ->addSelect('o', 'c', 'b', $rarityRank . ' AS HIDDEN rarityRank')
+            ->join('oc.boosterOpening', 'o')
+            ->join('oc.card', 'c')
+            ->join('o.booster', 'b')
+            ->where('o.discordUser = :user')
+            ->setParameter('user', $user)
+            ->orderBy('rarityRank', 'DESC')
+            ->addOrderBy('o.openedAt', 'ASC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult()
         ;
     }
 }

--- a/src/Repository/BoosterOpeningRepository.php
+++ b/src/Repository/BoosterOpeningRepository.php
@@ -30,6 +30,30 @@ class BoosterOpeningRepository extends ServiceEntityRepository
     }
 
     /**
+     * @return array<string, int> booster id => openings by this user
+     */
+    public function countPerBoosterForUser(DiscordUser $user): array
+    {
+        /** @var list<array{boosterId: string, openings: int|string}> $rows */
+        $rows = $this->createQueryBuilder('o')
+            ->select('IDENTITY(o.booster) AS boosterId', 'COUNT(o.id) AS openings')
+            ->where('o.discordUser = :user')
+            ->setParameter('user', $user)
+            ->groupBy('o.booster')
+            ->getQuery()
+            ->getArrayResult()
+        ;
+
+        $counts = [];
+
+        foreach ($rows as $row) {
+            $counts[$row['boosterId']] = (int) $row['openings'];
+        }
+
+        return $counts;
+    }
+
+    /**
      * One page of the player's opening history, newest first, with everything
      * the page renders (cards, their extension, the booster) fetch-joined.
      *

--- a/src/Repository/BoosterRepository.php
+++ b/src/Repository/BoosterRepository.php
@@ -42,4 +42,28 @@ class BoosterRepository extends ServiceEntityRepository
             ->getResult()
         ;
     }
+
+    /**
+     * Boosters by id WITH their extension: getDisplayName() falls back to
+     * extension.name, so a plain findBy() lazy-loads one extension per booster.
+     *
+     * @param list<string> $ids
+     *
+     * @return list<Booster>
+     */
+    public function findWithExtensionByIds(array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        return $this->createQueryBuilder('booster')
+            ->join('booster.extension', 'extension')
+            ->addSelect('extension')
+            ->andWhere('booster.id IN (:ids)')
+            ->setParameter('ids', $ids)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
 }

--- a/src/Service/Booster/OpeningLuckStatsProvider.php
+++ b/src/Service/Booster/OpeningLuckStatsProvider.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Booster;
+
+use App\Dto\BestPull;
+use App\Dto\BoosterLuckStats;
+use App\Dto\OpeningLuckStats;
+use App\Entity\Booster;
+use App\Entity\BoosterOpeningCard;
+use App\Entity\DiscordUser;
+use App\Enum\Entity\CardRarityEnum;
+use App\Repository\BoosterOpeningCardRepository;
+use App\Repository\BoosterOpeningRepository;
+use App\Repository\BoosterRepository;
+
+/**
+ * Builds the « Ma chance » sheet from SQL aggregates only — the history can
+ * grow forever, nothing here ever hydrates it.
+ */
+final readonly class OpeningLuckStatsProvider
+{
+    public function __construct(
+        private BoosterOpeningRepository $boosterOpeningRepository,
+        private BoosterOpeningCardRepository $boosterOpeningCardRepository,
+        private BoosterRepository $boosterRepository,
+    ) {
+    }
+
+    public function getStats(DiscordUser $user): OpeningLuckStats
+    {
+        $openingCount = $this->boosterOpeningRepository->countByUser($user);
+
+        if (0 === $openingCount) {
+            return new OpeningLuckStats(0, 0, 0, 0.0, [], [], [], null);
+        }
+
+        ['cards' => $cardCount, 'holos' => $holoCount] = $this->boosterOpeningCardRepository->sumPulledForUser($user);
+        $pulledPerRarity = $this->boosterOpeningCardRepository->countPerRarityForUser($user);
+
+        $rarityCounts = [];
+        $rarityShares = [];
+
+        foreach (CardRarityEnum::ascending() as $rarity) {
+            $count = $pulledPerRarity[$rarity->value] ?? 0;
+            $rarityCounts[$rarity->value] = $count;
+            $rarityShares[$rarity->value] = $this->share($count, $cardCount);
+        }
+
+        return new OpeningLuckStats(
+            $openingCount,
+            $cardCount,
+            $holoCount,
+            $this->share($holoCount, $cardCount),
+            $rarityCounts,
+            $rarityShares,
+            $this->buildBoosterLucks($user),
+            $this->buildBestPull($user),
+        );
+    }
+
+    /**
+     * @return list<BoosterLuckStats>
+     */
+    private function buildBoosterLucks(DiscordUser $user): array
+    {
+        $openingsPerBooster = $this->boosterOpeningRepository->countPerBoosterForUser($user);
+
+        if ([] === $openingsPerBooster) {
+            return [];
+        }
+
+        $pullsPerBooster = $this->boosterOpeningCardRepository->aggregatePerBoosterForUser($user);
+
+        $boosters = [];
+
+        foreach ($this->boosterRepository->findBy(['id' => array_keys($openingsPerBooster)]) as $booster) {
+            $boosterId = (string) $booster->getId();
+            $pulls = $pullsPerBooster[$boosterId] ?? ['cards' => 0, 'holos' => 0, 'rarities' => []];
+            ['expectedShares' => $expectedShares, 'expectedHoloRate' => $expectedHoloRate] = $this->expectedRates($booster);
+
+            $rarityRows = [];
+
+            foreach (CardRarityEnum::ascending() as $rarity) {
+                $observed = $this->share($pulls['rarities'][$rarity->value] ?? 0, $pulls['cards']);
+                $expected = $expectedShares[$rarity->value] ?? 0.0;
+
+                // only tiers involved on either side: no row of double zeros
+                if ($observed > 0 || $expected > 0) {
+                    $rarityRows[$rarity->value] = ['observed' => $observed, 'expected' => $expected];
+                }
+            }
+
+            $boosters[] = new BoosterLuckStats(
+                $booster,
+                $openingsPerBooster[$boosterId] ?? 0,
+                $pulls['cards'],
+                $this->share($pulls['holos'], $pulls['cards']),
+                $expectedHoloRate,
+                $rarityRows,
+            );
+        }
+
+        usort($boosters, static fn (BoosterLuckStats $left, BoosterLuckStats $right): int => [$right->openingCount, $left->booster->getDisplayName()] <=> [$left->openingCount, $right->booster->getDisplayName()]);
+
+        return $boosters;
+    }
+
+    private function buildBestPull(DiscordUser $user): ?BestPull
+    {
+        $pull = $this->boosterOpeningCardRepository->findBestPullForUser($user);
+
+        if (!$pull instanceof BoosterOpeningCard) {
+            return null;
+        }
+
+        return new BestPull(
+            $pull->getCard(),
+            $pull->getCard()->getRarity(),
+            $pull->getBoosterOpening()->getOpenedAt(),
+            $pull->getHoloQuantity() > 0,
+        );
+    }
+
+    /**
+     * The pack's CURRENT advertised rates, projected per card: every slot
+     * yields exactly one card, so the expected share of a rarity is the mean
+     * of its per-slot percentages (same for the holo chance).
+     *
+     * @return array{expectedShares: array<string, float>, expectedHoloRate: float}
+     */
+    private function expectedRates(Booster $booster): array
+    {
+        $slots = $booster->getDropRates();
+        $slotCount = \count($slots);
+
+        if (0 === $slotCount) {
+            return ['expectedShares' => [], 'expectedHoloRate' => 0.0];
+        }
+
+        $rateSums = [];
+        $holoSum = 0;
+
+        foreach ($slots as $slot) {
+            foreach ($slot['rates'] as $rarity => $rate) {
+                $rateSums[$rarity] = ($rateSums[$rarity] ?? 0.0) + $rate;
+            }
+
+            $holoSum += $slot['holoChance'];
+        }
+
+        return [
+            'expectedShares' => array_map(static fn (float $sum): float => round($sum / $slotCount, 1), $rateSums),
+            'expectedHoloRate' => round($holoSum / $slotCount, 1),
+        ];
+    }
+
+    /**
+     * Percentage (1 decimal) safe against an empty denominator.
+     */
+    private function share(int $count, int $total): float
+    {
+        return $total > 0 ? round($count / $total * 100, 1) : 0.0;
+    }
+}

--- a/src/Service/Booster/OpeningLuckStatsProvider.php
+++ b/src/Service/Booster/OpeningLuckStatsProvider.php
@@ -75,7 +75,7 @@ final readonly class OpeningLuckStatsProvider
 
         $boosters = [];
 
-        foreach ($this->boosterRepository->findBy(['id' => array_keys($openingsPerBooster)]) as $booster) {
+        foreach ($this->boosterRepository->findWithExtensionByIds(array_keys($openingsPerBooster)) as $booster) {
             $boosterId = (string) $booster->getId();
             $pulls = $pullsPerBooster[$boosterId] ?? ['cards' => 0, 'holos' => 0, 'rarities' => []];
             ['expectedShares' => $expectedShares, 'expectedHoloRate' => $expectedHoloRate] = $this->expectedRates($booster);

--- a/templates/pages/opening_history.html.twig
+++ b/templates/pages/opening_history.html.twig
@@ -32,6 +32,95 @@
             </div>
         </section>
 
+        {# -------------------------------------------------------- Ma chance #}
+        {% if stats.openingCount > 0 %}
+            <section class="border-b border-hairline px-6 py-10 lg:px-12" data-testid="luck-section">
+                <div class="mx-auto max-w-7xl">
+                    <p class="eyebrow">Ma chance</p>
+
+                    {# ------------------------------------------- Compteurs #}
+                    <div class="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-4" data-testid="luck-tiles">
+                        <div class="border border-hairline bg-surface p-4">
+                            <p class="chip-mono text-ink-dim">Cartes tirées</p>
+                            <p class="mt-2 font-display text-3xl font-bold leading-none text-ink-strong" data-testid="luck-cards">{{ stats.cardCount }}</p>
+                            <p class="chip-mono mt-2 text-ink-dim">doublons compris</p>
+                        </div>
+                        <div class="border border-hairline bg-surface p-4">
+                            <p class="chip-mono text-ink-dim">Holos</p>
+                            <p class="mt-2 font-display text-3xl font-bold leading-none text-transparent bg-clip-text bg-gradient-to-r from-primary to-magenta" data-testid="luck-holos">✦ {{ stats.holoCount }}</p>
+                            <p class="chip-mono mt-2 text-ink-dim">taux réel · <span class="text-magenta">{{ _self.pct(stats.holoRate) }}</span></p>
+                        </div>
+                        <div class="border border-hairline bg-surface p-4">
+                            <p class="chip-mono text-ink-dim">Légendaires</p>
+                            <p class="mt-2 font-display text-3xl font-bold leading-none" style="color: var(--rarity-legendary);" data-testid="luck-legendaries">{{ stats.rarityCounts['legendary'] }}</p>
+                            <p class="chip-mono mt-2 text-ink-dim">{{ _self.pct(stats.rarityShares['legendary']) }} de tes tirages</p>
+                        </div>
+                        {% if stats.bestPull %}
+                            <div class="border p-4" style="border-color: color-mix(in srgb, var(--rarity-{{ stats.bestPull.rarity.value }}) 55%, transparent); background: color-mix(in srgb, var(--rarity-{{ stats.bestPull.rarity.value }}) 8%, var(--surface));" data-testid="luck-best-pull">
+                                <p class="chip-mono" style="color: var(--rarity-{{ stats.bestPull.rarity.value }});">
+                                    {{ stats.bestPull.rarity.value == 'legendary' ? 'Première légendaire' : 'Meilleur pull' }}
+                                </p>
+                                <p class="mt-2 truncate font-display text-lg font-bold uppercase leading-tight text-ink-strong" title="{{ stats.bestPull.card.name }}">
+                                    {{ stats.bestPull.holo ? '✦ ' }}{{ stats.bestPull.card.name }}
+                                </p>
+                                <p class="chip-mono mt-2 text-ink-dim">le {{ stats.bestPull.openedAt|date('d/m/Y', 'Europe/Paris') }}</p>
+                            </div>
+                        {% endif %}
+                    </div>
+
+                    <div class="mt-8 grid gap-8 lg:grid-cols-2">
+                        {# --------------------------------- Répartition raretés #}
+                        <div data-testid="luck-rarities">
+                            <p class="chip-mono font-bold text-ink-strong">Répartition par rareté</p>
+                            <div class="mt-4 flex flex-col gap-3">
+                                {% for rarity, count in stats.rarityCounts %}
+                                    <div>
+                                        <div class="flex items-baseline justify-between font-mono text-[11px] tracking-[.12em]">
+                                            <span style="color: var(--rarity-{{ rarity }});">{{ rarity_label(rarity) }}</span>
+                                            <span class="text-ink-muted">{{ count }} carte{{ count > 1 ? 's' }} · {{ _self.pct(stats.rarityShares[rarity]) }}</span>
+                                        </div>
+                                        <div class="mt-1 h-1.5 bg-white/10">
+                                            <div class="h-full" style="width: {{ stats.rarityShares[rarity] }}%; background: var(--rarity-{{ rarity }});"></div>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+
+                        {# ------------------------------- Observé vs annoncé #}
+                        <div data-testid="luck-boosters">
+                            <p class="chip-mono font-bold text-ink-strong">Observé vs annoncé, pack par pack</p>
+                            <div class="mt-4 flex flex-col gap-3">
+                                {% for boosterLuck in stats.boosters %}
+                                    <div class="border border-hairline bg-surface p-4" data-testid="luck-booster">
+                                        <div class="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                                            <p class="font-display text-sm font-bold uppercase tracking-[-0.02em] text-ink-strong">{{ boosterLuck.booster.displayName }}</p>
+                                            <p class="chip-mono text-ink-dim">{{ boosterLuck.openingCount }} pack{{ boosterLuck.openingCount > 1 ? 's' }} · {{ boosterLuck.cardCount }} carte{{ boosterLuck.cardCount > 1 ? 's' }}</p>
+                                        </div>
+                                        <div class="mt-3 flex flex-wrap gap-x-4 gap-y-1.5 font-mono text-[11px] tracking-[.08em]">
+                                            {% for rarity, row in boosterLuck.rarityRows %}
+                                                <span>
+                                                    <span style="color: var(--rarity-{{ rarity }});">{{ rarity_label(rarity) }}</span>
+                                                    <span class="text-ink-strong">{{ _self.pct(row.observed) }}</span>
+                                                    <span class="text-ink-dim">/ {{ _self.pct(row.expected) }} annoncé</span>
+                                                </span>
+                                            {% endfor %}
+                                            <span>
+                                                <span class="text-magenta">✦ Holo</span>
+                                                <span class="text-ink-strong">{{ _self.pct(boosterLuck.observedHoloRate) }}</span>
+                                                <span class="text-ink-dim">/ {{ _self.pct(boosterLuck.expectedHoloRate) }} annoncé</span>
+                                            </span>
+                                        </div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                            <p class="chip-mono mt-3 text-ink-dim">« Annoncé » = les taux actuels du pack (panneau Taux du hub), moyennés sur ses cartes.</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        {% endif %}
+
         {# ---------------------------------------------------------- Journal #}
         <section class="px-6 pb-24 pt-10 lg:px-12">
             <div class="mx-auto max-w-7xl">
@@ -140,3 +229,6 @@
         </section>
     </main>
 {% endblock %}
+
+{# entier affiché sans décimale, sinon 1 décimale (même règle que le panneau Taux du hub) #}
+{% macro pct(value) %}{{ value == value|round ? value|round : value }}%{% endmacro %}

--- a/templates/pages/opening_history.html.twig
+++ b/templates/pages/opening_history.html.twig
@@ -88,33 +88,46 @@
                         </div>
 
                         {# ------------------------------- Observé vs annoncé #}
-                        <div data-testid="luck-boosters">
-                            <p class="chip-mono font-bold text-ink-strong">Observé vs annoncé, pack par pack</p>
-                            <div class="mt-4 flex flex-col gap-3">
-                                {% for boosterLuck in stats.boosters %}
-                                    <div class="border border-hairline bg-surface p-4" data-testid="luck-booster">
-                                        <div class="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
-                                            <p class="font-display text-sm font-bold uppercase tracking-[-0.02em] text-ink-strong">{{ boosterLuck.booster.displayName }}</p>
-                                            <p class="chip-mono text-ink-dim">{{ boosterLuck.openingCount }} pack{{ boosterLuck.openingCount > 1 ? 's' }} · {{ boosterLuck.cardCount }} carte{{ boosterLuck.cardCount > 1 ? 's' }}</p>
-                                        </div>
-                                        <div class="mt-3 flex flex-wrap gap-x-4 gap-y-1.5 font-mono text-[11px] tracking-[.08em]">
-                                            {% for rarity, row in boosterLuck.rarityRows %}
-                                                <span>
-                                                    <span style="color: var(--rarity-{{ rarity }});">{{ rarity_label(rarity) }}</span>
-                                                    <span class="text-ink-strong">{{ _self.pct(row.observed) }}</span>
-                                                    <span class="text-ink-dim">/ {{ _self.pct(row.expected) }} annoncé</span>
-                                                </span>
-                                            {% endfor %}
-                                            <span>
-                                                <span class="text-magenta">✦ Holo</span>
-                                                <span class="text-ink-strong">{{ _self.pct(boosterLuck.observedHoloRate) }}</span>
-                                                <span class="text-ink-dim">/ {{ _self.pct(boosterLuck.expectedHoloRate) }} annoncé</span>
-                                            </span>
-                                        </div>
-                                    </div>
-                                {% endfor %}
+                        {# un seul pack affiché à la fois : la liste complète
+                           grandissait avec le catalogue et noyait la page #}
+                        <div data-testid="luck-boosters" data-controller="stat-switcher">
+                            <div class="flex flex-wrap items-center justify-between gap-3">
+                                <p class="chip-mono font-bold text-ink-strong">Observé vs annoncé</p>
+                                <select data-stat-switcher-target="select"
+                                        data-action="stat-switcher#show"
+                                        aria-label="Choisir un pack"
+                                        data-testid="luck-booster-select"
+                                        class="max-w-full border border-hairline bg-surface px-3 py-1.5 font-mono text-[11px] tracking-[.08em] text-ink-strong focus:border-primary focus:outline-none">
+                                    {% for boosterLuck in stats.boosters %}
+                                        <option value="{{ boosterLuck.booster.id }}">
+                                            {{ boosterLuck.booster.displayName }} · {{ boosterLuck.openingCount }} pack{{ boosterLuck.openingCount > 1 ? 's' }}
+                                        </option>
+                                    {% endfor %}
+                                </select>
                             </div>
-                            <p class="chip-mono mt-3 text-ink-dim">« Annoncé » = les taux actuels du pack (panneau Taux du hub), moyennés sur ses cartes.</p>
+
+                            {% for boosterLuck in stats.boosters %}
+                                <div class="mt-4 border border-hairline bg-surface p-5 {{ not loop.first ? 'hidden' }}"
+                                     data-stat-switcher-target="panel"
+                                     data-panel-id="{{ boosterLuck.booster.id }}"
+                                     data-testid="luck-booster">
+                                    <div class="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+                                        <p class="font-display text-sm font-bold uppercase tracking-[-0.02em] text-ink-strong">{{ boosterLuck.booster.displayName }}</p>
+                                        <p class="chip-mono text-ink-dim">{{ boosterLuck.openingCount }} pack{{ boosterLuck.openingCount > 1 ? 's' }} · {{ boosterLuck.cardCount }} carte{{ boosterLuck.cardCount > 1 ? 's' }}</p>
+                                    </div>
+
+                                    <div class="mt-4 flex flex-col gap-3">
+                                        {% for rarity, row in boosterLuck.rarityRows %}
+                                            {{ _self.rate_bar(rarity_label(rarity), 'var(--rarity-' ~ rarity ~ ')', row.observed, row.expected) }}
+                                        {% endfor %}
+                                        {{ _self.rate_bar('✦ Holo', 'var(--magenta)', boosterLuck.observedHoloRate, boosterLuck.expectedHoloRate) }}
+                                    </div>
+                                </div>
+                            {% endfor %}
+
+                            <p class="chip-mono mt-3 text-ink-dim">
+                                Le trait clair marque le taux annoncé du pack (panneau Taux du hub), moyenné sur ses cartes.
+                            </p>
                         </div>
                     </div>
                 </div>
@@ -232,3 +245,23 @@
 
 {# entier affiché sans décimale, sinon 1 décimale (même règle que le panneau Taux du hub) #}
 {% macro pct(value) %}{{ value == value|round ? value|round : value }}%{% endmacro %}
+
+{# Taux observé en barre pleine, taux annoncé en repère : la barre qui dépasse
+   le trait = tu es au-dessus de ce que le pack promet. #}
+{% macro rate_bar(label, color, observed, expected) %}
+    <div>
+        <div class="flex items-baseline justify-between font-mono text-[11px] tracking-[.08em]">
+            <span style="color: {{ color }};">{{ label }}</span>
+            <span>
+                <span class="text-ink-strong">{{ _self.pct(observed) }}</span>
+                <span class="text-ink-dim">/ {{ _self.pct(expected) }} annoncé</span>
+            </span>
+        </div>
+        <div class="relative mt-1.5 h-2 bg-white/10">
+            <div class="absolute inset-y-0 left-0" style="width: {{ min(observed, 100) }}%; background: {{ color }};"></div>
+            <div class="absolute inset-y-[-2px] w-0.5 bg-white/70"
+                 style="left: {{ min(expected, 100) }}%;"
+                 title="Annoncé : {{ _self.pct(expected) }}"></div>
+        </div>
+    </div>
+{% endmacro %}

--- a/tests/Functional/OpeningLuckStatsTest.php
+++ b/tests/Functional/OpeningLuckStatsTest.php
@@ -175,6 +175,17 @@ final class OpeningLuckStatsTest extends WebTestCase
             static fn (Crawler $node): string => $node->filter('p')->first()->text(normalizeWhitespace: true),
         );
         $this->assertSame([$this->booster->getDisplayName(), $secondBooster->getDisplayName()], $names);
+
+        // one option per pack, and a single panel shown: the section keeps a
+        // constant height however many packs the player has opened
+        $options = $crawler->filter('[data-testid="luck-booster-select"] option');
+        $this->assertCount(2, $options);
+        $this->assertStringContainsString($this->booster->getDisplayName(), $options->first()->text(normalizeWhitespace: true));
+
+        $hidden = $crawler->filter('[data-testid="luck-booster"]')->each(
+            static fn (Crawler $node): bool => str_contains((string) $node->attr('class'), 'hidden'),
+        );
+        $this->assertSame([false, true], $hidden);
     }
 
     /**

--- a/tests/Functional/OpeningLuckStatsTest.php
+++ b/tests/Functional/OpeningLuckStatsTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Booster;
+use App\Entity\BoosterOpening;
+use App\Entity\BoosterOpeningCard;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+
+final class OpeningLuckStatsTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private KernelBrowser $client;
+
+    private EntityManagerInterface $entityManager;
+
+    private DiscordUser $user;
+
+    private Extension $extension;
+
+    private Booster $booster;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->user = $this->authenticateClient($this->client);
+
+        $this->extension = new Extension()
+            ->setName('Luck extension ' . uniqid())
+            ->setDescription('Test extension')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($this->extension);
+
+        // 2 cards per pack, advertised: common 75%, rare 25%, holo 10%
+        $this->booster = $this->createBooster('Pack Chance ' . uniqid(), [
+            ['rarities' => ['common' => 100], 'holoChance' => 0],
+            ['rarities' => ['common' => 50, 'rare' => 50], 'holoChance' => 20],
+        ]);
+        $this->entityManager->flush();
+    }
+
+    public function testNoLuckSectionWithoutAnyOpening(): void
+    {
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(0, $crawler->filter('[data-testid="luck-section"]'));
+        $this->assertStringContainsString('Aucune ouverture.', $crawler->filter('[data-testid="empty-state"]')->text());
+    }
+
+    public function testGlobalCountersAndRealHoloRate(): void
+    {
+        $this->createScenario();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $this->assertSame('4', $crawler->filter('[data-testid="luck-cards"]')->text(normalizeWhitespace: true));
+        $this->assertStringContainsString('1', $crawler->filter('[data-testid="luck-holos"]')->text());
+        // 1 holo out of 4 copies pulled
+        $this->assertStringContainsString('25%', $crawler->filter('[data-testid="luck-tiles"]')->text());
+        $this->assertSame('1', $crawler->filter('[data-testid="luck-legendaries"]')->text(normalizeWhitespace: true));
+    }
+
+    public function testRarityDistributionShowsEveryTierEvenEmpty(): void
+    {
+        $this->createScenario();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $distribution = $crawler->filter('[data-testid="luck-rarities"]')->text(normalizeWhitespace: true);
+        $this->assertStringContainsString('Commune 3 cartes · 75%', $distribution);
+        $this->assertStringContainsString('Légendaire 1 carte · 25%', $distribution);
+        // tiers never pulled stay visible at zero
+        $this->assertStringContainsString('Peu commune 0 carte · 0%', $distribution);
+        $this->assertStringContainsString('Rare 0 carte · 0%', $distribution);
+    }
+
+    public function testBoosterPanelComparesObservedToAdvertisedRates(): void
+    {
+        $this->createScenario();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $panels = $crawler->filter('[data-testid="luck-booster"]');
+        $this->assertCount(1, $panels);
+
+        $panel = $panels->first()->text(normalizeWhitespace: true);
+        $this->assertStringContainsString($this->booster->getDisplayName(), $panel);
+        $this->assertStringContainsString('2 packs · 4 cartes', $panel);
+        // observed vs the pack's advertised per-card averages
+        $this->assertStringContainsString('Commune 75% / 75% annoncé', $panel);
+        $this->assertStringContainsString('Rare 0% / 25% annoncé', $panel);
+        // the legendary was never advertised but WAS pulled: the row shows up
+        $this->assertStringContainsString('Légendaire 25% / 0% annoncé', $panel);
+        $this->assertStringContainsString('✦ Holo 25% / 10% annoncé', $panel);
+    }
+
+    public function testBestPullIsTheEarliestOfTheRarestTier(): void
+    {
+        $this->createScenario();
+        // a second, later legendary must not steal the tile
+        $this->createOpening($this->booster, new \DateTimeImmutable('2026-03-15 10:00:00'), [
+            ['name' => 'Légendaire tardive ' . uniqid(), 'rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 1, 'holoQuantity' => 0],
+        ]);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $tile = $crawler->filter('[data-testid="luck-best-pull"]')->text(normalizeWhitespace: true);
+        $this->assertStringContainsString('Première légendaire', $tile);
+        $this->assertStringContainsString('Youl doré', $tile);
+        $this->assertStringContainsString('le 01/02/2026', $tile);
+    }
+
+    public function testBestPullFallsBackToTheRarestTierReached(): void
+    {
+        $this->createOpening($this->booster, new \DateTimeImmutable('2026-01-10 09:00:00'), [
+            ['name' => 'Simple rare ' . uniqid(), 'rarity' => CardRarityEnum::RARE, 'quantity' => 1, 'holoQuantity' => 0],
+            ['name' => 'Simple commune ' . uniqid(), 'rarity' => CardRarityEnum::COMMON, 'quantity' => 1, 'holoQuantity' => 0],
+        ]);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $tile = $crawler->filter('[data-testid="luck-best-pull"]')->text(normalizeWhitespace: true);
+        $this->assertStringContainsString('Meilleur pull', $tile);
+        $this->assertStringContainsString('Simple rare', $tile);
+    }
+
+    public function testBoostersAreOrderedByOpeningsAndForeignPullsAreIgnored(): void
+    {
+        $this->createScenario();
+
+        // one opening of a second pack: it must list after the main one
+        $secondBooster = $this->createBooster('Pack Secondaire ' . uniqid(), [['rarities' => ['common' => 100], 'holoChance' => 0]]);
+        $this->createOpening($secondBooster, new \DateTimeImmutable('2026-02-05 10:00:00'), [
+            ['name' => 'Commune secondaire ' . uniqid(), 'rarity' => CardRarityEnum::COMMON, 'quantity' => 1, 'holoQuantity' => 0],
+        ]);
+
+        // someone else's legendary opening must not leak into the stats
+        $otherUser = $this->entityManager->find(DiscordUser::class, '195659530363731968');
+        \assert($otherUser instanceof DiscordUser);
+        $this->createOpening($this->booster, new \DateTimeImmutable('2026-01-02 10:00:00'), [
+            ['name' => 'Légendaire des autres ' . uniqid(), 'rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 1, 'holoQuantity' => 1],
+        ], $otherUser);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/mes-ouvertures');
+
+        self::assertResponseIsSuccessful();
+        $this->assertSame('5', $crawler->filter('[data-testid="luck-cards"]')->text(normalizeWhitespace: true));
+        $this->assertSame('1', $crawler->filter('[data-testid="luck-legendaries"]')->text(normalizeWhitespace: true));
+
+        $names = $crawler->filter('[data-testid="luck-booster"]')->each(
+            static fn (Crawler $node): string => $node->filter('p')->first()->text(normalizeWhitespace: true),
+        );
+        $this->assertSame([$this->booster->getDisplayName(), $secondBooster->getDisplayName()], $names);
+    }
+
+    /**
+     * Two openings of the same pack:
+     * - 10/01: 2 commons (one duplicated copy);
+     * - 01/02: 1 common + 1 holo legendary « Youl doré ».
+     * Totals: 4 copies, 1 holo (25%), common 75% / legendary 25%.
+     */
+    private function createScenario(): void
+    {
+        $this->createOpening($this->booster, new \DateTimeImmutable('2026-01-10 09:00:00'), [
+            ['name' => 'Youl commun ' . uniqid(), 'rarity' => CardRarityEnum::COMMON, 'quantity' => 2, 'holoQuantity' => 0],
+        ]);
+        $this->createOpening($this->booster, new \DateTimeImmutable('2026-02-01 18:00:00'), [
+            ['name' => 'Youl banal ' . uniqid(), 'rarity' => CardRarityEnum::COMMON, 'quantity' => 1, 'holoQuantity' => 0],
+            ['name' => 'Youl doré ' . uniqid(), 'rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 1, 'holoQuantity' => 1],
+        ]);
+        $this->entityManager->flush();
+    }
+
+    /**
+     * @param list<array{rarities: array<string, int>, holoChance: int}> $rarityRates
+     */
+    private function createBooster(string $name, array $rarityRates): Booster
+    {
+        $booster = new Booster()
+            ->setName($name)
+            ->setExtension($this->extension)
+            ->setRarityRates($rarityRates)
+        ;
+        $this->entityManager->persist($booster);
+
+        return $booster;
+    }
+
+    /**
+     * @param list<array{name: string, rarity: CardRarityEnum, quantity: int, holoQuantity: int}> $drawnCards
+     */
+    private function createOpening(Booster $booster, \DateTimeImmutable $openedAt, array $drawnCards, ?DiscordUser $owner = null): void
+    {
+        $opening = new BoosterOpening($owner ?? $this->user, $booster, 1234, $openedAt);
+        $this->entityManager->persist($opening);
+
+        foreach ($drawnCards as $drawnCard) {
+            $card = new Card()
+                ->setName($drawnCard['name'])
+                ->setDescription('Test card')
+                ->setStatus(CardStatusEnum::PUBLISHED)
+                ->setRarity($drawnCard['rarity'])
+                ->setExtension($this->extension)
+            ;
+            $card->setImageName('default_card.png');
+            $this->entityManager->persist($card);
+
+            $openingCard = new BoosterOpeningCard($opening, $card, $drawnCard['quantity'], $drawnCard['holoQuantity']);
+            $opening->addBoosterOpeningCard($openingCard);
+            $this->entityManager->persist($openingCard);
+        }
+    }
+}


### PR DESCRIPTION
> **Base : #137** (`feat/phase-6-historique-ouvertures`) — à merger après elle, PR empilée.

## Ce que ça fait

Section **« Ma chance »** en tête de `/mes-ouvertures`, entièrement calculée par agrégats SQL — l'historique peut grossir indéfiniment, rien n'est jamais hydraté en masse (6 requêtes d'agrégat, quel que soit le volume).

- **Compteurs** : cartes tirées (doublons compris), holos + **taux de holo réel**, légendaires (+ part des tirages).
- **Fun fact** : tuile « Première légendaire » (carte + date) dès que le joueur en a une ; sinon « Meilleur pull » = le premier tirage du palier le plus rare atteint. Une seule requête : tri SQL par rang de rareté (CASE construit depuis `CardRarityEnum::ascending()`, en `AS HIDDEN`) puis date croissante.
- **Répartition par rareté** : barres colorées `--rarity-*` avec nombre + %, les paliers jamais tirés restent visibles à zéro (le « 0 légendaire » fait partie du fun).
- **Observé vs annoncé, pack par pack** : pour chaque booster ouvert, packs/cartes puis par rareté `observé% / attendu% annoncé` + ligne holo. Boosters triés par nombre d'ouvertures décroissant.
- Joueur à zéro ouverture : pas de section, l'état vide du journal (PR #137) reste seul — aucune division par zéro nulle part (`share()` gère le dénominateur vide).

## Décisions prises

- **Comparaison honnête, par booster** : on ne compare jamais un taux global du joueur à des taux par pack hétérogènes. Chaque booster est comparé à SES taux. L'« attendu » = la **moyenne des pourcentages par slot** de `Booster::getDropRates()` — chaque slot donnant exactement une carte, cette moyenne est l'espérance exacte de la part d'une rareté dans un pack (idem pour le holo : moyenne des `holoChance`).
- **Footnote de loyauté** : « Annoncé » = les taux *actuels* du pack (ceux du panneau Taux du hub). Si l'admin retouche les `rarityRates` après coup, l'historique a été tiré sous d'autres taux ; de même le fallback de `CardDrawer` (palier voisin quand une rareté n'a pas de carte publiée) peut légitimement faire dériver l'observé — d'où la ligne « Légendaire 25% / 0% annoncé » possible, affichée sans filtre (l'union observé/attendu > 0 pilote les lignes).
- **Archi** : DTOs `OpeningLuckStats` / `BoosterLuckStats` / `BestPull` construits par `OpeningLuckStatsProvider` (`src/Service/Booster/`), le contrôleur reste bête et le template ne calcule rien. Agrégats dans les repositories (`SUM`/`COUNT`/`GROUP BY`, `IDENTITY(o.booster)`), entités `Booster` récupérées ensuite par `findBy(['id' => …])`.
- Les stats sont rendues sur toutes les pages du journal (elles sont globales, la section sert d'en-tête constant).

## Pièges rencontrés

- `BoosterOpeningCard.quantity` **inclut** les exemplaires holo (cf. `BoosterOpeningService::aggregate()`) : cartes tirées = `SUM(quantity)` seul, holos = `SUM(holoQuantity)`. ⚠️ Au passage : `BoosterOpeningCardRepository::countPulledCards()` (compteur homepage, hors scope ici) somme `quantity + holoQuantity` et compte donc les holos double — à corriger dans un fix séparé si vous confirmez.
- Hydratation scalaire des colonnes enum : selon le contexte Doctrine renvoie l'enum ou sa valeur — normalisé défensivement dans les repositories.

## Tests

`tests/Functional/OpeningLuckStatsTest.php` — 7 tests / 32 assertions : pas de section sans ouverture, compteurs + taux holo réel (1/4 = 25%), répartition avec paliers à zéro, panneau observé vs annoncé (attendu 75/25 + holo 10% depuis des slots 100/0 et 50-50/20 ; légendaire hors taux annoncés affichée), première légendaire (une plus tardive ne vole pas la tuile), fallback « Meilleur pull » sans légendaire, tri des boosters + isolation des tirages des autres joueurs.

- Suite complète : **355 tests OK** dans le conteneur.
- `make quality` : OK (phpcs, cs-fixer, phpstan 8, rector).
- `make tailwind.build` passé.
- Vérif visuelle Playwright sur la base dev (50 packs réels) : tuiles, barres, panneaux par pack, mobile sans scroll horizontal.