### PR TITLE
feat(recyclage): domaine du recyclage de doublons (phase 9, 1/2)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -41,6 +41,9 @@ when@test:
         App\Service\Booster\BoosterCodeGenerator:
             public: true
 
+        App\Service\Recycle\RecycleService:
+            public: true
+
         # Functional tests reset a player's code-attempt budget before running:
         # the limiter state is cached on disk and would otherwise carry over
         # from one test (and one run) to the next.

--- a/migrations/Version20260809182441.php
+++ b/migrations/Version20260809182441.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Recycle audit tables: one operation row (user, booster, points, date) plus
+ * one card row per distinct debited card — same pattern as booster_opening.
+ */
+final class Version20260809182441 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Recycle operation audit tables';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE recycle_operation (points INT NOT NULL, recycled_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, id UUID NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, discord_user_id VARCHAR NOT NULL, booster_id UUID NOT NULL, PRIMARY KEY (id))');
+        $this->addSql('CREATE INDEX IDX_25705E62E3F3F7CE ON recycle_operation (discord_user_id)');
+        $this->addSql('CREATE INDEX IDX_25705E62F85E4930 ON recycle_operation (booster_id)');
+        $this->addSql('CREATE TABLE recycle_operation_card (quantity INT NOT NULL, holo_quantity INT DEFAULT 0 NOT NULL, recycle_operation_id UUID NOT NULL, card_id UUID NOT NULL, PRIMARY KEY (recycle_operation_id, card_id))');
+        $this->addSql('CREATE INDEX IDX_3F130CC3592FDBBD ON recycle_operation_card (recycle_operation_id)');
+        $this->addSql('CREATE INDEX IDX_3F130CC34ACC9A20 ON recycle_operation_card (card_id)');
+        $this->addSql('ALTER TABLE recycle_operation ADD CONSTRAINT FK_25705E62E3F3F7CE FOREIGN KEY (discord_user_id) REFERENCES discord_user (discord_id) NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE recycle_operation ADD CONSTRAINT FK_25705E62F85E4930 FOREIGN KEY (booster_id) REFERENCES booster (id) NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE recycle_operation_card ADD CONSTRAINT FK_3F130CC3592FDBBD FOREIGN KEY (recycle_operation_id) REFERENCES recycle_operation (id) NOT DEFERRABLE');
+        $this->addSql('ALTER TABLE recycle_operation_card ADD CONSTRAINT FK_3F130CC34ACC9A20 FOREIGN KEY (card_id) REFERENCES card (id) NOT DEFERRABLE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE recycle_operation DROP CONSTRAINT FK_25705E62E3F3F7CE');
+        $this->addSql('ALTER TABLE recycle_operation DROP CONSTRAINT FK_25705E62F85E4930');
+        $this->addSql('ALTER TABLE recycle_operation_card DROP CONSTRAINT FK_3F130CC3592FDBBD');
+        $this->addSql('ALTER TABLE recycle_operation_card DROP CONSTRAINT FK_3F130CC34ACC9A20');
+        $this->addSql('DROP TABLE recycle_operation');
+        $this->addSql('DROP TABLE recycle_operation_card');
+    }
+}

--- a/src/Controller/Admin/BoosterCrudController.php
+++ b/src/Controller/Admin/BoosterCrudController.php
@@ -8,6 +8,7 @@ use App\Admin\Field\ImageField as VichImageField;
 use App\Entity\Booster;
 use App\Entity\BoosterClaim;
 use App\Entity\BoosterOpening;
+use App\Entity\RecycleOperation;
 use App\Entity\UserBooster;
 use App\Enum\Entity\CardRarityEnum;
 use App\Form\BoosterSlotType;
@@ -223,6 +224,7 @@ class BoosterCrudController extends AbstractGuardedCrudController
             '%d joueur(s) le possèdent encore' => $this->entityManager->getRepository(UserBooster::class)->count(['booster' => $entity]),
             '%d ouverture(s) le référencent' => $this->entityManager->getRepository(BoosterOpening::class)->count(['booster' => $entity]),
             '%d récupération(s) le référencent' => $this->entityManager->getRepository(BoosterClaim::class)->count(['booster' => $entity]),
+            '%d recyclage(s) le référencent' => $this->entityManager->getRepository(RecycleOperation::class)->count(['booster' => $entity]),
         ]);
     }
 }

--- a/src/Dto/RecycleSelectionLine.php
+++ b/src/Dto/RecycleSelectionLine.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Entity\Card;
+
+/**
+ * One card of a recycle selection: how many normal and holo copies the player
+ * wants to trade in. Quantities are kept separate on purpose (unlike the
+ * UserCard total/sub-count pair) so the debit math cannot mix them up.
+ */
+final readonly class RecycleSelectionLine
+{
+    public function __construct(
+        public Card $card,
+        public int $normalQuantity,
+        public int $holoQuantity,
+    ) {
+    }
+
+    public function getTotalQuantity(): int
+    {
+        return $this->normalQuantity + $this->holoQuantity;
+    }
+
+    public function getPoints(): int
+    {
+        $rarity = $this->card->getRarity();
+
+        return $this->normalQuantity * $rarity->recyclePoints()
+            + $this->holoQuantity * $rarity->holoRecyclePoints();
+    }
+}

