### PR TITLE
feat(classement): classement des collectionneurs et profils joueurs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
   - Routes: `/` (homepage), `/boosters` (opening hub), `/extensions` (301 → `/univers`)
   - Uses custom `CardRepository::findRandomCardId()` with RANDOM() DQL function
 - **UniverseController**: `/univers` (index of published extensions with per-universe completion) + `/univers/{slug}` (pokédex page: banner carousel, full description, personal completion, set grid with unowned cards masked behind the card back, related boosters using the hub's claimable-or-owned visibility rule, unique 1/1 drop status without revealing the holder)
+- **LeaderboardController**: `/classement` (route `leaderboard`) + `/joueur/{discordId}` (route `leaderboard_player` — discordId, not username: usernames are not unique). `LeaderboardService` (`src/Service/Leaderboard/`) ranks every player by global completion from one grouped query per metric (never one query per player), deterministic tiebreaks (total copies → username → discordId). Uniques 1/1 are a COUNT only, never named. Profile masking rule: a card of the profile renders in clear ONLY if the visitor also owns it, otherwise the shared `parts/_masked_card.html.twig` card back (also used by the universe page) with zero name leak in the DOM — a 1/1 of another player is therefore always masked. `UserCard.quantity` already includes holo copies (`holoQuantity` is a subset): total copies = SUM(quantity), never quantity + holoQuantity
 
 **Admin (`src/Controller/Admin/`):**
 - **DashboardController**: EasyAdmin dashboard entry

--- a/fixtures/DiscordUser.yaml
+++ b/fixtures/DiscordUser.yaml
@@ -23,3 +23,9 @@ App\Entity\DiscordUser:
   discord_user_veli:
     discordId: 189029821328785409
     username: "Veli"
+
+  # collectionneur de démo : il a des cartes (voir UserCard.yaml) pour que le
+  # classement et le masquage des profils soient testables sans rien ouvrir
+  discord_user_collectionneur:
+    discordId: 100000000000000001
+    username: "Collectionneur"

--- a/fixtures/UserCard.yaml
+++ b/fixtures/UserCard.yaml
@@ -1,0 +1,26 @@
+# Collections de démo. Le recouvrement est volontaire : sur le profil du
+# Collectionneur, Barlito voit en clair la carte qu'il possède aussi et face
+# cachée celles qu'il n'a pas — les deux cas du masquage sur un seul écran.
+App\Entity\UserCard:
+  user_card_barlito_cp_barlito:
+    discordUser: '@discord_user_barlito'
+    card: '@card_cp_barlito'
+    quantity: 3
+    holoQuantity: 1
+
+  user_card_collectionneur_cp_barlito:
+    discordUser: '@discord_user_collectionneur'
+    card: '@card_cp_barlito'
+    quantity: 2
+    holoQuantity: 1
+
+  user_card_collectionneur_rogue:
+    discordUser: '@discord_user_collectionneur'
+    card: '@card_rogue'
+    quantity: 1
+
+  user_card_collectionneur_ichigo:
+    discordUser: '@discord_user_collectionneur'
+    card: '@card_ichigo'
+    quantity: 4
+    holoQuantity: 2

--- a/src/Controller/LeaderboardController.php
+++ b/src/Controller/LeaderboardController.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Entity\UserCard;
+use App\Repository\DiscordUserRepository;
+use App\Repository\UserCardRepository;
+use App\Service\Leaderboard\LeaderboardService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
+
+/**
+ * The collectors leaderboard and the public player profiles. A profile only
+ * reveals a card the visitor ALSO owns; everything else is masked (card back,
+ * no name anywhere in the DOM) — the 1/1 mystery included.
+ */
+class LeaderboardController extends AbstractController
+{
+    public function __construct(
+        private readonly LeaderboardService $leaderboardService,
+        private readonly DiscordUserRepository $discordUserRepository,
+        private readonly UserCardRepository $userCardRepository,
+    ) {
+    }
+
+    #[Route('/classement', name: 'leaderboard')]
+    public function index(#[CurrentUser] DiscordUser $user): Response
+    {
+        return $this->render('pages/leaderboard.html.twig', [
+            'entries' => $this->leaderboardService->getLeaderboard(),
+            'currentUser' => $user,
+        ]);
+    }
+
+    #[Route('/joueur/{discordId}', name: 'leaderboard_player', requirements: ['discordId' => '\d+'])]
+    public function player(#[CurrentUser] DiscordUser $visitor, string $discordId): Response
+    {
+        $profile = $this->discordUserRepository->find($discordId);
+
+        if (!$profile instanceof DiscordUser) {
+            throw $this->createNotFoundException(\sprintf('Unknown player "%s".', $discordId));
+        }
+
+        $isSelf = $visitor->getDiscordId() === $profile->getDiscordId();
+        // cards the VISITOR owns: the reveal key of the masking rule
+        $visitorCardIds = $isSelf ? [] : array_flip($this->userCardRepository->findOwnedCardIds($visitor));
+
+        $universes = [];
+        $hiddenTotal = 0;
+        foreach ($this->userCardRepository->findOwnedWithCards($profile) as $userCard) {
+            $extension = $userCard->getCard()->getExtension();
+            if (!$extension instanceof Extension) {
+                continue;
+            }
+            $extensionId = (string) $extension->getId();
+            $visible = $isSelf || isset($visitorCardIds[(string) $userCard->getCard()->getId()]);
+
+            $universes[$extensionId] ??= ['extension' => $extension, 'cards' => [], 'hiddenCount' => 0];
+            $universes[$extensionId]['cards'][] = ['userCard' => $userCard, 'visible' => $visible];
+            $universes[$extensionId]['hiddenCount'] += $visible ? 0 : 1;
+            $hiddenTotal += $visible ? 0 : 1;
+        }
+
+        /** @var list<array{extension: Extension, cards: list<array{userCard: UserCard, visible: bool}>, hiddenCount: int}> $universes */
+        $universes = array_values($universes);
+        usort($universes, static fn (array $a, array $b): int => strcasecmp($a['extension']->getName(), $b['extension']->getName()));
+
+        return $this->render('pages/player_profile.html.twig', [
+            'profile' => $profile,
+            'entry' => $this->leaderboardService->getEntryFor($profile),
+            'universes' => $universes,
+            'hiddenTotal' => $hiddenTotal,
+            'isSelf' => $isSelf,
+        ]);
+    }
+}

--- a/src/Dto/LeaderboardEntry.php
+++ b/src/Dto/LeaderboardEntry.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Service\Leaderboard;
+namespace App\Dto;
 
 use App\Entity\DiscordUser;
 

--- a/src/Repository/BoosterOpeningRepository.php
+++ b/src/Repository/BoosterOpeningRepository.php
@@ -22,4 +22,27 @@ class BoosterOpeningRepository extends ServiceEntityRepository
     {
         return $this->count([]);
     }
+
+    /**
+     * Boosters opened per player, one grouped query (leaderboard stat).
+     *
+     * @return array<string, int> discord id => openings
+     */
+    public function countGroupedByUser(): array
+    {
+        /** @var list<array{userId: string, openingCount: string|int}> $rows */
+        $rows = $this->createQueryBuilder('o')
+            ->select('IDENTITY(o.discordUser) AS userId', 'COUNT(o.id) AS openingCount')
+            ->groupBy('o.discordUser')
+            ->getQuery()
+            ->getResult()
+        ;
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[$row['userId']] = (int) $row['openingCount'];
+        }
+
+        return $counts;
+    }
 }

--- a/src/Repository/CardRepository.php
+++ b/src/Repository/CardRepository.php
@@ -108,6 +108,31 @@ class CardRepository extends ServiceEntityRepository
     }
 
     /**
+     * How many one-of-one uniques each player holds (leaderboard stat): the
+     * count only — WHICH uniques someone holds stays a mystery on purpose.
+     *
+     * @return array<string, int> discord id => claimed uniques
+     */
+    public function countClaimedUniquesByUser(): array
+    {
+        /** @var list<array{userId: string, uniqueCount: string|int}> $rows */
+        $rows = $this->createQueryBuilder('c')
+            ->select('IDENTITY(c.claimedBy) AS userId', 'COUNT(c.id) AS uniqueCount')
+            ->andWhere('c.claimedBy IS NOT NULL')
+            ->groupBy('c.claimedBy')
+            ->getQuery()
+            ->getResult()
+        ;
+
+        $counts = [];
+        foreach ($rows as $row) {
+            $counts[$row['userId']] = (int) $row['uniqueCount'];
+        }
+
+        return $counts;
+    }
+
+    /**
      * Cover artwork of the "next universe" teaser: the extension's rarest
      * card, DRAFTS INCLUDED — a teased universe is unpublished, so its cards
      * usually are too (the tile blurs the artwork anyway).

--- a/src/Repository/UserCardRepository.php
+++ b/src/Repository/UserCardRepository.php
@@ -107,6 +107,43 @@ class UserCardRepository extends ServiceEntityRepository
     }
 
     /**
+     * Collection aggregates for every collector at once (leaderboard): distinct
+     * cards, total copies (holos included) and holo copies — a single grouped
+     * query instead of one per player.
+     *
+     * @return array<string, array{distinct: int, total: int, holo: int}> discord id => stats
+     */
+    public function aggregateOwnedByUser(): array
+    {
+        /** @var list<array{userId: string, distinctCount: string|int, totalCount: string|int, holoCount: string|int}> $rows */
+        $rows = $this->createQueryBuilder('uc')
+            ->select(
+                'IDENTITY(uc.discordUser) AS userId',
+                'COUNT(DISTINCT c.id) AS distinctCount',
+                // quantity already includes the holo copies (holoQuantity is a subset)
+                'COALESCE(SUM(uc.quantity), 0) AS totalCount',
+                'COALESCE(SUM(uc.holoQuantity), 0) AS holoCount',
+            )
+            ->join('uc.card', 'c')
+            ->andWhere('uc.quantity > 0 OR uc.holoQuantity > 0')
+            ->groupBy('uc.discordUser')
+            ->getQuery()
+            ->getResult()
+        ;
+
+        $stats = [];
+        foreach ($rows as $row) {
+            $stats[$row['userId']] = [
+                'distinct' => (int) $row['distinctCount'],
+                'total' => (int) $row['totalCount'],
+                'holo' => (int) $row['holoCount'],
+            ];
+        }
+
+        return $stats;
+    }
+
+    /**
      * Total number of cards owned, holo included (collection banner stat).
      */
     public function sumOwnedQuantities(DiscordUser $discordUser): int

