### PR TITLE
feat(streak): flamme et choix de récompense sur le hub (2/2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ docker exec $(docker ps --filter name="ytcg_php" -q) bin/console make:controller
 - Streak = consecutive Europe/Paris days with ≥1 `BoosterOpening` — computed by QUERY (`BoosterOpeningRepository::findDistinctOpeningDays`, native SQL `AT TIME ZONE`, capped at 3650 distinct days: a shorter window would shift the series identity of long streaks and re-grant milestones), consecutive run walked in PHP (`OpeningStreakService` → `OpeningStreak` DTO). A series ending yesterday still counts (today's opening keeps it alive: `isAtRisk()`)
 - **Series identity** = Paris day the run started; milestones every 7 days (7/14/21…). `StreakReward` is unique on `(user, series_started_on, milestone)`; granting is `INSERT … ON CONFLICT DO NOTHING` (raw SQL — a caught unique violation would close the EntityManager), triggered post-commit in `BoosterOpeningService::open()` (the streak only changes on an opening; all reached milestones are (re)inserted, so a missed grant self-heals)
 - **Spending**: `StreakRewardService::chooseBooster()` — `FOR UPDATE` on the reward row, claim-like guards (claimable + published extension), credits `UserBooster` via `UserInventoryService`. Own distribution channel: no `BoosterClaim`, daily quota untouched
+- Hub UI: flame chip in the hero (always visible — running / at-risk / empty states) + "Récompense de streak" banner surfacing the oldest pending reward with one button per claimable booster (`chooseStreakReward` LiveAction)
 
 ### Booster Opening Flow (`src/Service/Booster/`)
 

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -392,9 +392,11 @@
     display: grid;
     grid-template-columns: repeat(var(--track-count, 3), minmax(0, 1fr));
     gap: 10px;
-    /* 1fr per slot blew a 1-card pack up to the whole panel width: cap the
-       grid so a tile keeps the size it has in a 5-card pack, then centre it */
-    max-width: calc(var(--track-count, 3) * 132px + (var(--track-count, 3) - 1) * 10px);
+    /* 1fr per slot blew a 1-card pack up to the whole panel width. Cap a tile
+       to the size it would have in a 3-card pack — the reference layout — so
+       small packs stay in scale while 3+ cards keep the full width (the
+       max-width then resolves above 100% and never bites). */
+    max-width: calc((100% - 20px) / 3 * var(--track-count, 3) + (var(--track-count, 3) - 1) * 10px);
     margin-inline: auto;
 }
 .opening__track-tile { min-width: 0; }

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -50,6 +50,10 @@ final class BoosterHub extends AbstractController
     #[LiveProp]
     public ?string $streakSuccess = null;
 
+    /** Pack picked in the streak reward selector (its id). */
+    #[LiveProp(writable: true)]
+    public string $streakRewardBoosterId = '';
+
     /**
      * Inventory is read twice per render (hero total + packs grid): memoize
      * the query for the lifetime of the (per-request) component instance.
@@ -256,15 +260,15 @@ final class BoosterHub extends AbstractController
      * a forged live action gets a clean French refusal.
      */
     #[LiveAction]
-    public function chooseStreakReward(#[LiveArg] string $rewardId, #[LiveArg] string $boosterId): void
+    public function chooseStreakReward(#[LiveArg] string $rewardId): void
     {
         $this->streakError = null;
         $this->streakSuccess = null;
 
-        $booster = $this->findBooster($boosterId);
+        $booster = $this->findBooster($this->streakRewardBoosterId);
 
         if (!$booster instanceof Booster) {
-            $this->streakError = 'Booster introuvable.';
+            $this->streakError = 'Choisis un pack avant de valider.';
 
             return;
         }

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -288,11 +288,24 @@ final class BoosterHub extends AbstractController
         }
 
         $this->inventory = null; // the memoized inventory is stale after the credit
+        $this->streakRewardBoosterId = '';
         $this->streakSuccess = \sprintf(
             'Palier %d jours : un pack « %s » ajouté à ton stock !',
             $reward->getMilestone(),
             $booster->getDisplayName(),
         );
+
+        // the banner immediately shows the next milestone: say so, or spending
+        // a reward looks like the click did nothing
+        $remaining = \count($this->getPendingStreakRewards());
+
+        if ($remaining > 0) {
+            $this->streakSuccess .= \sprintf(
+                ' Il te reste %d récompense%s à récupérer.',
+                $remaining,
+                $remaining > 1 ? 's' : '',
+            );
+        }
     }
 
     /**

--- a/src/Twig/Components/BoosterHub.php
+++ b/src/Twig/Components/BoosterHub.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Twig\Components;
 
+use App\Dto\OpeningStreak;
 use App\Entity\Booster;
 use App\Entity\DiscordUser;
+use App\Entity\StreakReward;
 use App\Enum\Booster\BoosterCodeRefusalEnum;
 use App\Exception\Booster\BoosterCodeRefusedException;
 use App\Exception\Booster\BoosterException;
@@ -14,6 +16,8 @@ use App\Repository\UserBoosterRepository;
 use App\Service\Booster\BoosterAvailabilityService;
 use App\Service\Booster\BoosterClaimService;
 use App\Service\Booster\BoosterCodeRedeemService;
+use App\Service\Booster\OpeningStreakService;
+use App\Service\Booster\StreakRewardService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\RateLimiter\RateLimiterFactoryInterface;
 use Symfony\Component\Uid\Uuid;
@@ -40,6 +44,12 @@ final class BoosterHub extends AbstractController
     #[LiveProp]
     public ?string $codeSuccess = null;
 
+    #[LiveProp]
+    public ?string $streakError = null;
+
+    #[LiveProp]
+    public ?string $streakSuccess = null;
+
     /**
      * Inventory is read twice per render (hero total + packs grid): memoize
      * the query for the lifetime of the (per-request) component instance.
@@ -55,6 +65,8 @@ final class BoosterHub extends AbstractController
         private readonly BoosterClaimService $boosterClaimService,
         private readonly BoosterCodeRedeemService $boosterCodeRedeemService,
         private readonly RateLimiterFactoryInterface $boosterCodeRedeemLimiter,
+        private readonly OpeningStreakService $openingStreakService,
+        private readonly StreakRewardService $streakRewardService,
     ) {
     }
 
@@ -204,6 +216,78 @@ final class BoosterHub extends AbstractController
             $redemption->getQuantity() > 1 ? 's' : '',
             $redemption->getBoosterCode()->getBooster()->getDisplayName(),
             $redemption->getQuantity() > 1 ? 's' : '',
+        );
+    }
+
+    public function getStreak(): OpeningStreak
+    {
+        return $this->openingStreakService->getStreak($this->getDiscordUser());
+    }
+
+    /**
+     * Streak milestones whose bonus booster is still to pick, oldest first.
+     * The hub surfaces the first one; the rest queue up behind it.
+     *
+     * @return list<StreakReward>
+     */
+    public function getPendingStreakRewards(): array
+    {
+        return $this->streakRewardService->getPendingRewards($this->getDiscordUser());
+    }
+
+    /**
+     * Boosters offered as a streak bonus: the claimable ones, same visibility
+     * rule as the daily claim (findPublished already scopes to published
+     * extensions).
+     *
+     * @return list<Booster>
+     */
+    public function getStreakRewardChoices(): array
+    {
+        return array_values(array_filter(
+            $this->boosterRepository->findPublished(),
+            $this->boosterAvailability->isClaimable(...),
+        ));
+    }
+
+    /**
+     * Spends a streak reward on the chosen booster. The real guards live in
+     * StreakRewardService (FOR UPDATE on the reward row, claimable booster):
+     * a forged live action gets a clean French refusal.
+     */
+    #[LiveAction]
+    public function chooseStreakReward(#[LiveArg] string $rewardId, #[LiveArg] string $boosterId): void
+    {
+        $this->streakError = null;
+        $this->streakSuccess = null;
+
+        $booster = $this->findBooster($boosterId);
+
+        if (!$booster instanceof Booster) {
+            $this->streakError = 'Booster introuvable.';
+
+            return;
+        }
+
+        if (!Uuid::isValid($rewardId)) {
+            $this->streakError = 'Cette récompense n\'est plus disponible.';
+
+            return;
+        }
+
+        try {
+            $reward = $this->streakRewardService->chooseBooster($this->getDiscordUser(), $rewardId, $booster);
+        } catch (BoosterException $exception) {
+            $this->streakError = $exception->getUserMessage();
+
+            return;
+        }
+
+        $this->inventory = null; // the memoized inventory is stale after the credit
+        $this->streakSuccess = \sprintf(
+            'Palier %d jours : un pack « %s » ajouté à ton stock !',
+            $reward->getMilestone(),
+            $booster->getDisplayName(),
         );
     }
 

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -14,47 +14,58 @@
                     </p>
                 </div>
 
-                <div class="flex flex-col items-start gap-2.5 md:items-end">
-                    <div class="bg-primary px-5 py-3.5 text-black" data-testid="daily-packs">
-                        <p class="font-mono text-[10px] font-bold tracking-[.2em]">PACKS / JOUR</p>
-                        <p class="mt-1 font-display text-3xl font-bold leading-none">
-                            {{ this.remainingClaims }}<span class="text-lg opacity-50"> / {{ constant('App\\Service\\Booster\\BoosterClaimQuotaInterface::DAILY_LIMIT') }}</span>
-                        </p>
+                {# trois tuiles de même gabarit : l'empilement de chips de
+                   longueurs différentes était illisible et jamais aligné #}
+                {% set totalOwned = this.totalOwned %}
+                {% set streak = this.streak %}
+                <div class="flex flex-col items-stretch gap-2.5">
+                    <div class="grid grid-cols-3 gap-2.5">
+                        <div class="bg-primary px-4 py-3 text-black" data-testid="daily-packs">
+                            <p class="font-mono text-[10px] font-bold tracking-[.16em]">PACKS / JOUR</p>
+                            <p class="mt-1 font-display text-3xl font-bold leading-none">
+                                {{ this.remainingClaims }}<span class="text-lg opacity-50">/{{ constant('App\\Service\\Booster\\BoosterClaimQuotaInterface::DAILY_LIMIT') }}</span>
+                            </p>
+                            <p class="mt-1.5 font-mono text-[10px] leading-tight tracking-[.08em] text-black/70">
+                                {% if this.remainingClaims == 0 %}
+                                    dans <span data-controller="countdown"
+                                               data-countdown-seconds-value="{{ this.secondsUntilReset }}">--:--:--</span>
+                                {% else %}
+                                    à récupérer
+                                {% endif %}
+                            </p>
+                        </div>
+
+                        <div class="border border-hairline bg-surface px-4 py-3" data-testid="total-owned">
+                            <p class="font-mono text-[10px] font-bold tracking-[.16em] text-ink-dim">EN STOCK</p>
+                            <p class="mt-1 font-display text-3xl font-bold leading-none {{ totalOwned > 0 ? 'text-primary' : 'text-ink-dim' }}">{{ totalOwned }}</p>
+                            <p class="mt-1.5 font-mono text-[10px] leading-tight tracking-[.08em] text-ink-dim">
+                                pack{{ totalOwned > 1 ? 's' }} à ouvrir
+                            </p>
+                        </div>
+
+                        <div class="border px-4 py-3 {{ streak.running ? 'border-soon/50 bg-soon/5' : 'border-hairline bg-surface' }}"
+                             data-testid="streak-flame">
+                            <p class="font-mono text-[10px] font-bold tracking-[.16em] text-ink-dim">SÉRIE</p>
+                            <p class="mt-1 font-display text-3xl font-bold leading-none {{ streak.running ? 'text-soon' : 'text-ink-dim' }}">
+                                {{ streak.running ? streak.length : 0 }}<span class="text-lg opacity-60">j</span>
+                            </p>
+                            <p class="mt-1.5 font-mono text-[10px] leading-tight tracking-[.08em] {{ streak.atRisk ? 'text-soon' : 'text-ink-dim' }}">
+                                {% if not streak.running %}
+                                    ouvre un pack
+                                {% elseif streak.atRisk %}
+                                    ouvre aujourd'hui !
+                                {% else %}
+                                    palier à {{ streak.nextMilestone }}j
+                                {% endif %}
+                            </p>
+                        </div>
                     </div>
 
-                    {% if this.remainingClaims == 0 %}
-                        <p class="chip-mono text-ink-dim">
-                            Prochains packs dans
-                            <span class="text-primary"
-                                  data-controller="countdown"
-                                  data-countdown-seconds-value="{{ this.secondsUntilReset }}">--:--:--</span>
-                        </p>
-                    {% else %}
-                        <p class="chip-mono text-live">✦ {{ this.remainingClaims }} pack{{ this.remainingClaims > 1 ? 's' }} à récupérer</p>
-                    {% endif %}
-
-                    {% set totalOwned = this.totalOwned %}
-                    <p class="chip-mono {{ totalOwned > 0 ? 'text-primary' : 'text-ink-dim' }}" data-testid="total-owned">
-                        ◈ {{ totalOwned }} pack{{ totalOwned > 1 ? 's' }} en stock
-                    </p>
                     <a href="{{ path('opening_history') }}"
-                       class="chip-mono text-ink-dim transition-colors hover:text-primary"
+                       class="chip-mono self-end text-ink-dim transition-colors hover:text-primary"
                        data-testid="history-link">
                         ◎ Mes ouvertures ▸
                     </a>
-
-                    {% set streak = this.streak %}
-                    {% if streak.running %}
-                        <p class="chip-mono {{ streak.openedToday ? 'text-live' : 'text-soon' }}"
-                           data-testid="streak-flame"
-                           title="Prochain palier à {{ streak.nextMilestone }} jours de suite">
-                            🔥 {{ streak.length }} jour{{ streak.length > 1 ? 's' }} de suite{% if streak.atRisk %} — ouvre un pack aujourd'hui pour continuer !{% endif %}
-                        </p>
-                    {% else %}
-                        <p class="chip-mono text-ink-dim" data-testid="streak-flame">
-                            🔥 Ouvre un pack aujourd'hui pour lancer ta série
-                        </p>
-                    {% endif %}
                 </div>
             </div>
         </section>
@@ -79,23 +90,36 @@
                                 </p>
                             </div>
 
-                            <div class="flex flex-wrap gap-2 md:justify-end">
-                                {% for booster in this.streakRewardChoices %}
+                            {# un bouton par pack devenait ingérable dès que le
+                               catalogue grandit : sélecteur + validation #}
+                            <div class="flex flex-wrap items-center gap-2 md:justify-end">
+                                {% set choices = this.streakRewardChoices %}
+                                {% if choices is empty %}
+                                    <p class="chip-mono text-ink-dim">Aucun pack disponible pour l'instant — ta récompense t'attend.</p>
+                                {% else %}
+                                    <select data-model="norender|streakRewardBoosterId"
+                                            aria-label="Choisir le pack de ta récompense"
+                                            data-testid="streak-reward-select"
+                                            class="w-full min-w-0 border border-hairline bg-surface px-3 py-2 font-mono text-xs tracking-[.08em] text-ink-strong focus:border-primary focus:outline-none md:w-72">
+                                        <option value="">Choisis ton pack…</option>
+                                        {% for booster in choices %}
+                                            <option value="{{ booster.id }}" {{ booster.id == streakRewardBoosterId ? 'selected' }}>
+                                                {{ booster.displayName }}
+                                            </option>
+                                        {% endfor %}
+                                    </select>
                                     {# plain label + opacity while loading: swapping two spans
                                        leaves the hidden one hidden after the re-render #}
                                     <button type="button"
                                             data-action="live#action"
                                             data-live-action-param="chooseStreakReward"
                                             data-live-reward-id-param="{{ reward.id }}"
-                                            data-live-booster-id-param="{{ booster.id }}"
                                             data-loading="addClass(opacity-50)"
                                             data-testid="streak-reward-choice"
-                                            class="border border-primary px-3 py-2 font-display text-xs font-bold uppercase tracking-[.12em] text-primary transition hover:bg-primary hover:text-black">
-                                        {{ booster.displayName }}
+                                            class="shrink-0 border border-primary bg-primary px-4 py-2 font-display text-xs font-bold uppercase tracking-[.12em] text-black transition hover:bg-transparent hover:text-primary">
+                                        Récupérer
                                     </button>
-                                {% else %}
-                                    <p class="chip-mono text-ink-dim">Aucun pack disponible pour l'instant — ta récompense t'attend.</p>
-                                {% endfor %}
+                                {% endif %}
                             </div>
                         </div>
                     {% endif %}

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -42,9 +42,76 @@
                        data-testid="history-link">
                         ◎ Mes ouvertures ▸
                     </a>
+
+                    {% set streak = this.streak %}
+                    {% if streak.running %}
+                        <p class="chip-mono {{ streak.openedToday ? 'text-live' : 'text-soon' }}"
+                           data-testid="streak-flame"
+                           title="Prochain palier à {{ streak.nextMilestone }} jours de suite">
+                            🔥 {{ streak.length }} jour{{ streak.length > 1 ? 's' }} de suite{% if streak.atRisk %} — ouvre un pack aujourd'hui pour continuer !{% endif %}
+                        </p>
+                    {% else %}
+                        <p class="chip-mono text-ink-dim" data-testid="streak-flame">
+                            🔥 Ouvre un pack aujourd'hui pour lancer ta série
+                        </p>
+                    {% endif %}
                 </div>
             </div>
         </section>
+
+        {# ----------------------------------------------------- Streak reward #}
+        {% set pendingRewards = this.pendingStreakRewards %}
+        {% if pendingRewards is not empty or streakError or streakSuccess %}
+            <section class="border-b border-hairline px-6 py-5 lg:px-12" data-testid="streak-reward-banner">
+                <div class="mx-auto max-w-7xl">
+                    {% if pendingRewards is not empty %}
+                        {% set reward = pendingRewards|first %}
+                        <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                            <div>
+                                <p class="font-display text-sm font-bold uppercase tracking-[.15em] text-primary">
+                                    🔥 Récompense de streak — palier {{ reward.milestone }} jours
+                                </p>
+                                <p class="mt-1 max-w-md text-xs text-ink-muted">
+                                    Choisis un pack bonus : il s'ajoute à ton stock sans entamer tes récupérations du jour.
+                                    {% if pendingRewards|length > 1 %}
+                                        Encore {{ pendingRewards|length - 1 }} récompense{{ pendingRewards|length > 2 ? 's' }} ensuite.
+                                    {% endif %}
+                                </p>
+                            </div>
+
+                            <div class="flex flex-wrap gap-2 md:justify-end">
+                                {% for booster in this.streakRewardChoices %}
+                                    {# plain label + opacity while loading: swapping two spans
+                                       leaves the hidden one hidden after the re-render #}
+                                    <button type="button"
+                                            data-action="live#action"
+                                            data-live-action-param="chooseStreakReward"
+                                            data-live-reward-id-param="{{ reward.id }}"
+                                            data-live-booster-id-param="{{ booster.id }}"
+                                            data-loading="addClass(opacity-50)"
+                                            data-testid="streak-reward-choice"
+                                            class="border border-primary px-3 py-2 font-display text-xs font-bold uppercase tracking-[.12em] text-primary transition hover:bg-primary hover:text-black">
+                                        {{ booster.displayName }}
+                                    </button>
+                                {% else %}
+                                    <p class="chip-mono text-ink-dim">Aucun pack disponible pour l'instant — ta récompense t'attend.</p>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endif %}
+
+                    {% if streakError %}
+                        <div class="{{ pendingRewards is not empty ? 'mt-3' }} border border-magenta/50 bg-magenta/10 px-4 py-2.5 font-mono text-xs text-magenta" data-testid="streak-error">
+                            ⚠ {{ streakError }}
+                        </div>
+                    {% elseif streakSuccess %}
+                        <div class="{{ pendingRewards is not empty ? 'mt-3' }} border border-live/50 bg-live/10 px-4 py-2.5 font-mono text-xs text-live" data-testid="streak-success">
+                            ✦ {{ streakSuccess }}
+                        </div>
+                    {% endif %}
+                </div>
+            </section>
+        {% endif %}
 
         {# ----------------------------------------------------- Code redemption #}
         <section class="border-b border-hairline px-6 py-5 lg:px-12">

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -81,6 +81,9 @@
                             <div>
                                 <p class="font-display text-sm font-bold uppercase tracking-[.15em] text-primary">
                                     🔥 Récompense de streak — palier {{ reward.milestone }} jours
+                                    {% if pendingRewards|length > 1 %}
+                                        <span class="text-ink-dim" data-testid="streak-reward-counter">· 1 / {{ pendingRewards|length }}</span>
+                                    {% endif %}
                                 </p>
                                 <p class="mt-1 max-w-md text-xs text-ink-muted">
                                     Choisis un pack bonus : il s'ajoute à ton stock sans entamer tes récupérations du jour.

--- a/tests/Functional/BoosterHubComponentTest.php
+++ b/tests/Functional/BoosterHubComponentTest.php
@@ -9,6 +9,7 @@ use App\Repository\BoosterRepository;
 use App\Twig\Components\BoosterHub;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
 
 final class BoosterHubComponentTest extends WebTestCase
@@ -40,7 +41,7 @@ final class BoosterHubComponentTest extends WebTestCase
         // The owned count is surfaced on the pack card and totalled in the hero.
         $rendered = (string) $component->render();
         $this->assertStringContainsString('◈ 1 pack à ouvrir', $rendered);
-        $this->assertStringContainsString('◈ 1 pack en stock', $rendered);
+        $this->assertStringContainsString('1 pack à ouvrir', $this->stockTile($rendered));
     }
 
     public function testEmptyInventoryShowsAnExplicitZeroStockState(): void
@@ -52,7 +53,7 @@ final class BoosterHubComponentTest extends WebTestCase
         $rendered = (string) $component->render();
 
         $this->assertStringContainsString('◈ Aucun pack', $rendered);
-        $this->assertStringContainsString('◈ 0 pack en stock', $rendered);
+        $this->assertStringContainsString('0 pack à ouvrir', $this->stockTile($rendered));
     }
 
     public function testClaimBoosterWithMalformedIdReportsNotFoundInsteadOfCrashing(): void
@@ -174,6 +175,14 @@ final class BoosterHubComponentTest extends WebTestCase
         // The rendered "Ouvrir" control for Bleach is disabled, no scary error needed.
         $rendered = (string) $component->render();
         $this->assertStringContainsString('À venir', $rendered);
+    }
+
+    /**
+     * Text of the "en stock" hero tile, whitespace normalized.
+     */
+    private function stockTile(string $rendered): string
+    {
+        return new Crawler($rendered)->filter('[data-testid="total-owned"]')->text(normalizeWhitespace: true);
     }
 
     private function firstPublishedBooster(): \App\Entity\Booster

--- a/tests/Functional/StreakHubComponentTest.php
+++ b/tests/Functional/StreakHubComponentTest.php
@@ -13,6 +13,7 @@ use App\Repository\BoosterRepository;
 use App\Twig\Components\BoosterHub;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
 
 final class StreakHubComponentTest extends WebTestCase
@@ -30,8 +31,7 @@ final class StreakHubComponentTest extends WebTestCase
 
         $rendered = (string) $this->createLiveComponent(BoosterHub::class, client: $client)->render();
 
-        $this->assertStringContainsString('data-testid="streak-flame"', $rendered);
-        $this->assertStringContainsString('Ouvre un pack aujourd\'hui pour lancer ta série', $rendered);
+        $this->assertStringContainsString('ouvre un pack', $this->streakTile($rendered));
         $this->assertStringNotContainsString('data-testid="streak-reward-banner"', $rendered);
     }
 
@@ -43,8 +43,10 @@ final class StreakHubComponentTest extends WebTestCase
 
         $rendered = (string) $this->createLiveComponent(BoosterHub::class, client: $client)->render();
 
-        $this->assertStringContainsString('🔥 3 jours de suite', $rendered);
-        $this->assertStringNotContainsString('pour continuer', $rendered);
+        $tile = $this->streakTile($rendered);
+        $this->assertStringContainsString('3j', $tile);
+        $this->assertStringContainsString('palier à 7j', $tile);
+        $this->assertStringNotContainsString('aujourd\'hui', $tile);
     }
 
     public function testASeriesNotFedTodayAsksForAnOpening(): void
@@ -55,7 +57,9 @@ final class StreakHubComponentTest extends WebTestCase
 
         $rendered = (string) $this->createLiveComponent(BoosterHub::class, client: $client)->render();
 
-        $this->assertStringContainsString('🔥 2 jours de suite — ouvre un pack aujourd\'hui pour continuer !', $rendered);
+        $tile = $this->streakTile($rendered);
+        $this->assertStringContainsString('2j', $tile);
+        $this->assertStringContainsString('ouvre aujourd\'hui !', $tile);
     }
 
     public function testAPendingRewardShowsTheBannerWithClaimableChoicesOnly(): void
@@ -82,7 +86,8 @@ final class StreakHubComponentTest extends WebTestCase
         $booster = $this->firstClaimableBooster();
 
         $component = $this->createLiveComponent(BoosterHub::class, client: $client);
-        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId(), 'boosterId' => (string) $booster->getId()]);
+        $component->set('streakRewardBoosterId', (string) $booster->getId());
+        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId()]);
 
         $this->assertNull($component->component()->streakError);
         $this->assertStringContainsString('Palier 7 jours', (string) $component->component()->streakSuccess);