--- a/src/Entity/RecycleOperation.php
+++ b/src/Entity/RecycleOperation.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\RecycleOperationRepository;
+use Barlito\Utils\Traits\IdUuidTrait;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Timestampable\Traits\TimestampableEntity;
+
+/**
+ * Audit log of a recycle operation: who traded which duplicate copies, for how
+ * many points, against which booster. The card rows carry the exact debited
+ * copies so the operation can be reconstructed.
+ */
+#[ORM\Entity(repositoryClass: RecycleOperationRepository::class)]
+class RecycleOperation
+{
+    use IdUuidTrait;
+    use TimestampableEntity;
+
+    /**
+     * @var Collection<int, RecycleOperationCard>
+     */
+    #[ORM\OneToMany(targetEntity: RecycleOperationCard::class, mappedBy: 'recycleOperation', cascade: ['persist', 'remove'], orphanRemoval: true)]
+    private Collection $recycleOperationCards;
+
+    public function __construct(#[ORM\ManyToOne]
+        #[ORM\JoinColumn(referencedColumnName: 'discord_id', nullable: false)]
+        private DiscordUser $discordUser, #[ORM\ManyToOne]
+        #[ORM\JoinColumn(nullable: false)]
+        private Booster $booster, #[ORM\Column]
+        private int $points, #[ORM\Column]
+        private \DateTimeImmutable $recycledAt)
+    {
+        $this->recycleOperationCards = new ArrayCollection();
+    }
+
+    public function getDiscordUser(): DiscordUser
+    {
+        return $this->discordUser;
+    }
+
+    public function getBooster(): Booster
+    {
+        return $this->booster;
+    }
+
+    public function getPoints(): int
+    {
+        return $this->points;
+    }
+
+    public function getRecycledAt(): \DateTimeImmutable
+    {
+        return $this->recycledAt;
+    }
+
+    /**
+     * @return Collection<int, RecycleOperationCard>
+     */
+    public function getRecycleOperationCards(): Collection
+    {
+        return $this->recycleOperationCards;
+    }
+
+    public function addRecycleOperationCard(RecycleOperationCard $recycleOperationCard): static
+    {
+        if (!$this->recycleOperationCards->contains($recycleOperationCard)) {
+            $this->recycleOperationCards->add($recycleOperationCard);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Copies recycled, holo included: the operation's actual card count.
+     */
+    public function getRecycledCardCount(): int
+    {
+        $total = 0;
+
+        foreach ($this->recycleOperationCards as $recycledCard) {
+            $total += $recycledCard->getQuantity();
+        }
+
+        return $total;
+    }
+}

--- a/src/Entity/RecycleOperationCard.php
+++ b/src/Entity/RecycleOperationCard.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use App\Repository\RecycleOperationCardRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * One distinct card debited in a recycle operation (composite PK). Same
+ * quantity semantics as UserCard: quantity is the TOTAL of debited copies,
+ * holoQuantity the holo sub-count included in it.
+ */
+#[ORM\Entity(repositoryClass: RecycleOperationCardRepository::class)]
+class RecycleOperationCard
+{
+    public function __construct(
+        #[ORM\Id]
+        #[ORM\ManyToOne(inversedBy: 'recycleOperationCards')]
+        #[ORM\JoinColumn(nullable: false)]
+        private RecycleOperation $recycleOperation,
+        #[ORM\Id]
+        #[ORM\ManyToOne]
+        #[ORM\JoinColumn(nullable: false)]
+        private Card $card,
+        #[ORM\Column]
+        private int $quantity,
+        #[ORM\Column(options: ['default' => 0])]
+        private int $holoQuantity = 0,
+    ) {
+    }
+
+    public function getRecycleOperation(): RecycleOperation
+    {
+        return $this->recycleOperation;
+    }
+
+    public function getCard(): Card
+    {
+        return $this->card;
+    }
+
+    public function getQuantity(): int
+    {
+        return $this->quantity;
+    }
+
+    public function getHoloQuantity(): int
+    {
+        return $this->holoQuantity;
+    }
+}

--- a/src/Enum/Entity/CardRarityEnum.php
+++ b/src/Enum/Entity/CardRarityEnum.php
@@ -52,4 +52,26 @@ enum CardRarityEnum: string
     {
         return $b->rank() <=> $a->rank();
     }
+
+    /**
+     * Recycling value of one normal copy of this rarity. The whole recycle
+     * scale lives here: holoRecyclePoints() derives from it.
+     */
+    public function recyclePoints(): int
+    {
+        return match ($this) {
+            self::COMMON => 1,
+            self::UNCOMMON => 2,
+            self::RARE => 3,
+            self::LEGENDARY => 5,
+        };
+    }
+
+    /**
+     * Recycling value of one holo copy: the rarity scale plus a flat bonus.
+     */
+    public function holoRecyclePoints(): int
+    {
+        return $this->recyclePoints() + 1;
+    }
 }

--- a/src/Exception/Recycle/BoosterNotRecyclableException.php
+++ b/src/Exception/Recycle/BoosterNotRecyclableException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Recycle;
+
+final class BoosterNotRecyclableException extends RecycleException
+{
+}

--- a/src/Exception/Recycle/InvalidRecycleSelectionException.php
+++ b/src/Exception/Recycle/InvalidRecycleSelectionException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Recycle;
+
+final class InvalidRecycleSelectionException extends RecycleException
+{
+}

--- a/src/Exception/Recycle/NotEnoughCopiesException.php
+++ b/src/Exception/Recycle/NotEnoughCopiesException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Recycle;
+
+final class NotEnoughCopiesException extends RecycleException
+{
+}

--- a/src/Exception/Recycle/NotEnoughRecyclePointsException.php
+++ b/src/Exception/Recycle/NotEnoughRecyclePointsException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Recycle;
+
+final class NotEnoughRecyclePointsException extends RecycleException
+{
+}

--- a/src/Exception/Recycle/RecycleException.php
+++ b/src/Exception/Recycle/RecycleException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exception\Recycle;
+
+abstract class RecycleException extends \RuntimeException
+{
+    /**
+     * @param string $message     technical message (logs, tests)
+     * @param string $userMessage player-facing French message, safe to render as-is
+     */
+    public function __construct(string $message, private readonly string $userMessage)
+    {
+        parent::__construct($message);
+    }
+
+    public function getUserMessage(): string
+    {
+        return $this->userMessage;
+    }
+}

--- a/src/Repository/RecycleOperationCardRepository.php
+++ b/src/Repository/RecycleOperationCardRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\RecycleOperationCard;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<RecycleOperationCard>
+ */
+class RecycleOperationCardRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RecycleOperationCard::class);
+    }
+}