--- a/src/Service/Leaderboard/LeaderboardEntry.php
+++ b/src/Service/Leaderboard/LeaderboardEntry.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Leaderboard;
+
+use App\Entity\DiscordUser;
+
+/**
+ * One leaderboard row: a player and their collection aggregates. Uniques are a
+ * COUNT only — which 1/1 cards someone holds is never exposed.
+ */
+final readonly class LeaderboardEntry
+{
+    public function __construct(
+        public int $rank,
+        public DiscordUser $user,
+        public int $distinctCards,
+        public int $totalCards,
+        public int $holoCards,
+        public int $uniqueCards,
+        public int $openedBoosters,
+        public int $completionPct,
+    ) {
+    }
+}

--- a/src/Service/Leaderboard/LeaderboardService.php
+++ b/src/Service/Leaderboard/LeaderboardService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Service\Leaderboard;
 
+use App\Dto\LeaderboardEntry;
 use App\Entity\DiscordUser;
 use App\Repository\BoosterOpeningRepository;
 use App\Repository\CardRepository;

--- a/src/Service/Leaderboard/LeaderboardService.php
+++ b/src/Service/Leaderboard/LeaderboardService.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Leaderboard;
+
+use App\Entity\DiscordUser;
+use App\Repository\BoosterOpeningRepository;
+use App\Repository\CardRepository;
+use App\Repository\DiscordUserRepository;
+use App\Repository\ExtensionRepository;
+use App\Repository\UserCardRepository;
+
+/**
+ * Builds the collectors leaderboard: every player ranked by global completion
+ * (distinct owned cards vs published catalogue). Each metric comes from one
+ * grouped query — never one query per player.
+ */
+final readonly class LeaderboardService
+{
+    public function __construct(
+        private DiscordUserRepository $discordUserRepository,
+        private UserCardRepository $userCardRepository,
+        private CardRepository $cardRepository,
+        private BoosterOpeningRepository $boosterOpeningRepository,
+        private ExtensionRepository $extensionRepository,
+    ) {
+    }
+
+    /**
+     * @return list<LeaderboardEntry>
+     */
+    public function getLeaderboard(): array
+    {
+        $ownedStats = $this->userCardRepository->aggregateOwnedByUser();
+        $uniqueCounts = $this->cardRepository->countClaimedUniquesByUser();
+        $openingCounts = $this->boosterOpeningRepository->countGroupedByUser();
+        // same denominator as the collection page: published cards of published extensions
+        $totalPublished = array_sum(array_column($this->extensionRepository->findPublishedWithPublishedCardCount(), 'cardCount'));
+
+        $players = $this->discordUserRepository->findAll();
+
+        usort(
+            $players,
+            static function (DiscordUser $a, DiscordUser $b) use ($ownedStats): int {
+                $statsA = $ownedStats[$a->getDiscordId()] ?? ['distinct' => 0, 'total' => 0];
+                $statsB = $ownedStats[$b->getDiscordId()] ?? ['distinct' => 0, 'total' => 0];
+
+                // completion desc == distinct desc (shared denominator), total copies
+                // then username/discordId as deterministic tiebreaks
+                return $statsB['distinct'] <=> $statsA['distinct']
+                    ?: $statsB['total'] <=> $statsA['total']
+                    ?: strcasecmp($a->getUsername(), $b->getUsername())
+                    ?: $a->getDiscordId() <=> $b->getDiscordId();
+            },
+        );
+
+        $entries = [];
+        foreach ($players as $index => $player) {
+            $discordId = $player->getDiscordId();
+            $stats = $ownedStats[$discordId] ?? ['distinct' => 0, 'total' => 0, 'holo' => 0];
+
+            $entries[] = new LeaderboardEntry(
+                rank: $index + 1,
+                user: $player,
+                distinctCards: $stats['distinct'],
+                totalCards: $stats['total'],
+                holoCards: $stats['holo'],
+                uniqueCards: $uniqueCounts[$discordId] ?? 0,
+                openedBoosters: $openingCounts[$discordId] ?? 0,
+                completionPct: $totalPublished > 0 ? (int) round($stats['distinct'] / $totalPublished * 100) : 0,
+            );
+        }
+
+        return $entries;
+    }
+
+    /**
+     * The leaderboard row of a single player, rank included (profile header).
+     */
+    public function getEntryFor(DiscordUser $user): LeaderboardEntry
+    {
+        foreach ($this->getLeaderboard() as $entry) {
+            if ($entry->user->getDiscordId() === $user->getDiscordId()) {
+                return $entry;
+            }
+        }
+
+        throw new \LogicException(\sprintf('Player "%s" missing from the leaderboard.', $user->getDiscordId()));
+    }
+}