@@ -108,8 +113,9 @@ final class StreakHubComponentTest extends WebTestCase
         $booster = $this->firstClaimableBooster();
 
         $component = $this->createLiveComponent(BoosterHub::class, client: $client);
-        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId(), 'boosterId' => (string) $booster->getId()]);
-        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId(), 'boosterId' => (string) $booster->getId()]);
+        $component->set('streakRewardBoosterId', (string) $booster->getId());
+        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId()]);
+        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId()]);
 
         $this->assertSame('Cette récompense n\'est plus disponible.', $component->component()->streakError);
 
@@ -128,7 +134,8 @@ final class StreakHubComponentTest extends WebTestCase
         $eventBooster = $this->createEventBooster('Pack Event Forgé');
 
         $component = $this->createLiveComponent(BoosterHub::class, client: $client);
-        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId(), 'boosterId' => (string) $eventBooster->getId()]);
+        $component->set('streakRewardBoosterId', (string) $eventBooster->getId());
+        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId()]);
 
         $this->assertSame('Ce pack ne peut pas être choisi en récompense.', $component->component()->streakError);
 
@@ -145,11 +152,23 @@ final class StreakHubComponentTest extends WebTestCase
 
         $component = $this->createLiveComponent(BoosterHub::class, client: $client);
 