--- a/src/Repository/RecycleOperationRepository.php
+++ b/src/Repository/RecycleOperationRepository.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Repository;
+
+use App\Entity\RecycleOperation;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<RecycleOperation>
+ */
+class RecycleOperationRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RecycleOperation::class);
+    }
+}

--- a/src/Repository/UserCardRepository.php
+++ b/src/Repository/UserCardRepository.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Repository;
 
+use App\Entity\Card;
 use App\Entity\DiscordUser;
 use App\Entity\Extension;
 use App\Entity\UserCard;
 use App\Enum\Entity\CardRarityEnum;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\LockMode;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -104,6 +106,30 @@ class UserCardRepository extends ServiceEntityRepository
         ;
 
         return array_map(static fn (array $row): string => (string) $row['cardId'], $rows);
+    }
+
+    /**
+     * Pessimistic write lock on the user's rows for the given cards, so a
+     * recycle debit re-validates quantities against what concurrent operations
+     * left. Requires an active transaction. Rows are locked in card id order:
+     * two concurrent selections lock in the same sequence, never a deadlock.
+     *
+     * @param list<Card> $cards
+     *
+     * @return list<UserCard>
+     */
+    public function findOwnedForUpdate(DiscordUser $discordUser, array $cards): array
+    {
+        return $this->createQueryBuilder('uc')
+            ->andWhere('uc.discordUser = :user')
+            ->andWhere('uc.card IN (:cards)')
+            ->setParameter('user', $discordUser)
+            ->setParameter('cards', $cards)
+            ->orderBy('IDENTITY(uc.card)', 'ASC')
+            ->getQuery()
+            ->setLockMode(LockMode::PESSIMISTIC_WRITE)
+            ->getResult()
+        ;
     }
 
     /**

--- a/src/Service/Recycle/RecycleService.php
+++ b/src/Service/Recycle/RecycleService.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Recycle;
+
+use App\Dto\RecycleSelectionLine;
+use App\Entity\Booster;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\RecycleOperation;
+use App\Entity\RecycleOperationCard;
+use App\Entity\UserCard;
+use App\Exception\Recycle\BoosterNotRecyclableException;
+use App\Exception\Recycle\InvalidRecycleSelectionException;
+use App\Exception\Recycle\NotEnoughCopiesException;
+use App\Exception\Recycle\NotEnoughRecyclePointsException;
+use App\Repository\UserCardRepository;
+use App\Service\Booster\BoosterAvailabilityService;
+use App\Service\Booster\UserInventoryService;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Clock\ClockInterface;
+
+/**
+ * Trades duplicate copies for a claimable booster, as one atomic transaction:
+ * lock the UserCard rows, re-validate the quantities under lock, debit the
+ * copies, credit the booster and persist the audit trail.
+ *
+ * Own distribution channel, like the codes: no BoosterClaim row, so the daily
+ * quota is neither checked nor consumed. Points beyond the cost are lost by
+ * design (no balance, no currency) — the UI says so before confirming.
+ */
+final readonly class RecycleService
+{
+    /**
+     * Points a booster costs; the per-rarity scale lives on CardRarityEnum.
+     */
+    public const int BOOSTER_COST = 10;
+
+    public function __construct(
+        private UserCardRepository $userCardRepository,
+        private UserInventoryService $userInventoryService,
+        private BoosterAvailabilityService $boosterAvailability,
+        private EntityManagerInterface $entityManager,
+        private ClockInterface $clock,
+    ) {
+    }
+
+    /**
+     * @param list<RecycleSelectionLine> $selection
+     *
+     * @throws InvalidRecycleSelectionException
+     * @throws BoosterNotRecyclableException
+     * @throws NotEnoughCopiesException
+     * @throws NotEnoughRecyclePointsException
+     */
+    public function recycle(DiscordUser $discordUser, array $selection, Booster $booster): RecycleOperation
+    {
+        $this->assertSelectionIsWellFormed($selection);
+        // Same server-side guards as the daily claim: recycling must not be a
+        // side door to event-only packs or unpublished extensions.
+        $this->assertBoosterIsRecyclable($booster);
+
+        return $this->entityManager->wrapInTransaction(function () use ($discordUser, $selection, $booster): RecycleOperation {
+            $lockedRows = [];
+            foreach ($this->userCardRepository->findOwnedForUpdate($discordUser, array_map(static fn (RecycleSelectionLine $line): Card => $line->card, $selection)) as $userCard) {
+                // a row already in the identity map is NOT re-hydrated by the locked
+                // SELECT: re-read it so the checks below see the locked DB state
+                $this->entityManager->refresh($userCard);
+                $lockedRows[(string) $userCard->getCard()->getId()] = $userCard;
+            }
+
+            $points = 0;
+            foreach ($selection as $line) {
+                $this->debit($lockedRows[(string) $line->card->getId()] ?? null, $line);
+                $points += $line->getPoints();
+            }
+
+            if ($points < self::BOOSTER_COST) {
+                throw new NotEnoughRecyclePointsException(
+                    \sprintf('Selection is worth %d points, %d required.', $points, self::BOOSTER_COST),
+                    \sprintf('Il te faut au moins %d points pour recycler (sélection actuelle : %d).', self::BOOSTER_COST, $points),
+                );
+            }
+
+            $this->userInventoryService->creditBooster($discordUser, $booster);
+
+            $operation = new RecycleOperation($discordUser, $booster, $points, $this->clock->now());
+            foreach ($selection as $line) {
+                $operation->addRecycleOperationCard(new RecycleOperationCard($operation, $line->card, $line->getTotalQuantity(), $line->holoQuantity));
+            }
+
+            $this->entityManager->persist($operation);
+            $this->entityManager->flush();
+
+            return $operation;
+        });
+    }
+
+    /**
+     * Shape checks on the client-built selection: never trust the caller.
+     *
+     * @param list<RecycleSelectionLine> $selection
+     */
+    private function assertSelectionIsWellFormed(array $selection): void
+    {
+        if ([] === $selection) {
+            throw new InvalidRecycleSelectionException('Empty selection.', 'Sélectionne d\'abord des copies à recycler.');
+        }
+
+        $seen = [];
+        foreach ($selection as $line) {
+            if ($line->normalQuantity < 0 || $line->holoQuantity < 0 || $line->getTotalQuantity() < 1) {
+                throw new InvalidRecycleSelectionException(
+                    \sprintf('Invalid quantities for card "%s" (%d normal / %d holo).', $line->card->getName(), $line->normalQuantity, $line->holoQuantity),
+                    'Sélection invalide, recharge la page et réessaie.',
+                );
+            }
+
+            $cardId = (string) $line->card->getId();
+            if (isset($seen[$cardId])) {
+                throw new InvalidRecycleSelectionException(
+                    \sprintf('Card "%s" appears twice in the selection.', $line->card->getName()),
+                    'Sélection invalide, recharge la page et réessaie.',
+                );
+            }
+            $seen[$cardId] = true;
+        }
+    }
+
+    private function assertBoosterIsRecyclable(Booster $booster): void
+    {
+        if (!$this->boosterAvailability->isClaimable($booster)) {
+            throw new BoosterNotRecyclableException(
+                \sprintf('Booster "%s" is not claimable (event/code distribution only).', $booster->getDisplayName()),
+                'Ce pack ne peut pas être obtenu par recyclage — il se gagne en event ou via un code.',
+            );
+        }
+
+        if (!$this->boosterAvailability->hasPublishedExtension($booster)) {
+            throw new BoosterNotRecyclableException(
+                \sprintf('Booster "%s" belongs to an unpublished extension.', $booster->getDisplayName()),
+                'Ce pack n\'est pas disponible.',
+            );
+        }
+    }
+
+    /**
+     * Re-validates ONE line against the locked row, then debits it. Quantities
+     * may have moved between display and confirmation — the locked row is the
+     * only truth. Invariants kept: quantity >= holoQuantity >= 0, and at least
+     * one copy of the card always stays in the collection (a 1/1 unique, at
+     * quantity 1 by construction, is therefore never recyclable).
+     */
+    private function debit(?UserCard $userCard, RecycleSelectionLine $line): void
+    {
+        $cardName = $line->card->getName();
+
+        if (!$userCard instanceof UserCard) {
+            throw new NotEnoughCopiesException(
+                \sprintf('Card "%s" is not owned.', $cardName),
+                \sprintf('Tu ne possèdes pas « %s ».', $cardName),
+            );
+        }
+
+        if ($userCard->getQuantity() - $line->getTotalQuantity() < 1) {
+            throw new NotEnoughCopiesException(
+                \sprintf('Recycling %d copies of "%s" would leave the collection without one (owned: %d).', $line->getTotalQuantity(), $cardName, $userCard->getQuantity()),
+                \sprintf('Tu dois garder au moins un exemplaire de « %s » — seuls les doublons se recyclent.', $cardName),
+            );
+        }
+
+        if ($line->holoQuantity > $userCard->getHoloQuantity()) {
+            throw new NotEnoughCopiesException(
+                \sprintf('Not enough holo copies of "%s" (asked %d, owned %d).', $cardName, $line->holoQuantity, $userCard->getHoloQuantity()),
+                \sprintf('Tu n\'as plus assez de copies holo de « %s ».', $cardName),
+            );
+        }
+
+        // quantity is the TOTAL (holo included): normal copies = quantity - holoQuantity
+        if ($line->normalQuantity > $userCard->getQuantity() - $userCard->getHoloQuantity()) {
+            throw new NotEnoughCopiesException(
+                \sprintf('Not enough normal copies of "%s" (asked %d, owned %d).', $cardName, $line->normalQuantity, $userCard->getQuantity() - $userCard->getHoloQuantity()),
+                \sprintf('Tu n\'as plus assez de copies normales de « %s ».', $cardName),
+            );
+        }
+
+        $userCard
+            ->setQuantity($userCard->getQuantity() - $line->getTotalQuantity())
+            ->setHoloQuantity($userCard->getHoloQuantity() - $line->holoQuantity)
+        ;
+    }
+}