--- a/templates/pages/leaderboard.html.twig
+++ b/templates/pages/leaderboard.html.twig
@@ -1,0 +1,79 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    YOUL TCG — Classement
+{% endblock %}
+
+{% block body %}
+    <main>
+        <section class="relative px-6 pb-24 pt-10 lg:px-12">
+            <div class="glow-ambient" aria-hidden="true"></div>
+            <div class="relative mx-auto max-w-7xl">
+                <p class="eyebrow">Classement</p>
+                <h1 class="mt-1 font-display text-4xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-5xl">
+                    Les collectionneurs
+                </h1>
+                <p class="mt-2 max-w-2xl text-sm leading-relaxed text-ink-muted">
+                    Tous les joueurs, classés par complétion globale de la collection. Les 1/1 restent secrètes : on affiche combien, jamais lesquelles.
+                </p>
+
+                <div class="mt-10 border border-hairline bg-surface" data-testid="leaderboard">
+                    {# en-tête de colonnes (desktop) #}
+                    <div class="hidden items-center gap-4 border-b border-hairline px-5 py-3 font-mono text-[10px] uppercase tracking-[.2em] text-ink-dim md:grid md:grid-cols-[3rem_minmax(0,1fr)_minmax(0,14rem)_4.5rem_4.5rem_4.5rem_4.5rem_4.5rem]">
+                        <span>#</span>
+                        <span>Joueur</span>
+                        <span>Complétion</span>
+                        <span class="text-right">Cartes</span>
+                        <span class="text-right">Total</span>
+                        <span class="text-right">Holos</span>
+                        <span class="text-right">1/1</span>
+                        <span class="text-right">Packs</span>
+                    </div>
+
+                    {% for entry in entries %}
+                        {% set isMe = entry.user.discordId == currentUser.discordId %}
+                        <a href="{{ path('leaderboard_player', { discordId: entry.user.discordId }) }}"
+                           data-testid="leaderboard-row"
+                           {{ isMe ? 'data-current="true"' }}
+                           class="group grid grid-cols-[3rem_minmax(0,1fr)_auto] items-center gap-4 border-b border-hairline px-5 py-4 transition-colors last:border-b-0 hover:bg-white/[.03] md:grid-cols-[3rem_minmax(0,1fr)_minmax(0,14rem)_4.5rem_4.5rem_4.5rem_4.5rem_4.5rem] {{ isMe ? 'border-l-2 border-l-primary bg-primary/5' : 'border-l-2 border-l-transparent' }}">
+                            <span class="font-display text-xl font-bold tracking-[-0.04em] {{ entry.rank <= 3 ? 'text-primary [text-shadow:0_0_12px_#a435f077]' : 'text-ink-dim' }}">
+                                {{ '%02d'|format(entry.rank) }}
+                            </span>
+
+                            <span class="flex min-w-0 items-center gap-3">
+                                <span class="flex h-9 w-9 shrink-0 items-center justify-center bg-gradient-to-br from-primary to-magenta font-display text-base font-bold text-black">
+                                    {{ entry.user.username|first|upper }}
+                                </span>
+                                <span class="min-w-0">
+                                    <span class="block truncate font-display text-sm font-bold uppercase tracking-[.05em] text-ink-strong transition-colors group-hover:text-primary">
+                                        {{ entry.user.username }}
+                                        {% if isMe %}<span class="font-mono text-[9px] tracking-[.2em] text-primary">· TOI</span>{% endif %}
+                                    </span>
+                                    <span class="chip-mono block text-ink-dim md:hidden">{{ entry.distinctCards }} cartes · ✦{{ entry.holoCards }} · ▣{{ entry.openedBoosters }}</span>
+                                </span>
+                            </span>
+
+                            <span class="block">
+                                <span class="chip-mono flex justify-between text-ink-muted">
+                                    <span class="hidden md:inline">{{ entry.distinctCards }} distinctes</span>
+                                    <span class="font-bold text-primary">{{ entry.completionPct }}%</span>
+                                </span>
+                                <span class="mt-1.5 block h-1 bg-white/10">
+                                    <span class="block h-full bg-gradient-to-r from-primary to-magenta shadow-[0_0_8px_#a435f077]" style="width: {{ entry.completionPct }}%;"></span>
+                                </span>
+                            </span>
+
+                            <span class="hidden text-right font-mono text-sm text-ink md:block">{{ entry.distinctCards }}</span>
+                            <span class="hidden text-right font-mono text-sm text-ink-muted md:block">{{ entry.totalCards }}</span>
+                            <span class="hidden text-right font-mono text-sm md:block {{ entry.holoCards > 0 ? 'text-primary' : 'text-ink-dim' }}">✦{{ entry.holoCards }}</span>
+                            <span class="hidden text-right font-mono text-sm md:block {{ entry.uniqueCards > 0 ? 'text-magenta' : 'text-ink-dim' }}">◆{{ entry.uniqueCards }}</span>
+                            <span class="hidden text-right font-mono text-sm text-ink-muted md:block">{{ entry.openedBoosters }}</span>
+                        </a>
+                    {% else %}
+                        <p class="px-8 py-16 text-center text-ink-dim">Aucun joueur pour le moment.</p>
+                    {% endfor %}
+                </div>
+            </div>
+        </section>
+    </main>
+{% endblock %}

--- a/templates/pages/player_profile.html.twig
+++ b/templates/pages/player_profile.html.twig
@@ -1,0 +1,107 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    YOUL TCG — Profil de {{ profile.username }}
+{% endblock %}
+
+{% block body %}
+    <main>
+        {# --------------------------------------------------- Bandeau joueur #}
+        <section class="relative border-b border-hairline px-6 py-10 lg:px-12">
+            <div class="glow-ambient" aria-hidden="true"></div>
+            <div class="relative mx-auto grid max-w-7xl items-center gap-8 md:grid-cols-[auto_1fr_auto]">
+                <div class="notched-avatar h-[100px] w-[100px] bg-gradient-to-br from-primary to-magenta p-[3px]">
+                    <div class="notched-avatar flex h-full w-full items-center justify-center bg-bg font-display text-[44px] font-bold text-primary">
+                        {{ profile.username|first|upper }}
+                    </div>
+                </div>
+
+                <div>
+                    <p class="eyebrow">Profil joueur</p>
+                    <h1 class="mt-1 font-display text-4xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-5xl">
+                        {{ profile.username }}
+                        {% if isSelf %}<span class="align-middle font-mono text-xs tracking-[.2em] text-primary">· TOI</span>{% endif %}
+                    </h1>
+                    <p class="mt-1.5 font-mono text-xs text-ink-dim">joueur depuis {{ profile.createdAt|date('m/Y') }}</p>
+
+                    <div class="mt-4 max-w-md" data-testid="profile-completion">
+                        <div class="chip-mono mb-1 flex justify-between text-ink-muted">
+                            <span>Complétion</span>
+                            <span>{{ entry.distinctCards }} cartes distinctes · {{ entry.completionPct }}%</span>
+                        </div>
+                        <div class="h-2 border border-hairline bg-surface">
+                            <div class="h-full bg-gradient-to-r from-primary to-magenta shadow-[0_0_10px_#a435f0]"
+                                 style="width: {{ entry.completionPct }}%;"></div>
+                        </div>
+                    </div>
+
+                    <div class="chip-mono mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-ink-muted" data-testid="profile-stats">
+                        <span>◈ {{ entry.totalCards }} carte{{ entry.totalCards > 1 ? 's' }} au total</span>
+                        <span class="{{ entry.holoCards > 0 ? 'text-primary' : '' }}">✦ {{ entry.holoCards }} holo{{ entry.holoCards > 1 ? 's' }}</span>
+                        <span class="{{ entry.uniqueCards > 0 ? 'text-magenta' : '' }}">◆ {{ entry.uniqueCards }} unique{{ entry.uniqueCards > 1 ? 's' }} 1/1</span>
+                        <span>▣ {{ entry.openedBoosters }} pack{{ entry.openedBoosters > 1 ? 's' }} ouvert{{ entry.openedBoosters > 1 ? 's' }}</span>
+                    </div>
+                </div>
+
+                <div class="flex flex-col items-start gap-2.5 md:items-end">
+                    <div class="bg-primary px-5 py-3.5 text-black" data-testid="profile-rank">
+                        <p class="font-mono text-[10px] font-bold tracking-[.2em]">CLASSEMENT</p>
+                        <p class="mt-1 font-display text-3xl font-bold leading-none">#{{ entry.rank }}</p>
+                    </div>
+                    <a href="{{ path('leaderboard') }}"
+                       class="border border-primary bg-black px-5 py-3.5 font-display text-[13px] font-bold uppercase tracking-[.15em] text-primary">
+                        ◂ Le classement
+                    </a>
+                </div>
+            </div>
+        </section>
+
+        {# ------------------------------------------- Collection par univers #}
+        <section class="px-6 pb-24 pt-8 lg:px-12">
+            <div class="mx-auto max-w-7xl">
+                {% if not isSelf and hiddenTotal > 0 %}
+                    <p class="chip-mono mb-8 inline-block border border-hairline bg-surface px-3 py-2 text-ink-muted" data-testid="masking-hint">
+                        Les cartes que tu ne possèdes pas encore restent face cachée. À toi de les trouver.
+                    </p>
+                {% endif %}
+
+                {% for universe in universes %}
+                    {% set universeCount = universe.cards|length %}
+                    <div class="mb-12" data-testid="profile-universe">
+                        <div class="flex flex-wrap items-baseline justify-between gap-2">
+                            <h2 class="font-display text-sm font-bold uppercase tracking-[.1em] text-ink-strong">
+                                {{ universe.extension.name }}
+                            </h2>
+                            <span class="chip-mono text-ink-dim" data-testid="universe-count">
+                                {{ universeCount }} carte{{ universeCount > 1 ? 's' }}{% if universe.hiddenCount > 0 %} dont {{ universe.hiddenCount }} que tu n'as pas encore{% endif %}
+                            </span>
+                        </div>
+
+                        <div class="mt-6 grid grid-cols-2 gap-6 md:grid-cols-3 xl:grid-cols-5" data-testid="profile-grid">
+                            {% for item in universe.cards %}
+                                <div class="card-tile relative">
+                                    {% if item.visible %}
+                                        {{ include('components/CardComponent.html.twig', { card: item.userCard.card, holo: item.userCard.holoQuantity > 0, lazy: true }) }}
+                                        <div class="card-tile__chips pointer-events-none absolute -right-2 -top-2 z-10 flex gap-1.5">
+                                            <span class="chip-mono bg-black/90 px-2 py-1 font-bold text-white">×{{ item.userCard.quantity }}</span>
+                                            {% if item.userCard.holoQuantity > 0 %}
+                                                <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">✦{{ item.userCard.holoQuantity }}</span>
+                                            {% endif %}
+                                        </div>
+                                    {% else %}
+                                        {{ include('parts/_masked_card.html.twig') }}
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% else %}
+                    <div class="border border-dashed border-hairline px-8 py-20 text-center text-ink-dim" data-testid="empty-state">
+                        <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Collection vide.</p>
+                        <p class="mt-3 text-sm">{{ isSelf ? 'Aucune carte pour le moment. Ouvre un pack, gros youl.' : 'Ce joueur n\'a encore aucune carte.' }}</p>
+                    </div>
+                {% endfor %}
+            </div>
+        </section>
+    </main>
+{% endblock %}

--- a/templates/pages/universe.html.twig
+++ b/templates/pages/universe.html.twig
@@ -104,12 +104,7 @@
                                     {% endif %}
                                 </div>
                             {% else %}
-                                {# carte non possédée : dos de carte, aucun indice (nom / rareté) #}
-                                <div class="flex aspect-[0.718] items-center justify-center overflow-hidden rounded-[4.55%/3.5%] border border-hairline bg-surface"
-                                     data-testid="masked-card">
-                                    <span class="h-full w-full bg-cover bg-center opacity-50" aria-hidden="true"
-                                          style="background-image: url('{{ asset('images/card-back.svg') }}');"></span>
-                                </div>
+                                {{ include('parts/_masked_card.html.twig') }}
                             {% endif %}
                         </div>
                     {% endfor %}

--- a/templates/parts/_header.html.twig
+++ b/templates/parts/_header.html.twig
@@ -14,6 +14,7 @@
             {{ _self.nav_link('collection', 'Collection') }}
             {{ _self.nav_link('universes', 'Univers') }}
             {{ _self.nav_link('boosters', 'Boosters') }}
+            {{ _self.nav_link('leaderboard', 'Classement') }}
             {{ _self.nav_soon('Échanges') }}
             {{ _self.nav_soon('Duels') }}
         </nav>

--- a/templates/parts/_masked_card.html.twig
+++ b/templates/parts/_masked_card.html.twig
@@ -1,0 +1,6 @@
+{# tuile masquée : dos de carte, aucun indice (ni nom, ni rareté, ni artwork) #}
+<div class="flex aspect-[0.718] items-center justify-center overflow-hidden rounded-[4.55%/3.5%] border border-hairline bg-surface"
+     data-testid="masked-card">
+    <span class="h-full w-full bg-cover bg-center opacity-50" aria-hidden="true"
+          style="background-image: url('{{ asset('images/card-back.svg') }}');"></span>
+</div>

--- a/tests/Functional/CollectionControllerTest.php
+++ b/tests/Functional/CollectionControllerTest.php
@@ -20,6 +20,8 @@ final class CollectionControllerTest extends WebTestCase
 {
     use JwtAuthTrait;
 
+    private const string USER_WITHOUT_FIXTURE_CARDS = '195659530363731968';
+
     private KernelBrowser $client;
 
     private EntityManagerInterface $entityManager;
@@ -38,7 +40,9 @@ final class CollectionControllerTest extends WebTestCase
     {
         $this->client = self::createClient();
         $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
-        $this->user = $this->authenticateClient($this->client);
+        // a player WITHOUT any fixture card: the banner totals below are exact,
+        // they must not drift when the demo collections grow
+        $this->user = $this->authenticateClient($this->client, self::USER_WITHOUT_FIXTURE_CARDS);
 
         $this->createScenario();
     }

--- a/tests/Functional/LeaderboardControllerTest.php
+++ b/tests/Functional/LeaderboardControllerTest.php
@@ -50,9 +50,12 @@ final class LeaderboardControllerTest extends WebTestCase
         $rival = $this->createPlayer('Rival');
         $cards = [$this->createCard(), $this->createCard(), $this->createCard()];
 
-        // rival: 2 distinct cards (3 copies, 1 holo) + 1 opened pack; me: 1 distinct card
+        // rival: 3 distinct cards (4 copies, 1 holo) + 1 opened pack; me: 1 distinct
+        // card. The gap stays wide enough that the demo fixture collections
+        // cannot flip the order.
         $this->giveCard($rival, $cards[0], quantity: 2, holoQuantity: 1);
         $this->giveCard($rival, $cards[1]);
+        $this->giveCard($rival, $cards[2]);
         $this->giveCard($this->user, $cards[0]);
 
         $booster = new Booster()
@@ -72,7 +75,7 @@ final class LeaderboardControllerTest extends WebTestCase
         $this->assertLessThan($this->positionOf($rows, $this->user->getUsername()), $rivalPosition);
 
         $rivalRow = $rows->eq($rivalPosition);
-        $this->assertStringContainsString('2 distinctes', $rivalRow->text());
+        $this->assertStringContainsString('3 distinctes', $rivalRow->text());
         $this->assertStringContainsString('✦1', $rivalRow->text());
         // ▣N is the mobile summary of the opened packs count
         $this->assertStringContainsString('▣1', $rivalRow->text());

--- a/tests/Functional/LeaderboardControllerTest.php
+++ b/tests/Functional/LeaderboardControllerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Booster;
+use App\Entity\BoosterOpening;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Entity\UserCard;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
+
+final class LeaderboardControllerTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private KernelBrowser $client;
+
+    private EntityManagerInterface $entityManager;
+
+    private DiscordUser $user;
+
+    private Extension $extension;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->user = $this->authenticateClient($this->client);
+
+        $this->extension = new Extension()
+            ->setName('Univers classement ' . uniqid())
+            ->setDescription('Univers du classement')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($this->extension);
+    }
+
+    public function testRanksCollectorsByCompletionWithTheirMetrics(): void
+    {
+        $rival = $this->createPlayer('Rival');
+        $cards = [$this->createCard(), $this->createCard(), $this->createCard()];
+
+        // rival: 2 distinct cards (3 copies, 1 holo) + 1 opened pack; me: 1 distinct card
+        $this->giveCard($rival, $cards[0], quantity: 2, holoQuantity: 1);
+        $this->giveCard($rival, $cards[1]);
+        $this->giveCard($this->user, $cards[0]);
+
+        $booster = new Booster()
+            ->setExtension($this->extension)
+            ->setName('Pack classement')
+            ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]])
+        ;
+        $this->entityManager->persist($booster);
+        $this->entityManager->persist(new BoosterOpening($rival, $booster, 42, new \DateTimeImmutable()));
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/classement');
+
+        self::assertResponseIsSuccessful();
+        $rows = $crawler->filter('[data-testid="leaderboard-row"]');
+        $rivalPosition = $this->positionOf($rows, $rival->getUsername());
+        $this->assertLessThan($this->positionOf($rows, $this->user->getUsername()), $rivalPosition);
+
+        $rivalRow = $rows->eq($rivalPosition);
+        $this->assertStringContainsString('2 distinctes', $rivalRow->text());
+        $this->assertStringContainsString('✦1', $rivalRow->text());
+        // ▣N is the mobile summary of the opened packs count
+        $this->assertStringContainsString('▣1', $rivalRow->text());
+        $this->assertSame('/joueur/' . $rival->getDiscordId(), $rivalRow->attr('href'));
+    }
+
+    public function testTiesBreakOnTotalCopiesThenUsername(): void
+    {
+        $hoarder = $this->createPlayer('Aaa Hoarder');
+        $minimalist = $this->createPlayer('Aaa Minimalist');
+        $card = $this->createCard();
+
+        // same distinct count: more copies wins
+        $this->giveCard($hoarder, $card, quantity: 5);
+        $this->giveCard($minimalist, $card);
+        // both empty-handed: username (asc, case-insensitive) decides
+        $late = $this->createPlayer('Zzz Empty');
+        $early = $this->createPlayer('Aaa Empty');
+        $this->entityManager->flush();
+
+        $rows = $this->client->request('GET', '/classement')->filter('[data-testid="leaderboard-row"]');
+
+        $this->assertLessThan($this->positionOf($rows, $minimalist->getUsername()), $this->positionOf($rows, $hoarder->getUsername()));
+        $this->assertLessThan($this->positionOf($rows, $late->getUsername()), $this->positionOf($rows, $early->getUsername()));
+    }
+
+    public function testCurrentUserRowIsHighlighted(): void
+    {
+        $crawler = $this->client->request('GET', '/classement');
+
+        self::assertResponseIsSuccessful();
+        $highlighted = $crawler->filter('[data-testid="leaderboard-row"][data-current]');
+        $this->assertCount(1, $highlighted);
+        $this->assertStringContainsString($this->user->getUsername(), $highlighted->text());
+    }
+
+    public function testUniquesAreCountedWithoutRevealingWhichOnes(): void
+    {
+        $rival = $this->createPlayer('Détenteur');
+        $unique = $this->createCard(CardRarityEnum::LEGENDARY);
+        $unique->setName('Unique Mystère ' . uniqid());
+        $unique->setUnique(true);
+        $unique->setClaimedBy($rival);
+        $this->giveCard($rival, $unique);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/classement');
+
+        self::assertResponseIsSuccessful();
+        $rows = $crawler->filter('[data-testid="leaderboard-row"]');
+        $rivalRow = $rows->eq($this->positionOf($rows, $rival->getUsername()));
+        $this->assertStringContainsString('◆1', $rivalRow->text());
+        // the count shows, the card itself stays a mystery
+        $this->assertStringNotContainsString($unique->getName(), (string) $this->client->getResponse()->getContent());
+    }
+
+    public function testHeaderNavigationLinksToTheLeaderboard(): void
+    {
+        $crawler = $this->client->request('GET', '/classement');
+
+        self::assertResponseIsSuccessful();
+        $navLink = $crawler->filter('header nav a[href="/classement"]');
+        $this->assertCount(1, $navLink);
+        $this->assertSame('Classement', trim($navLink->text()));
+    }
+
+    private function positionOf(Crawler $rows, string $username): int
+    {
+        foreach ($rows as $index => $row) {
+            if (str_contains($row->textContent, $username)) {
+                return $index;
+            }
+        }
+
+        $this->fail(\sprintf('No leaderboard row for "%s".', $username));
+    }
+
+    private function createPlayer(string $username): DiscordUser
+    {
+        $player = new DiscordUser()
+            ->setDiscordId((string) random_int(300000000000000000, 999999999999999999))
+            ->setUsername($username . ' ' . uniqid())
+        ;
+        $this->entityManager->persist($player);
+
+        return $player;
+    }
+
+    private function createCard(CardRarityEnum $rarity = CardRarityEnum::COMMON): Card
+    {
+        $card = new Card()
+            ->setName('Card L ' . uniqid())
+            ->setDescription('Test card')
+            ->setStatus(CardStatusEnum::PUBLISHED)
+            ->setRarity($rarity)
+            ->setExtension($this->extension)
+        ;
+        $card->setImageName('default_card.png');
+        $this->entityManager->persist($card);
+
+        return $card;
+    }
+
+    private function giveCard(DiscordUser $owner, Card $card, int $quantity = 1, int $holoQuantity = 0): void
+    {
+        $this->entityManager->persist(
+            new UserCard()
+                ->setDiscordUser($owner)
+                ->setCard($card)
+                ->setQuantity($quantity)
+                ->setHoloQuantity($holoQuantity),
+        );
+    }
+}