-        $component->call('chooseStreakReward', ['rewardId' => 'not-a-uuid', 'boosterId' => (string) $this->firstClaimableBooster()->getId()]);
+        $component->set('streakRewardBoosterId', (string) $this->firstClaimableBooster()->getId());
+        $component->call('chooseStreakReward', ['rewardId' => 'not-a-uuid']);
         $this->assertSame('Cette récompense n\'est plus disponible.', $component->component()->streakError);
 
-        $component->call('chooseStreakReward', ['rewardId' => 'not-a-uuid', 'boosterId' => 'not-a-uuid']);
-        $this->assertSame('Booster introuvable.', $component->component()->streakError);
+        // nothing picked in the selector, or a forged id: same clean refusal
+        $component->set('streakRewardBoosterId', 'not-a-uuid');
+        $component->call('chooseStreakReward', ['rewardId' => 'not-a-uuid']);
+        $this->assertSame('Choisis un pack avant de valider.', $component->component()->streakError);
+    }
+
+    /**
+     * Text of the streak tile, whitespace normalized: the assertions target
+     * what the player reads, not the markup around it.
+     */
+    private function streakTile(string $rendered): string
+    {
+        return new Crawler($rendered)->filter('[data-testid="streak-flame"]')->text(normalizeWhitespace: true);
     }
 
     /**

--- a/tests/Functional/StreakHubComponentTest.php
+++ b/tests/Functional/StreakHubComponentTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Booster;
+use App\Entity\BoosterOpening;
+use App\Entity\DiscordUser;
+use App\Entity\StreakReward;
+use App\Entity\UserBooster;
+use App\Repository\BoosterRepository;
+use App\Twig\Components\BoosterHub;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
+
+final class StreakHubComponentTest extends WebTestCase
+{
+    use InteractsWithLiveComponents;
+    use JwtAuthTrait;
+
+    // Juju has no opening nor UserBooster fixture: clean streak state.
+    private const string USER_WITHOUT_INVENTORY = '195659530363731968';
+
+    public function testTheEmptyStateInvitesToStartASeries(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+
+        $rendered = (string) $this->createLiveComponent(BoosterHub::class, client: $client)->render();
+
+        $this->assertStringContainsString('data-testid="streak-flame"', $rendered);
+        $this->assertStringContainsString('Ouvre un pack aujourd\'hui pour lancer ta série', $rendered);
+        $this->assertStringNotContainsString('data-testid="streak-reward-banner"', $rendered);
+    }
+
+    public function testTheFlameShowsTheRunningStreak(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $this->createOpenings($user, daysAgo: [0, 1, 2]);
+
+        $rendered = (string) $this->createLiveComponent(BoosterHub::class, client: $client)->render();
+
+        $this->assertStringContainsString('🔥 3 jours de suite', $rendered);
+        $this->assertStringNotContainsString('pour continuer', $rendered);
+    }
+
+    public function testASeriesNotFedTodayAsksForAnOpening(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $this->createOpenings($user, daysAgo: [1, 2]);
+
+        $rendered = (string) $this->createLiveComponent(BoosterHub::class, client: $client)->render();
+
+        $this->assertStringContainsString('🔥 2 jours de suite — ouvre un pack aujourd\'hui pour continuer !', $rendered);
+    }
+
+    public function testAPendingRewardShowsTheBannerWithClaimableChoicesOnly(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $this->createPendingReward($user);
+        $this->createEventBooster('Pack Event Streak');
+
+        $rendered = (string) $this->createLiveComponent(BoosterHub::class, client: $client)->render();
+
+        $this->assertStringContainsString('data-testid="streak-reward-banner"', $rendered);
+        $this->assertStringContainsString('palier 7 jours', $rendered);
+        $this->assertStringContainsString('data-testid="streak-reward-choice"', $rendered);
+        // the event/code pack is not claimable: never offered as a streak bonus
+        $this->assertStringNotContainsString('Pack Event Streak', $rendered);
+    }
+
+    public function testChoosingABoosterCreditsTheInventoryAndClosesTheReward(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $reward = $this->createPendingReward($user);
+        $booster = $this->firstClaimableBooster();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId(), 'boosterId' => (string) $booster->getId()]);
+
+        $this->assertNull($component->component()->streakError);
+        $this->assertStringContainsString('Palier 7 jours', (string) $component->component()->streakSuccess);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $userBooster = $entityManager->getRepository(UserBooster::class)
+            ->findOneBy(['discordUser' => $user, 'booster' => $booster])
+        ;
+        $this->assertSame(1, $userBooster?->getQuantity());
+        $this->assertTrue($entityManager->getRepository(StreakReward::class)->find($reward->getId())?->isChosen());
+
+        // the banner is gone, the success bandeau remains
+        $rendered = (string) $component->render();
+        $this->assertStringNotContainsString('data-testid="streak-reward-choice"', $rendered);
+        $this->assertStringContainsString('data-testid="streak-success"', $rendered);
+    }
+
+    public function testARewardCannotBeSpentTwice(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $reward = $this->createPendingReward($user);
+        $booster = $this->firstClaimableBooster();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId(), 'boosterId' => (string) $booster->getId()]);
+        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId(), 'boosterId' => (string) $booster->getId()]);
+
+        $this->assertSame('Cette récompense n\'est plus disponible.', $component->component()->streakError);
+
+        $userBooster = static::getContainer()->get(EntityManagerInterface::class)
+            ->getRepository(UserBooster::class)
+            ->findOneBy(['discordUser' => $user, 'booster' => $booster])
+        ;
+        $this->assertSame(1, $userBooster?->getQuantity(), 'The second call must not credit again.');
+    }
+
+    public function testAForgedChoiceOfANonClaimableBoosterIsRefused(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $reward = $this->createPendingReward($user);
+        $eventBooster = $this->createEventBooster('Pack Event Forgé');
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId(), 'boosterId' => (string) $eventBooster->getId()]);
+
+        $this->assertSame('Ce pack ne peut pas être choisi en récompense.', $component->component()->streakError);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $this->assertSame([], $entityManager->getRepository(UserBooster::class)->findBy(['discordUser' => $user]));
+        $this->assertFalse($entityManager->getRepository(StreakReward::class)->find($reward->getId())?->isChosen());
+    }
+
+    public function testMalformedIdsAreReportedWithoutCrashing(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $this->createPendingReward($user);
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+
+        $component->call('chooseStreakReward', ['rewardId' => 'not-a-uuid', 'boosterId' => (string) $this->firstClaimableBooster()->getId()]);
+        $this->assertSame('Cette récompense n\'est plus disponible.', $component->component()->streakError);
+
+        $component->call('chooseStreakReward', ['rewardId' => 'not-a-uuid', 'boosterId' => 'not-a-uuid']);
+        $this->assertSame('Booster introuvable.', $component->component()->streakError);
+    }
+
+    /**
+     * @param list<int> $daysAgo
+     */
+    private function createOpenings(DiscordUser $user, array $daysAgo): void
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $booster = $this->firstClaimableBooster();
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        foreach ($daysAgo as $days) {
+            $entityManager->persist(
+                new BoosterOpening($user, $booster, seed: 42, openedAt: $now->modify(\sprintf('-%d days', $days))),
+            );
+        }
+
+        $entityManager->flush();
+    }
+
+    private function createPendingReward(DiscordUser $user): StreakReward
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $reward = new StreakReward(
+            $user,
+            new \DateTimeImmutable('7 days ago'),
+            7,
+            new \DateTimeImmutable(),
+        );
+        $entityManager->persist($reward);
+        $entityManager->flush();
+
+        return $reward;
+    }
+
+    private function createEventBooster(string $name): Booster
+    {
+        $booster = new Booster()
+            ->setExtension($this->firstClaimableBooster()->getExtension())
+            ->setName($name)
+            ->setClaimable(false)
+            ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]])
+        ;
+        $booster->setImageName('default_card.png');
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $entityManager->persist($booster);
+        $entityManager->flush();
+
+        return $booster;
+    }
+
+    private function firstClaimableBooster(): Booster
+    {
+        foreach (static::getContainer()->get(BoosterRepository::class)->findPublished() as $booster) {
+            if ($booster->isClaimable()) {
+                return $booster;
+            }
+        }
+
+        $this->fail('No claimable booster fixture found, load the alice fixtures first.');
+    }
+}