--- a/tests/Integration/Service/RecycleServiceTest.php
+++ b/tests/Integration/Service/RecycleServiceTest.php
@@ -1,0 +1,501 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Service;
+
+use App\Dto\RecycleSelectionLine;
+use App\Entity\Booster;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Entity\RecycleOperation;
+use App\Entity\UserBooster;
+use App\Entity\UserCard;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use App\Exception\Recycle\BoosterNotRecyclableException;
+use App\Exception\Recycle\InvalidRecycleSelectionException;
+use App\Exception\Recycle\NotEnoughCopiesException;
+use App\Exception\Recycle\NotEnoughRecyclePointsException;
+use App\Service\Recycle\RecycleService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class RecycleServiceTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    private RecycleService $recycleService;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->entityManager = self::getContainer()->get(EntityManagerInterface::class);
+        $this->recycleService = self::getContainer()->get(RecycleService::class);
+    }
+
+    public function testRecyclingDebitsCopiesCreditsBoosterAndPersistsAudit(): void
+    {
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 12]]);
+
+        $operation = $this->recycleService->recycle(
+            $scenario['user'],
+            [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 10, holoQuantity: 0)],
+            $scenario['booster'],
+        );
+
+        $this->entityManager->clear();
+
+        $userCard = $this->findUserCard($scenario['user'], $scenario['cards'][0]);
+        $this->assertSame(2, $userCard->getQuantity());
+        $this->assertSame(0, $userCard->getHoloQuantity());
+
+        $userBooster = $this->entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $scenario['user']]);
+        $this->assertNotNull($userBooster);
+        $this->assertSame(1, $userBooster->getQuantity());
+
+        $persisted = $this->entityManager->getRepository(RecycleOperation::class)->find($operation->getId());
+        $this->assertNotNull($persisted);
+        $this->assertSame(10, $persisted->getPoints());
+        $this->assertSame(10, $persisted->getRecycledCardCount());
+        $this->assertCount(1, $persisted->getRecycleOperationCards());
+        $recycledCard = $persisted->getRecycleOperationCards()->first();
+        $this->assertNotFalse($recycledCard);
+        $this->assertSame(10, $recycledCard->getQuantity());
+        $this->assertSame(0, $recycledCard->getHoloQuantity());
+    }
+
+    public function testRecyclingDoesNotConsumeTheDailyClaimQuota(): void
+    {
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 12]]);
+
+        $this->recycleService->recycle(
+            $scenario['user'],
+            [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 10, holoQuantity: 0)],
+            $scenario['booster'],
+        );
+
+        $this->assertSame(
+            [],
+            $this->entityManager->getRepository(\App\Entity\BoosterClaim::class)->findBy(['discordUser' => $scenario['user']]),
+            'A recycle operation must not leave a BoosterClaim row (own distribution channel, quota untouched).',
+        );
+    }
+
+    public function testHoloCopiesAreWorthTheirRarityPlusOne(): void
+    {
+        // 5 holo commons at 2 points each: exactly the 10-point cost
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 6, 'holoQuantity' => 5]]);
+
+        $operation = $this->recycleService->recycle(
+            $scenario['user'],
+            [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 0, holoQuantity: 5)],
+            $scenario['booster'],
+        );
+
+        $this->assertSame(10, $operation->getPoints());
+
+        $this->entityManager->clear();
+
+        $userCard = $this->findUserCard($scenario['user'], $scenario['cards'][0]);
+        $this->assertSame(1, $userCard->getQuantity());
+        $this->assertSame(0, $userCard->getHoloQuantity());
+    }
+
+    public function testMixedRaritiesAndKindsComputeTheRightTotal(): void
+    {
+        // 2 normal rares (6) + 1 holo uncommon (3) + 1 normal common (1) = 10
+        $scenario = $this->createScenario([
+            ['rarity' => CardRarityEnum::RARE, 'quantity' => 3],
+            ['rarity' => CardRarityEnum::UNCOMMON, 'quantity' => 2, 'holoQuantity' => 2],
+            ['rarity' => CardRarityEnum::COMMON, 'quantity' => 2],
+        ]);
+
+        $operation = $this->recycleService->recycle(
+            $scenario['user'],
+            [
+                new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 2, holoQuantity: 0),
+                new RecycleSelectionLine($scenario['cards'][1], normalQuantity: 0, holoQuantity: 1),
+                new RecycleSelectionLine($scenario['cards'][2], normalQuantity: 1, holoQuantity: 0),
+            ],
+            $scenario['booster'],
+        );
+
+        $this->assertSame(10, $operation->getPoints());
+
+        $this->entityManager->clear();
+
+        $uncommon = $this->findUserCard($scenario['user'], $scenario['cards'][1]);
+        $this->assertSame(1, $uncommon->getQuantity());
+        $this->assertSame(1, $uncommon->getHoloQuantity(), 'Only one of the two holo copies is debited.');
+    }
+
+    public function testSurplusPointsBeyondTheCostAreLost(): void
+    {
+        // 3 legendaries = 15 points: one booster, the 5 extra points vanish
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 4]]);
+
+        $operation = $this->recycleService->recycle(
+            $scenario['user'],
+            [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 3, holoQuantity: 0)],
+            $scenario['booster'],
+        );
+
+        $this->assertSame(15, $operation->getPoints(), 'The audit keeps the real total, surplus included.');
+
+        $this->entityManager->clear();
+
+        $userBooster = $this->entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $scenario['user']]);
+        $this->assertNotNull($userBooster);
+        $this->assertSame(1, $userBooster->getQuantity(), 'Exactly ONE booster per operation, whatever the surplus.');
+        $this->assertCount(1, $this->entityManager->getRepository(RecycleOperation::class)->findBy(['discordUser' => $scenario['user']]));
+    }
+
+    public function testRefusesASelectionBelowTheCost(): void
+    {
+        // 9 points: 3 rares
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::RARE, 'quantity' => 4]]);
+
+        try {
+            $this->recycleService->recycle(
+                $scenario['user'],
+                [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 3, holoQuantity: 0)],
+                $scenario['booster'],
+            );
+            $this->fail('Expected NotEnoughRecyclePointsException');
+        } catch (NotEnoughRecyclePointsException $exception) {
+            $this->assertStringContainsString('9', $exception->getUserMessage());
+        }
+
+        $this->assertNothingChanged($scenario, expectedQuantities: [[4, 0]]);
+    }
+
+    public function testRefusesAnEmptySelection(): void
+    {
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 12]]);
+
+        $this->expectException(InvalidRecycleSelectionException::class);
+
+        $this->recycleService->recycle($scenario['user'], [], $scenario['booster']);
+    }
+
+    public function testRefusesNegativeQuantities(): void
+    {
+        // a forged negative holo count must not become a credit
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 20]]);
+
+        try {
+            $this->recycleService->recycle(
+                $scenario['user'],
+                [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 15, holoQuantity: -5)],
+                $scenario['booster'],
+            );
+            $this->fail('Expected InvalidRecycleSelectionException');
+        } catch (InvalidRecycleSelectionException) {
+        }
+
+        $this->assertNothingChanged($scenario, expectedQuantities: [[20, 0]]);
+    }
+
+    public function testRefusesAZeroQuantityLine(): void
+    {
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 12]]);
+
+        $this->expectException(InvalidRecycleSelectionException::class);
+
+        $this->recycleService->recycle(
+            $scenario['user'],
+            [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 0, holoQuantity: 0)],
+            $scenario['booster'],
+        );
+    }
+
+    public function testRefusesDuplicateCardLines(): void
+    {
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 30]]);
+
+        $this->expectException(InvalidRecycleSelectionException::class);
+
+        $this->recycleService->recycle(
+            $scenario['user'],
+            [
+                new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 5, holoQuantity: 0),
+                new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 5, holoQuantity: 0),
+            ],
+            $scenario['booster'],
+        );
+    }
+
+    public function testTheLastCopyOfACardIsNeverRecyclable(): void
+    {
+        // 10 copies: recycling all 10 would empty the collection entry
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 10]]);
+
+        try {
+            $this->recycleService->recycle(
+                $scenario['user'],
+                [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 10, holoQuantity: 0)],
+                $scenario['booster'],
+            );
+            $this->fail('Expected NotEnoughCopiesException');
+        } catch (NotEnoughCopiesException $exception) {
+            $this->assertStringContainsString('au moins un exemplaire', $exception->getUserMessage());
+        }
+
+        $this->assertNothingChanged($scenario, expectedQuantities: [[10, 0]]);
+    }
+
+    public function testASingleCopyCardIsNotRecyclableAtAll(): void
+    {
+        // covers the 1/1 uniques: quantity 1 by construction, never recyclable
+        $scenario = $this->createScenario([
+            ['rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 1],
+            ['rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 2],
+        ]);
+
+        try {
+            $this->recycleService->recycle(
+                $scenario['user'],
+                [
+                    new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 1, holoQuantity: 0),
+                    new RecycleSelectionLine($scenario['cards'][1], normalQuantity: 1, holoQuantity: 0),
+                ],
+                $scenario['booster'],
+            );
+            $this->fail('Expected NotEnoughCopiesException');
+        } catch (NotEnoughCopiesException) {
+        }
+
+        $this->assertNothingChanged($scenario, expectedQuantities: [[1, 0], [2, 0]]);
+    }
+
+    public function testRefusesMoreHoloCopiesThanOwned(): void
+    {
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 4, 'holoQuantity' => 1]]);
+
+        try {
+            $this->recycleService->recycle(
+                $scenario['user'],
+                [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 0, holoQuantity: 2)],
+                $scenario['booster'],
+            );
+            $this->fail('Expected NotEnoughCopiesException');
+        } catch (NotEnoughCopiesException $exception) {
+            $this->assertStringContainsString('holo', $exception->getUserMessage());
+        }
+
+        $this->assertNothingChanged($scenario, expectedQuantities: [[4, 1]]);
+    }
+
+    public function testRefusesNormalCopiesWhenOnlyHoloAreOwned(): void
+    {
+        // quantity is the TOTAL: 3 copies all holo means ZERO normal copies
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 3, 'holoQuantity' => 3]]);
+
+        try {
+            $this->recycleService->recycle(
+                $scenario['user'],
+                [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 2, holoQuantity: 0)],
+                $scenario['booster'],
+            );
+            $this->fail('Expected NotEnoughCopiesException');
+        } catch (NotEnoughCopiesException $exception) {
+            $this->assertStringContainsString('normales', $exception->getUserMessage());
+        }
+
+        $this->assertNothingChanged($scenario, expectedQuantities: [[3, 3]]);
+    }
+
+    public function testRefusesACardTheUserDoesNotOwn(): void
+    {
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 12]]);
+
+        $stranger = new Card()
+            ->setName('Never owned card')
+            ->setDescription('Test card')
+            ->setStatus(CardStatusEnum::PUBLISHED)
+            ->setRarity(CardRarityEnum::LEGENDARY)
+            ->setExtension($scenario['booster']->getExtension())
+        ;
+        $stranger->setImageName('default_card.png');
+        $this->entityManager->persist($stranger);
+        $this->entityManager->flush();
+
+        $this->expectException(NotEnoughCopiesException::class);
+
+        $this->recycleService->recycle(
+            $scenario['user'],
+            [new RecycleSelectionLine($stranger, normalQuantity: 2, holoQuantity: 0)],
+            $scenario['booster'],
+        );
+    }
+
+    public function testRefusesANonClaimableBooster(): void
+    {
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 12]], claimable: false);
+
+        try {
+            $this->recycleService->recycle(
+                $scenario['user'],
+                [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 10, holoQuantity: 0)],
+                $scenario['booster'],
+            );
+            $this->fail('Expected BoosterNotRecyclableException');
+        } catch (BoosterNotRecyclableException) {
+        }
+
+        $this->assertNothingChanged($scenario, expectedQuantities: [[12, 0]]);
+    }
+
+    public function testRefusesABoosterOfAnUnpublishedExtension(): void
+    {
+        $scenario = $this->createScenario(
+            [['rarity' => CardRarityEnum::COMMON, 'quantity' => 12]],
+            extensionStatus: ExtensionStatusEnum::DRAFT,
+        );
+
+        $this->expectException(BoosterNotRecyclableException::class);
+
+        $this->recycleService->recycle(
+            $scenario['user'],
+            [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 10, holoQuantity: 0)],
+            $scenario['booster'],
+        );
+    }
+
+    public function testAFailingLineRollsBackTheWholeOperation(): void
+    {
+        // line 1 is valid and debited in memory before line 2 blows up: the
+        // rollback must leave BOTH untouched, with no booster and no audit row
+        $scenario = $this->createScenario([
+            ['rarity' => CardRarityEnum::COMMON, 'quantity' => 12],
+            ['rarity' => CardRarityEnum::COMMON, 'quantity' => 1],
+        ]);
+
+        try {
+            $this->recycleService->recycle(
+                $scenario['user'],
+                [
+                    new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 10, holoQuantity: 0),
+                    new RecycleSelectionLine($scenario['cards'][1], normalQuantity: 1, holoQuantity: 0),
+                ],
+                $scenario['booster'],
+            );
+            $this->fail('Expected NotEnoughCopiesException');
+        } catch (NotEnoughCopiesException) {
+        }
+
+        $this->assertNothingChanged($scenario, expectedQuantities: [[12, 0], [1, 0]]);
+    }
+
+    public function testStaleQuantitiesAreRevalidatedUnderLock(): void
+    {
+        // valid at display time; a concurrent operation then eats the copies
+        // behind the entity manager's back (raw SQL, like another request)
+        $scenario = $this->createScenario([['rarity' => CardRarityEnum::COMMON, 'quantity' => 12]]);
+
+        $this->entityManager->getConnection()->executeStatement(
+            'UPDATE user_card SET quantity = 3 WHERE discord_user_id = :user AND card_id = :card',
+            ['user' => $scenario['user']->getDiscordId(), 'card' => (string) $scenario['cards'][0]->getId()],
+        );
+
+        try {
+            $this->recycleService->recycle(
+                $scenario['user'],
+                [new RecycleSelectionLine($scenario['cards'][0], normalQuantity: 10, holoQuantity: 0)],
+                $scenario['booster'],
+            );
+            $this->fail('Expected NotEnoughCopiesException');
+        } catch (NotEnoughCopiesException) {
+        }
+
+        $this->assertNothingChanged($scenario, expectedQuantities: [[3, 0]]);
+    }
+
+    /**
+     * @param list<array{int, int}>                                         $expectedQuantities [quantity, holoQuantity] per scenario card
+     * @param array{user: DiscordUser, booster: Booster, cards: list<Card>} $scenario
+     */
+    private function assertNothingChanged(array $scenario, array $expectedQuantities): void
+    {
+        $this->entityManager->clear();
+
+        foreach ($expectedQuantities as $index => [$quantity, $holoQuantity]) {
+            $userCard = $this->findUserCard($scenario['user'], $scenario['cards'][$index]);
+            $this->assertSame($quantity, $userCard->getQuantity());
+            $this->assertSame($holoQuantity, $userCard->getHoloQuantity());
+        }
+
+        $this->assertNull($this->entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $scenario['user']]));
+        $this->assertSame([], $this->entityManager->getRepository(RecycleOperation::class)->findBy(['discordUser' => $scenario['user']]));
+    }
+
+    private function findUserCard(DiscordUser $user, Card $card): UserCard
+    {
+        $userCard = $this->entityManager->getRepository(UserCard::class)->findOneBy(['discordUser' => $user, 'card' => $card]);
+        $this->assertNotNull($userCard);
+
+        return $userCard;
+    }
+
+    /**
+     * @param list<array{rarity: CardRarityEnum, quantity: int, holoQuantity?: int}> $ownedCards
+     *
+     * @return array{user: DiscordUser, booster: Booster, cards: list<Card>}
+     */
+    private function createScenario(
+        array $ownedCards,
+        bool $claimable = true,
+        ExtensionStatusEnum $extensionStatus = ExtensionStatusEnum::PUBLISHED,
+    ): array {
+        $extension = new Extension()
+            ->setName('Recycle test extension ' . uniqid())
+            ->setDescription('Test extension')
+            ->setStatus($extensionStatus)
+        ;
+        $this->entityManager->persist($extension);
+
+        $user = new DiscordUser()
+            ->setDiscordId('recycle-test-' . uniqid())
+            ->setUsername('Recycle tester')
+        ;
+        $this->entityManager->persist($user);
+
+        $cards = [];
+        foreach ($ownedCards as $index => $definition) {
+            $card = new Card()
+                ->setName(\sprintf('Recycle card %d %s', $index, uniqid()))
+                ->setDescription('Test card')
+                ->setStatus(CardStatusEnum::PUBLISHED)
+                ->setRarity($definition['rarity'])
+                ->setExtension($extension)
+            ;
+            $card->setImageName('default_card.png');
+            $this->entityManager->persist($card);
+            $cards[] = $card;
+
+            $userCard = new UserCard()
+                ->setDiscordUser($user)
+                ->setCard($card)
+                ->setQuantity($definition['quantity'])
+                ->setHoloQuantity($definition['holoQuantity'] ?? 0)
+            ;
+            $this->entityManager->persist($userCard);
+        }
+
+        $booster = new Booster()
+            ->setExtension($extension)
+            ->setClaimable($claimable)
+            ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]])
+        ;
+        $booster->setImageName('default_card.png');
+        $this->entityManager->persist($booster);
+
+        $this->entityManager->flush();
+
+        return ['user' => $user, 'booster' => $booster, 'cards' => $cards];
+    }
+}

