### PR TITLE
fix(collection): les holos ne comptent plus double dans « Cartes possédées »

### DIFF
--- a/src/Repository/UserCardRepository.php
+++ b/src/Repository/UserCardRepository.php
@@ -144,12 +144,13 @@ class UserCardRepository extends ServiceEntityRepository
     }
 
     /**
-     * Total number of cards owned, holo included (collection banner stat).
+     * Total number of cards owned (collection banner stat). quantity already
+     * counts holo copies (holoQuantity is a sub-count, not an extra).
      */
     public function sumOwnedQuantities(DiscordUser $discordUser): int
     {
         return (int) $this->createQueryBuilder('uc')
-            ->select('COALESCE(SUM(uc.quantity + uc.holoQuantity), 0)')
+            ->select('COALESCE(SUM(uc.quantity), 0)')
             ->andWhere('uc.discordUser = :user')
             ->setParameter('user', $discordUser)
             ->getQuery()

--- a/tests/Functional/CollectionControllerTest.php
+++ b/tests/Functional/CollectionControllerTest.php
@@ -58,8 +58,9 @@ final class CollectionControllerTest extends WebTestCase
         $this->assertStringContainsString('2', $quota);
         $this->assertStringContainsString('/ 2', $quota);
 
+        // 3 (1 holo copy included) + 1 + 0: quantity is the total per card
         $this->assertStringContainsString(
-            'Cartes possédées · 5',
+            'Cartes possédées · 4',
             $crawler->filter('main')->text(),
         );
     }


### PR DESCRIPTION
Troisième occurrence du même bug de sémantique, signalée par l'agent de la phase 7 (PR #140) : `UserCard.quantity` inclut déjà les copies holo (`holoQuantity` est un sous-compte), or `sumOwnedQuantities()` sommait `quantity + holoQuantity` — le bandeau de `/collection` gonflait le total d'une unité par copie holo.

Fix identique à celui du ticker homepage (#139) : `SUM(quantity)`. Le test du bandeau attendait la valeur gonflée (5), recalé sur la vraie (4 = 3 dont 1 holo + 1 + 0).

`make quality` OK, CollectionControllerTest au vert (14 tests).