### PR TITLE
fix(home): compteur de cartes tirées juste dans le ticker

### DIFF
--- a/src/Repository/BoosterOpeningCardRepository.php
+++ b/src/Repository/BoosterOpeningCardRepository.php
@@ -19,12 +19,13 @@ class BoosterOpeningCardRepository extends ServiceEntityRepository
     }
 
     /**
-     * Every card ever pulled from a booster, duplicates and holos included.
+     * Every card ever pulled from a booster, duplicates included. quantity
+     * already counts holo copies (holoQuantity is a sub-count, not an extra).
      */
     public function countPulledCards(): int
     {
         return (int) $this->createQueryBuilder('oc')
-            ->select('COALESCE(SUM(oc.quantity + oc.holoQuantity), 0)')
+            ->select('COALESCE(SUM(oc.quantity), 0)')
             ->getQuery()
             ->getSingleScalarResult()
         ;

--- a/tests/Functional/HomepageTest.php
+++ b/tests/Functional/HomepageTest.php
@@ -67,8 +67,9 @@ final class HomepageTest extends WebTestCase
         self::assertResponseIsSuccessful();
         $ticker = $crawler->filter('[data-testid="ticker"]')->text();
         $this->assertStringContainsString('2 packs ouverts', $ticker);
-        // 2 openings × (2 normal + 1 holo): duplicates and holos all count
-        $this->assertStringContainsString('6 cartes tirées', $ticker);
+        // 2 openings × quantity 2 — quantity already includes the holo copy,
+        // holoQuantity is a sub-count and must NOT be added on top
+        $this->assertStringContainsString('4 cartes tirées', $ticker);
         $this->assertStringContainsString('univers', $ticker);
         $this->assertStringContainsString('2 packs / jour', $ticker);
     }


### PR DESCRIPTION
Fix homepage repéré après le merge de la phase 5 (#136).

## Ce que ça fait

**Le ticker ne compte plus les holos en double.** `BoosterOpeningCardRepository::countPulledCards()` sommait `quantity + holoQuantity`, or `quantity` porte déjà le total tiré et `holoQuantity` n'en est qu'un sous-compte (même sémantique que `UserCard`). Chaque holo était donc compté deux fois sur l'accueil. Le compteur passe à `SUM(quantity)`.

Bug introduit en phase 5, repéré par l'agent de la phase 6 (signalé dans #138).

## Périmètre réduit après #131

Cette PR embarquait aussi l'exclusion des cartes uniques du tirage du hero (`CardRepository::findRandomCardId()`), les fixtures qui allaient avec et un test dédié. **#131 (mergée) livre déjà ce filtre**, ainsi que sa propre couverture (`tests/Integration/Repository/CardRepositoryHomepageTest.php`, qui vérifie à la fois qu'une carte normale sort et qu'une unique ne sort jamais) ; elle prépare en plus ses 3 cartes publiées directement dans le test de redraw plutôt que dans les fixtures.

Après rebase sur master, tout ce volet a donc été retiré d'ici : plus de doublon de code, de test, ni de modification de `fixtures/Card.yaml`. Le diff se limite au fix du compteur et à son test.

## Tests

- `testTickerShowsRealCounters` recalé sur la vraie sémantique : 2 ouvertures × `quantity` 2 = **4** cartes tirées (holo compris dans `quantity`), au lieu de 6.

`make quality` OK, suite complète 340 tests au vert (fixtures rechargées en base de test).