--- a/tests/Unit/Enum/CardRarityEnumTest.php
+++ b/tests/Unit/Enum/CardRarityEnumTest.php
@@ -46,6 +46,21 @@ final class CardRarityEnumTest extends TestCase
         $this->assertSame('Légendaire', CardRarityEnum::LEGENDARY->label());
     }
 
+    public function testRecyclePointsFollowTheAgreedScale(): void
+    {
+        $this->assertSame(1, CardRarityEnum::COMMON->recyclePoints());
+        $this->assertSame(2, CardRarityEnum::UNCOMMON->recyclePoints());
+        $this->assertSame(3, CardRarityEnum::RARE->recyclePoints());
+        $this->assertSame(5, CardRarityEnum::LEGENDARY->recyclePoints());
+    }
+
+    public function testAHoloCopyIsWorthItsRarityPlusOne(): void
+    {
+        foreach (CardRarityEnum::cases() as $rarity) {
+            $this->assertSame($rarity->recyclePoints() + 1, $rarity->holoRecyclePoints());
+        }
+    }
+
     public function testCompareRarestFirstSortsFromLegendaryToCommon(): void
     {
         $rarities = [


### PR DESCRIPTION
Phase 9, PR 1/2 : le cœur du recyclage de doublons — barème, service transactionnel, audit. L'UI (page + Live Component) arrive dans la PR empilée.

## Ce que ça fait

**Le barème**, centralisé sur `CardRarityEnum` : `recyclePoints()` (commune 1 / peu commune 2 / rare 3 / légendaire 5) et `holoRecyclePoints()` (= rareté + 1). **10 points = 1 booster** (`RecycleService::BOOSTER_COST`), au choix du joueur parmi les boosters claimables (mêmes gardes serveur que le claim quotidien : `claimable = true` + extension publiée — pas de porte dérobée vers les packs d'event).

**`RecycleService::recycle()`** : canal de distribution à part entière, comme les codes — pas de `BoosterClaim`, donc le quota quotidien n'est ni consommé ni vérifié (testé). Une transaction unique :

1. validation de forme de la sélection (non vide, quantités positives, pas de carte en double) — le serveur ne fait jamais confiance aux points calculés côté client ;
2. verrou `FOR UPDATE` sur les lignes `UserCard` (ordre d'id de carte déterministe → pas de deadlock entre opérations concurrentes) **puis `refresh()` de chaque ligne** — piège : une entité déjà dans l'identity map n'est PAS ré-hydratée par le SELECT verrouillé, les checks liraient l'état d'affichage au lieu de l'état verrouillé ;
3. re-validation sous verrou et débit ligne à ligne, en maintenant l'invariant `quantity >= holoQuantity >= 0` (`quantity` = TOTAL, holo inclus — la sémantique qui a déjà mordu trois fois) ;
4. seuil de points, crédit du booster (`UserInventoryService::creditBooster`, lui aussi verrouillé), audit, flush.

Tout refus est une exception métier `RecycleException` avec message FR propre (pattern `BoosterException`), jamais un 500.

**Audit** : `RecycleOperation` (user, booster, points, date) + `RecycleOperationCard` (PK composite opération+carte, quantity totale débitée / holoQuantity en sous-compte, même sémantique que `UserCard` et `BoosterOpeningCard`). L'opération est intégralement reconstituable. La suppression d'un booster référencé est bloquée proprement dans l'admin (compteur ajouté à `deletionBlockers`).

## Décisions produit (à valider)

- **Le surplus au-delà de 10 points est perdu** : pas de solde, pas de monnaie — la simplicité prime. L'audit garde le total réel (une opération à 15 points est enregistrée à 15). L'UI de la PR 2 l'affiche noir sur blanc avant confirmation.
- **Le joueur garde toujours au moins 1 exemplaire** de chaque carte : seuls les doublons se recyclent (protège la complétion de collection). Corollaire : une unique 1/1 (quantity 1 par construction) n'est jamais recyclable.
- Une opération = exactement un booster, sélection d'au moins 10 points.

## Pièges

- La sélection entre en `RecycleSelectionLine` avec **normal et holo séparés** (pas le couple total/sous-compte de `UserCard`) : le débit ne peut pas les mélanger, la conversion vers la sémantique totale ne se fait qu'à l'écriture de l'audit.
- La migration a été nettoyée à la main : le `diff` généré voulait dropper les tables des PRs parallèles non mergées (streak) présentes en base dev.
- `RecycleService` est exposé `public: true` en `when@test` (sinon inliné/supprimé du conteneur compilé tant que l'UI n'existe pas), comme `BoosterOpeningService`.

## Tests

`tests/Integration/Service/RecycleServiceTest.php` (19 tests, Postgres) : happy path complet (débit, crédit, audit, points), pas de `BoosterClaim`, holo = rareté+1, surplus perdu (1 seul booster, total réel en audit), mix raretés/holo, refus < 10 points, sélection vide / quantités négatives / ligne à zéro / carte en double, **garde du dernier exemplaire** (y compris carte à exemplaire unique), plus de holo que possédé, copies normales quand tout est holo, carte non possédée, booster non claimable, extension non publiée, **rollback complet quand une ligne échoue après un débit en mémoire**, **re-validation sous verrou de quantités périmées** (UPDATE SQL brut entre l'affichage et la confirmation). Plus le barème verrouillé dans `CardRarityEnumTest`.

`make quality` OK (phpstan 8 zéro baseline), suite complète **360 tests / 2686 assertions au vert**. Migration passée en dev et en test.