--- a/tests/Functional/PlayerProfileTest.php
+++ b/tests/Functional/PlayerProfileTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Entity\UserCard;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * The player profile masking rule: a card of the profile is only shown in
+ * clear when the visitor ALSO owns it — otherwise card back, and the name must
+ * not leak anywhere in the DOM (no text, no alt, no title, no aria).
+ */
+final class PlayerProfileTest extends WebTestCase
+{
+    use JwtAuthTrait;
+
+    private KernelBrowser $client;
+
+    private EntityManagerInterface $entityManager;
+
+    private DiscordUser $user;
+
+    private DiscordUser $rival;
+
+    private Extension $extension;
+
+    private Card $sharedCard;
+
+    private Card $secretCard;
+
+    private Card $uniqueCard;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        $this->client = self::createClient();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->user = $this->authenticateClient($this->client);
+
+        $this->createScenario();
+    }
+
+    public function testProfileHeaderShowsIdentityRankAndStats(): void
+    {
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString($this->rival->getUsername(), $crawler->filter('h1')->text());
+        $this->assertStringContainsString('joueur depuis', $crawler->filter('main')->text());
+        $this->assertStringContainsString('3 cartes distinctes', $crawler->filter('[data-testid="profile-completion"]')->text());
+
+        $stats = $crawler->filter('[data-testid="profile-stats"]')->text();
+        $this->assertStringContainsString('4 cartes au total', $stats);
+        $this->assertStringContainsString('1 holo', $stats);
+        $this->assertStringContainsString('1 unique 1/1', $stats);
+        $this->assertStringContainsString('#', $crawler->filter('[data-testid="profile-rank"]')->text());
+    }
+
+    public function testSharedCardIsShownInClear(): void
+    {
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(1, $crawler->filter(\sprintf('img[alt="%s"]', $this->sharedCard->getName())));
+        // the profile's own quantities are public: ×2 and one holo chip
+        $this->assertStringContainsString('×2', $crawler->filter('[data-testid="profile-grid"]')->text());
+    }
+
+    public function testUnsharedCardsAreMaskedWithoutLeakingTheirNames(): void
+    {
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        // secret + unique: two card backs
+        $this->assertCount(2, $crawler->filter('[data-testid="masked-card"]'));
+
+        // no leak at all in the HTML — covers text, alt, title and aria attributes
+        $html = (string) $this->client->getResponse()->getContent();
+        $this->assertStringNotContainsString($this->secretCard->getName(), $html);
+        $this->assertStringNotContainsString($this->uniqueCard->getName(), $html);
+    }
+
+    public function testCardCountsStayVisibleOnMaskedUniverses(): void
+    {
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString(
+            "3 cartes dont 2 que tu n'as pas encore",
+            $crawler->filter('[data-testid="universe-count"]')->text(),
+        );
+    }
+
+    public function testOwnProfileShowsEverythingInClear(): void
+    {
+        // the rival visits their own profile: nothing is masked, the 1/1 included
+        $this->authenticateClient($this->client, $this->rival->getDiscordId());
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(0, $crawler->filter('[data-testid="masked-card"]'));
+        $this->assertCount(1, $crawler->filter(\sprintf('img[alt="%s"]', $this->secretCard->getName())));
+        $this->assertCount(1, $crawler->filter(\sprintf('img[alt="%s"]', $this->uniqueCard->getName())));
+        $this->assertStringNotContainsString("que tu n'as pas encore", $crawler->filter('main')->text());
+    }
+
+    public function testAnotherPlayersUniqueIsAlwaysMaskedForVisitors(): void
+    {
+        // nobody but the claimer can own a 1/1, so it can never be shown to a visitor
+        $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringNotContainsString(
+            $this->uniqueCard->getName(),
+            (string) $this->client->getResponse()->getContent(),
+        );
+    }
+
+    public function testEmptyProfileShowsAnEmptyState(): void
+    {
+        $empty = new DiscordUser()
+            ->setDiscordId((string) random_int(300000000000000000, 999999999999999999))
+            ->setUsername('Empty ' . uniqid())
+        ;
+        $this->entityManager->persist($empty);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/joueur/' . $empty->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $this->assertCount(1, $crawler->filter('[data-testid="empty-state"]'));
+    }
+
+    public function testUnknownPlayerIsNotFound(): void
+    {
+        $this->client->request('GET', '/joueur/111111111111111111');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testNonNumericIdentifierIsNotFound(): void
+    {
+        $this->client->request('GET', '/joueur/not-a-discord-id');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    /**
+     * A rival with 3 cards: one the visitor also owns (shared), one the
+     * visitor doesn't (secret), and a claimed 1/1 (unique).
+     */
+    private function createScenario(): void
+    {
+        $this->extension = new Extension()
+            ->setName('Univers profil ' . uniqid())
+            ->setDescription('Univers du profil')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $this->entityManager->persist($this->extension);
+
+        $this->rival = new DiscordUser()
+            ->setDiscordId((string) random_int(300000000000000000, 999999999999999999))
+            ->setUsername('Rival ' . uniqid())
+        ;
+        $this->entityManager->persist($this->rival);
+
+        $this->sharedCard = $this->createCard('Carte Partagée ' . uniqid());
+        $this->secretCard = $this->createCard('Carte Secrète ' . uniqid());
+        $this->uniqueCard = $this->createCard('Unique Mystère ' . uniqid(), CardRarityEnum::LEGENDARY);
+        $this->uniqueCard->setUnique(true);
+        $this->uniqueCard->setClaimedBy($this->rival);
+
+        $this->giveCard($this->rival, $this->sharedCard, quantity: 2, holoQuantity: 1);
+        $this->giveCard($this->rival, $this->secretCard);
+        $this->giveCard($this->rival, $this->uniqueCard);
+        $this->giveCard($this->user, $this->sharedCard);
+
+        $this->entityManager->flush();
+    }
+
+    private function createCard(string $name, CardRarityEnum $rarity = CardRarityEnum::COMMON): Card
+    {
+        $card = new Card()
+            ->setName($name)
+            ->setDescription('Test card')
+            ->setStatus(CardStatusEnum::PUBLISHED)
+            ->setRarity($rarity)
+            ->setExtension($this->extension)
+        ;
+        $card->setImageName('default_card.png');
+        $this->entityManager->persist($card);
+
+        return $card;
+    }
+
+    private function giveCard(DiscordUser $owner, Card $card, int $quantity = 1, int $holoQuantity = 0): void
+    {
+        $this->entityManager->persist(
+            new UserCard()
+                ->setDiscordUser($owner)
+                ->setCard($card)
+                ->setQuantity($quantity)
+                ->setHoloQuantity($holoQuantity),
+        );
+    }
+}


### PR DESCRIPTION
Phase 7 : le classement des collectionneurs (`/classement`) et les profils joueurs consultables (`/joueur/{discordId}`), avec la règle de masquage stricte sur les collections.

## Ce que ça fait

**`/classement`** — tous les joueurs classés par **complétion globale** (cartes distinctes possédées / cartes publiées, même dénominateur que la page collection : cartes publiées des extensions publiées). Chaque ligne : % + barre de progression, cartes distinctes, total de copies, holos, uniques 1/1 (le **nombre** seulement), packs ouverts. Le joueur connecté est surligné (`data-current`, bordure primary + « TOI »), le top 3 en violet. Chaque ligne mène au profil. Entrée **« Classement »** dans la nav header (les pages profil la laissent allumée, comme `universes_show` → Univers).

**`/joueur/{discordId}`** — en-tête façon `/collection` (avatar initiale, username, « joueur depuis », barre de complétion, stats du classement + tuile **rang**), puis la collection **par univers**, triée rareté ↓ dans chaque set.

## La règle de masquage

Une carte du profil ne s'affiche en clair **que si le visiteur la possède aussi**. Sinon : le dos de carte de la page univers, extrait dans un partial partagé `parts/_masked_card.html.twig` (la page univers l'utilise désormais aussi) — **aucune trace du nom dans le DOM** (ni texte, ni `alt`, ni `title`, ni `aria`) : le calcul de visibilité se fait au contrôleur et le template masqué ne reçoit jamais la carte. Conséquence gratuite : une **1/1 d'un autre joueur est toujours masquée** (personne d'autre ne peut la posséder) ; le détenteur la voit en clair sur son propre profil. Les nombres restent visibles : « 3 cartes dont 2 que tu n'as pas encore » par univers. Son propre profil : tout en clair. Profil inconnu (ou id non numérique) → 404.