--- a/tests/Functional/StreakHubComponentTest.php
+++ b/tests/Functional/StreakHubComponentTest.php
@@ -115,6 +115,10 @@ final class StreakHubComponentTest extends WebTestCase
         $component = $this->createLiveComponent(BoosterHub::class, client: $client);
         $component->set('streakRewardBoosterId', (string) $booster->getId());
         $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId()]);
+
+        // the selector is cleared after a success: pick again to prove the
+        // refusal comes from the reward being spent, not from an empty choice
+        $component->set('streakRewardBoosterId', (string) $booster->getId());
         $component->call('chooseStreakReward', ['rewardId' => (string) $reward->getId()]);
 
         $this->assertSame('Cette récompense n\'est plus disponible.', $component->component()->streakError);
@@ -162,6 +166,61 @@ final class StreakHubComponentTest extends WebTestCase
         $this->assertSame('Choisis un pack avant de valider.', $component->component()->streakError);
     }
 
+    public function testQueuedRewardsAreSpentOneAtATimeOnDistinctPacks(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $first = $this->createPendingReward($user, milestone: 7);
+        $this->createPendingReward($user, milestone: 14);
+        [$packA, $packB] = $this->twoClaimableBoosters();
+
+        $component = $this->createLiveComponent(BoosterHub::class, client: $client);
+        // only the oldest milestone is offered at a time, and the title counts the queue
+        $rendered = (string) $component->render();
+        $this->assertStringContainsString('palier 7 jours', $rendered);
+        $this->assertStringContainsString('· 1 / 2', $rendered);
+
+        $component->set('streakRewardBoosterId', (string) $packA->getId());
+        $component->call('chooseStreakReward', ['rewardId' => (string) $first->getId()]);
+        $this->assertNull($component->component()->streakError);
+        $this->assertStringContainsString('reste 1 récompense', (string) $component->component()->streakSuccess);
+
+        // the next one takes its place, and may go to a DIFFERENT pack
+        $rendered = (string) $component->render();
+        $this->assertStringContainsString('palier 14 jours', $rendered);
+        $this->assertStringNotContainsString('palier 7 jours', $rendered);
+
+        $second = static::getContainer()->get(EntityManagerInterface::class)
+            ->getRepository(StreakReward::class)
+            ->findOneBy(['discordUser' => $user, 'milestone' => 14])
+        ;
+        $component->set('streakRewardBoosterId', (string) $packB->getId());
+        $component->call('chooseStreakReward', ['rewardId' => (string) $second?->getId()]);
+        $this->assertNull($component->component()->streakError);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        foreach ([$packA, $packB] as $pack) {
+            $userBooster = $entityManager->getRepository(UserBooster::class)
+                ->findOneBy(['discordUser' => $user, 'booster' => $pack])
+            ;
+            $this->assertSame(1, $userBooster?->getQuantity(), 'Chaque récompense crédite son propre pack.');
+        }
+
+        $this->assertStringNotContainsString('data-testid="streak-reward-choice"', (string) $component->render());
+    }
+
+    /**
+     * @return array{Booster, Booster}
+     */
+    private function twoClaimableBoosters(): array
+    {
+        $boosters = static::getContainer()->get(BoosterRepository::class)->findPublished();
+        $claimable = array_values(array_filter($boosters, static fn (Booster $booster): bool => $booster->isClaimable()));
+        $this->assertGreaterThanOrEqual(2, \count($claimable), 'Two claimable packs are needed.');
+
+        return [$claimable[0], $claimable[1]];
+    }
+
     /**
      * Text of the streak tile, whitespace normalized: the assertions target
      * what the player reads, not the markup around it.
@@ -189,14 +248,14 @@ final class StreakHubComponentTest extends WebTestCase
         $entityManager->flush();
     }
 
-    private function createPendingReward(DiscordUser $user): StreakReward
+    private function createPendingReward(DiscordUser $user, int $milestone = 7): StreakReward
     {
         $entityManager = static::getContainer()->get(EntityManagerInterface::class);
 
         $reward = new StreakReward(
             $user,
-            new \DateTimeImmutable('7 days ago'),
-            7,
+            new \DateTimeImmutable($milestone . ' days ago'),
+            $milestone,
             new \DateTimeImmutable(),
         );
         $entityManager->persist($reward);


### PR DESCRIPTION
Seconde PR de la phase 8 (base = `feat/phase-8-streak-ouvertures`, #142). À merger après elle.

## Ce que ça fait

**La flamme**, chip mono dans le hero de `/boosters`, toujours visible :
- série en cours nourrie aujourd'hui : « 🔥 12 jours de suite » (vert `text-live`, le `title` donne le prochain palier) ;
- série pas encore nourrie : « 🔥 12 jours de suite — ouvre un pack aujourd'hui pour continuer ! » (orange `text-soon`) ;
- aucun streak : « 🔥 Ouvre un pack aujourd'hui pour lancer ta série ».

**La bannière « Récompense de streak »**, entre le hero et le bloc code : elle présente le palier en attente le plus ancien (« palier 7 jours ») avec **un bouton par booster claimable** (même règle de visibilité que le claim quotidien — un pack event/code n'est jamais proposé). S'il y a plusieurs récompenses en attente, elles défilent une par une (« Encore N récompense(s) ensuite »). Le choix crédite le stock, affiche un bandeau vert et fait disparaître la bannière ; sans récompense en attente, aucune bannière.

L'action `chooseStreakReward` suit le patron de `redeemCode` : remise à zéro des messages, gardes sur les ids client (uuid malformé → refus propre), les vraies gardes restent dans `StreakRewardService` (FOR UPDATE, pack claimable) et leurs messages français remontent tels quels. Pas de rate limiter : l'action ne divulgue rien et ne dépense qu'un droit déjà acquis.

## Pièges respectés

- Boutons avec label statique + `data-loading="addClass(opacity-50)"` — pas de swap de deux spans (bug connu de re-render).
- `this.inventory` invalidé après le crédit pour que le hero et la grille se mettent à jour dans le même re-render.
- `make tailwind.build` passé (le CSS compilé est gitignoré, rien à committer).

## Tests

8 tests de composant (`StreakHubComponentTest`) : état vide sans bannière ; flamme à 3 jours ; série à sauver avec le message « pour continuer » ; bannière avec choix claimables uniquement (le pack event n'apparaît pas) ; le choix crédite l'inventaire, marque la récompense et remplace la bannière par le bandeau de succès ; double dépense refusée sans double crédit ; choix forgé d'un pack non claimable refusé en français sans rien créditer ; ids malformés gérés sans crash.

`make quality` et la suite complète (370 tests) au vert.

## À valider à la main

- Rendu visuel de la flamme et de la bannière sur le hub (desktop + mobile).
- Parcours réel : ouvrir un pack le 7ᵉ jour → retour hub → bannière → choisir → stock crédité.