## Décisions

- **Identifiant de route = `discordId`** (snowflake, `requirements: \d+`) : c'est la PK, stable et unique — le username ne l'est pas (rien ne l'impose en base, deux joueurs Discord peuvent porter le même nom d'affichage).
- **Agrégats : une requête groupée par métrique, jamais une par joueur.** `UserCardRepository::aggregateOwnedByUser()` (distinct + copies + holos en une seule requête, patron de `countOwnedGroupedByExtension`), `CardRepository::countClaimedUniquesByUser()` (via `Card.claimedBy`), `BoosterOpeningRepository::countGroupedByUser()`. Le tout assemblé par `LeaderboardService` (DTO `LeaderboardEntry` readonly, rang inclus).
- **Départage déterministe** : complétion ↓ (≡ distinctes ↓, dénominateur commun) → copies totales ↓ → username (insensible à la casse) → discordId.
- **Piège évité — `UserCard.quantity` contient déjà les holos** (`holoQuantity` est un sous-ensemble, cf. l'agrégation du `BoosterOpeningService`) : le total de copies est `SUM(quantity)`, pas `quantity + holoQuantity` qui double-compterait. Documenté dans CLAUDE.md.
- Le classement inclut aussi les joueurs à zéro carte (« tous les joueurs »), avec un rendu ligne vide propre.

## Tests

14 tests fonctionnels (WebTestCase + JwtAuthTrait, entités `uniqid()`, assertions d'ordre **relatives** pour cohabiter avec les users des fixtures) :

- **Classement** : ordre par complétion avec métriques par ligne (distinctes, ✦holos, ▣packs), départage copies puis username, ligne courante surlignée, uniques comptées **sans apparaître nommées dans la page**, lien vers le profil, entrée nav.
- **Profil** : en-tête (identité, rang, stats), carte partagée en clair avec chips ×qty/✦, cartes non partagées masquées **sans fuite du nom vérifiée sur le HTML brut de la réponse** (couvre texte, alt, title, aria), compteurs « dont N que tu n'as pas encore », profil perso tout en clair (1/1 incluse), 1/1 d'autrui toujours masquée, profil vide, 404 inconnu et non-numérique.

Suite complète : **353 tests, 2637 assertions, OK**. `make quality` au vert (phpstan 8 zéro baseline, cs-fixer, rector). `make tailwind.build` passé. Vérifié en dev via JWT forgé : `/classement` 200 (ligne unique Barlito 78 distinctes, surlignée), `/joueur/<moi>` 200, inconnu 404.