### PR TITLE
feat(recyclage): page /recyclage — sélection, points en direct, choix du pack (phase 9, 2/2)

### DIFF
--- a/src/Controller/RecycleController.php
+++ b/src/Controller/RecycleController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class RecycleController extends AbstractController
+{
+    #[Route('/recyclage', name: 'recycle')]
+    public function __invoke(): Response
+    {
+        return $this->render('pages/recycle.html.twig');
+    }
+}

--- a/src/Repository/UserCardRepository.php
+++ b/src/Repository/UserCardRepository.php
@@ -109,6 +109,37 @@ class UserCardRepository extends ServiceEntityRepository
     }
 
     /**
+     * Inventory entries with at least one recyclable duplicate (quantity > 1:
+     * the last copy always stays), card and extension eagerly hydrated for the
+     * recycle page, sorted rarest first then by name.
+     *
+     * @return list<UserCard>
+     */
+    public function findRecyclableWithCards(DiscordUser $discordUser): array
+    {
+        /** @var list<UserCard> $cards */
+        $cards = $this->createQueryBuilder('uc')
+            ->join('uc.card', 'c')
+            ->addSelect('c')
+            ->join('c.extension', 'e')
+            ->addSelect('e')
+            ->andWhere('uc.discordUser = :user')
+            ->andWhere('uc.quantity > 1')
+            ->setParameter('user', $discordUser)
+            ->getQuery()
+            ->getResult()
+        ;
+
+        usort(
+            $cards,
+            static fn (UserCard $a, UserCard $b): int => CardRarityEnum::compareRarestFirst($a->getCard()->getRarity(), $b->getCard()->getRarity())
+                ?: $a->getCard()->getName() <=> $b->getCard()->getName(),
+        );
+
+        return $cards;
+    }
+
+    /**
      * Pessimistic write lock on the user's rows for the given cards, so a
      * recycle debit re-validates quantities against what concurrent operations
      * left. Requires an active transaction. Rows are locked in card id order:

--- a/src/Twig/Components/RecycleHub.php
+++ b/src/Twig/Components/RecycleHub.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Twig\Components;
+
+use App\Dto\RecycleSelectionLine;
+use App\Entity\Booster;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\UserCard;
+use App\Enum\Entity\CardRarityEnum;
+use App\Exception\Recycle\RecycleException;
+use App\Repository\BoosterRepository;
+use App\Repository\CardRepository;
+use App\Repository\UserCardRepository;
+use App\Service\Booster\BoosterAvailabilityService;
+use App\Service\Recycle\RecycleService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Uid\Uuid;
+use Symfony\UX\LiveComponent\Attribute\AsLiveComponent;
+use Symfony\UX\LiveComponent\Attribute\LiveAction;
+use Symfony\UX\LiveComponent\Attribute\LiveArg;
+use Symfony\UX\LiveComponent\Attribute\LiveProp;
+use Symfony\UX\LiveComponent\DefaultActionTrait;
+
+/**
+ * Recycle page: pick duplicate copies (normal / holo counted apart), watch the
+ * live point total, choose a claimable booster, confirm. The selection lives
+ * in a non-writable LiveProp mutated by actions only (checksummed, so the
+ * client cannot forge it), and RecycleService re-validates everything under
+ * lock anyway — the component never trusts client-computed points.
+ */
+#[AsLiveComponent]
+final class RecycleHub extends AbstractController
+{
+    use DefaultActionTrait;
+
+    private const string KIND_NORMAL = 'normal';
+    private const string KIND_HOLO = 'holo';
+
+    /**
+     * @var array<string, array{normal: int, holo: int}> card id => selected copies
+     */
+    #[LiveProp]
+    public array $selection = [];
+
+    #[LiveProp(writable: true)]
+    public ?string $boosterId = null;
+
+    #[LiveProp]
+    public ?string $error = null;
+
+    #[LiveProp]
+    public ?string $success = null;
+
+    /**
+     * Recyclable rows are read by several getters per render: memoize them
+     * for the lifetime of the (per-request) component instance.
+     *
+     * @var array<string, UserCard>|null
+     */
+    private ?array $rows = null;
+
+    public function __construct(
+        private readonly UserCardRepository $userCardRepository,
+        private readonly BoosterRepository $boosterRepository,
+        private readonly CardRepository $cardRepository,
+        private readonly BoosterAvailabilityService $boosterAvailability,
+        private readonly RecycleService $recycleService,
+    ) {
+    }
+
+    /**
+     * @return list<UserCard> inventory rows with at least one duplicate
+     */
+    public function getRows(): array
+    {
+        return array_values($this->getRowMap());
+    }
+
+    /**
+     * Boosters offered in exchange: the claimable published ones — the same
+     * set the daily claim allows, enforced again by RecycleService.
+     *
+     * @return list<Booster>
+     */
+    public function getBoosters(): array
+    {
+        return array_values(array_filter(
+            $this->boosterRepository->findPublished(),
+            $this->boosterAvailability->isClaimable(...),
+        ));
+    }
+
+    public function getCost(): int
+    {
+        return RecycleService::BOOSTER_COST;
+    }
+
+    /**
+     * @return list<CardRarityEnum> the point scale legend, least rare first
+     */
+    public function getScale(): array
+    {
+        return CardRarityEnum::ascending();
+    }
+
+    /**
+     * Server-computed point total of the current selection (never client math).
+     */
+    public function getPoints(): int
+    {
+        $points = 0;
+
+        foreach ($this->selection as $cardId => $copies) {
+            $row = $this->getRowMap()[$cardId] ?? null;
+
+            if (!$row instanceof UserCard) {
+                continue;
+            }
+
+            $rarity = $row->getCard()->getRarity();
+            $points += $copies[self::KIND_NORMAL] * $rarity->recyclePoints()
+                + $copies[self::KIND_HOLO] * $rarity->holoRecyclePoints();
+        }
+
+        return $points;
+    }
+
+    public function getSelectedCopies(): int
+    {
+        $copies = 0;
+
+        foreach ($this->selection as $selected) {
+            $copies += $selected[self::KIND_NORMAL] + $selected[self::KIND_HOLO];
+        }
+
+        return $copies;
+    }
+
+    public function getSurplus(): int
+    {
+        return max(0, $this->getPoints() - RecycleService::BOOSTER_COST);
+    }
+
+    /**
+     * @return array{normal: int, holo: int}
+     */
+    public function selectionFor(string | Uuid $cardId): array
+    {
+        return $this->selection[(string) $cardId] ?? [self::KIND_NORMAL => 0, self::KIND_HOLO => 0];
+    }
+
+    #[LiveAction]
+    public function addCopy(#[LiveArg] string $cardId, #[LiveArg] string $kind): void
+    {
+        $this->resetMessages();
+
+        $row = $this->getRowMap()[$cardId] ?? null;
+
+        if (!$row instanceof UserCard || !\in_array($kind, [self::KIND_NORMAL, self::KIND_HOLO], true)) {
+            return;
+        }
+
+        $selected = $this->selectionFor($cardId);
+
+        // keep-one rule: at most quantity - 1 copies of a card, kinds combined
+        if ($selected[self::KIND_NORMAL] + $selected[self::KIND_HOLO] >= $row->getQuantity() - 1) {
+            return;
+        }
+
+        // quantity is the TOTAL (holo included): normal copies = quantity - holoQuantity
+        $kindCap = self::KIND_NORMAL === $kind
+            ? $row->getQuantity() - $row->getHoloQuantity()
+            : $row->getHoloQuantity();
+
+        if ($selected[$kind] >= $kindCap) {
+            return;
+        }
+
+        ++$selected[$kind];
+        $this->selection[$cardId] = $selected;
+    }
+
+    #[LiveAction]
+    public function removeCopy(#[LiveArg] string $cardId, #[LiveArg] string $kind): void
+    {
+        $this->resetMessages();
+
+        if (!\in_array($kind, [self::KIND_NORMAL, self::KIND_HOLO], true)) {
+            return;
+        }
+
+        $selected = $this->selectionFor($cardId);
+        $selected[$kind] = max(0, $selected[$kind] - 1);
+
+        if (0 === $selected[self::KIND_NORMAL] && 0 === $selected[self::KIND_HOLO]) {
+            unset($this->selection[$cardId]);
+
+            return;
+        }
+
+        $this->selection[$cardId] = $selected;
+    }
+
+    #[LiveAction]
+    public function recycle(): void
+    {
+        $this->resetMessages();
+
+        if ([] === $this->selection) {
+            $this->error = 'Sélectionne d\'abord des copies à recycler.';
+
+            return;
+        }
+
+        $booster = $this->findBooster();
+
+        if (!$booster instanceof Booster) {
+            $this->error = 'Choisis le pack à récupérer en échange.';
+
+            return;
+        }
+
+        $lines = [];
+        foreach ($this->selection as $cardId => $copies) {
+            $card = Uuid::isValid($cardId) ? $this->cardRepository->find($cardId) : null;
+
+            if (!$card instanceof Card) {
+                $this->error = 'Sélection invalide, recharge la page et réessaie.';
+
+                return;
+            }
+
+            $lines[] = new RecycleSelectionLine($card, $copies[self::KIND_NORMAL], $copies[self::KIND_HOLO]);
+        }
+
+        try {
+            $operation = $this->recycleService->recycle($this->getDiscordUser(), $lines, $booster);
+        } catch (RecycleException $exception) {
+            $this->error = $exception->getUserMessage();
+
+            return;
+        }
+
+        $surplus = $operation->getPoints() - RecycleService::BOOSTER_COST;
+        $copies = $operation->getRecycledCardCount();
+
+        $this->selection = [];
+        $this->rows = null; // the memoized inventory is stale after the debit
+        $this->success = \sprintf(
+            '%d copie%s recyclée%s — 1 pack « %s » ajouté à ton stock !%s',
+            $copies,
+            $copies > 1 ? 's' : '',
+            $copies > 1 ? 's' : '',
+            $booster->getDisplayName(),
+            $surplus > 0 ? \sprintf(' (%d point%s de surplus perdu%s)', $surplus, $surplus > 1 ? 's' : '', $surplus > 1 ? 's' : '') : '',
+        );
+    }
+
+    /**
+     * @return array<string, UserCard> card id => row
+     */
+    private function getRowMap(): array
+    {
+        if (null !== $this->rows) {
+            return $this->rows;
+        }
+
+        $rows = [];
+
+        foreach ($this->userCardRepository->findRecyclableWithCards($this->getDiscordUser()) as $userCard) {
+            $rows[(string) $userCard->getCard()->getId()] = $userCard;
+        }
+
+        return $this->rows = $rows;
+    }
+
+    /**
+     * The id is client-provided (writable prop): a malformed uuid must resolve
+     * to "not found" instead of a Doctrine conversion error.
+     */
+    private function findBooster(): ?Booster
+    {
+        if (null === $this->boosterId || !Uuid::isValid($this->boosterId)) {
+            return null;
+        }
+
+        return $this->boosterRepository->find($this->boosterId);
+    }
+
+    private function resetMessages(): void
+    {
+        $this->error = null;
+        $this->success = null;
+    }
+
+    private function getDiscordUser(): DiscordUser
+    {
+        $user = $this->getUser();
+
+        if (!$user instanceof DiscordUser) {
+            throw $this->createAccessDeniedException();
+        }
+
+        return $user;
+    }
+}

--- a/templates/components/RecycleHub.html.twig
+++ b/templates/components/RecycleHub.html.twig
@@ -1,0 +1,208 @@
+<div {{ attributes }}>
+    <main>
+        {# ----------------------------------------------------- Hero / points #}
+        <section class="relative border-b border-hairline px-6 py-10 lg:px-12">
+            <div class="glow-ambient" aria-hidden="true"></div>
+            <div class="relative mx-auto flex max-w-7xl flex-col gap-8 md:flex-row md:items-end md:justify-between">
+                <div>
+                    <p class="eyebrow">Recyclage</p>
+                    <h1 class="mt-2 font-display text-4xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-5xl">
+                        Recycle tes doublons
+                    </h1>
+                    <p class="mt-2 max-w-lg text-sm text-ink-muted">
+                        Échange tes copies en trop contre un pack au choix : {{ this.cost }} points = 1 pack.
+                        Tu gardes toujours au moins un exemplaire de chaque carte.
+                    </p>
+                    <div class="mt-4 flex flex-wrap items-baseline gap-x-3 gap-y-1 font-mono text-[11px]" data-testid="recycle-scale">
+                        {% for rarity in this.scale %}
+                            <span style="color: var(--rarity-{{ rarity.value }});">{{ rarity.label }} {{ rarity.recyclePoints }} pt{{ rarity.recyclePoints > 1 ? 's' }}</span>
+                        {% endfor %}
+                        <span class="text-magenta">✦ Holo +1 pt</span>
+                    </div>
+                </div>
+
+                <div class="flex flex-col items-start gap-2.5 md:items-end">
+                    <div class="bg-primary px-5 py-3.5 text-black" data-testid="points-counter">
+                        <p class="font-mono text-[10px] font-bold tracking-[.2em]">POINTS</p>
+                        <p class="mt-1 font-display text-3xl font-bold leading-none">
+                            {{ this.points }}<span class="text-lg opacity-50"> / {{ this.cost }}</span>
+                        </p>
+                    </div>
+                    {% if this.surplus > 0 %}
+                        <p class="chip-mono text-soon" data-testid="surplus-warning">
+                            ⚠ {{ this.points }}/{{ this.cost }} points — le surplus est perdu
+                        </p>
+                    {% else %}
+                        <p class="chip-mono text-ink-dim">Le surplus au-delà de {{ this.cost }} est perdu</p>
+                    {% endif %}
+                </div>
+            </div>
+        </section>
+
+        {% if error %}
+            <div class="mx-auto mt-6 max-w-7xl px-6 lg:px-12">
+                <div class="border border-magenta/50 bg-magenta/10 px-4 py-3 font-mono text-xs text-magenta" data-testid="recycle-error">
+                    ⚠ {{ error }}
+                </div>
+            </div>
+        {% elseif success %}
+            <div class="mx-auto mt-6 max-w-7xl px-6 lg:px-12">
+                <div class="border border-live/50 bg-live/10 px-4 py-3 font-mono text-xs text-live" data-testid="recycle-success">
+                    ♻ {{ success }}
+                </div>
+            </div>
+        {% endif %}
+
+        <section class="px-6 pb-24 pt-10 lg:px-12">
+            <div class="mx-auto grid max-w-7xl items-start gap-8 lg:grid-cols-[1fr_340px]">
+                {# --------------------------------------------- Doublons #}
+                <div>
+                    <h2 class="mb-5 font-display text-sm font-bold uppercase tracking-[.1em] text-ink-strong">
+                        1 · Choisis les copies à recycler
+                    </h2>
+
+                    {% if this.rows is empty %}
+                        <div class="border border-dashed border-hairline px-8 py-20 text-center text-ink-dim" data-testid="recycle-empty">
+                            <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Aucun doublon.</p>
+                            <p class="mt-3 text-sm">Rien à recycler pour l'instant — seules les copies en double se recyclent, ta collection reste intacte.</p>
+                            <a href="{{ path('boosters') }}" class="btn-arcade mt-8">Ouvrir un pack ▸</a>
+                        </div>
+                    {% else %}
+                        <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3" data-testid="recycle-grid">
+                            {% for row in this.rows %}
+                                {% set card = row.card %}
+                                {% set sel = this.selectionFor(card.id) %}
+                                {% set totalSelected = sel.normal + sel.holo %}
+                                {% set normalOwned = row.quantity - row.holoQuantity %}
+                                {% set recyclable = row.quantity - 1 %}
+                                {% set canAddMore = totalSelected < recyclable %}
+                                <article class="flex flex-col border bg-surface p-4 transition-colors {{ totalSelected > 0 ? 'border-primary/60' : 'border-hairline' }}"
+                                         data-testid="recycle-card">
+                                    <div class="flex items-start gap-3">
+                                        <img src="{{ vich_uploader_asset(card) }}" alt="{{ card.name }}" loading="lazy" decoding="async"
+                                             onerror="this.onerror=null;this.src='{{ asset('images/default_card.png') }}';"
+                                             class="h-24 w-auto shrink-0 border border-hairline object-cover">
+                                        <div class="min-w-0">
+                                            <h3 class="truncate font-display text-sm font-bold uppercase leading-tight text-ink-strong" title="{{ card.name }}">
+                                                {{ card.name }}
+                                            </h3>
+                                            <p class="chip-mono mt-1" style="color: var(--rarity-{{ card.rarity.value }});">{{ card.rarity.label }}</p>
+                                            <p class="chip-mono mt-1.5 text-ink-dim">
+                                                ×{{ row.quantity }}{% if row.holoQuantity > 0 %} dont ✦{{ row.holoQuantity }}{% endif %}
+                                                · {{ recyclable }} recyclable{{ recyclable > 1 ? 's' }}
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <div class="mt-3 flex flex-col gap-2 border-t border-hairline pt-3">
+                                        {% if normalOwned > 0 %}
+                                            <div class="flex items-center justify-between gap-2">
+                                                <span class="chip-mono text-ink-muted">Normale · {{ card.rarity.recyclePoints }} pt{{ card.rarity.recyclePoints > 1 ? 's' }}</span>
+                                                <div class="flex items-center gap-1.5">
+                                                    <button type="button" aria-label="Retirer une copie normale de {{ card.name }}"
+                                                            data-action="live#action"
+                                                            data-live-action-param="removeCopy"
+                                                            data-live-card-id-param="{{ card.id }}"
+                                                            data-live-kind-param="normal"
+                                                            {{ sel.normal == 0 ? 'disabled' }}
+                                                            class="border border-hairline px-2.5 py-0.5 font-mono text-sm text-ink-muted transition-colors hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-30">−</button>
+                                                    <span class="w-6 text-center font-mono text-sm font-bold {{ sel.normal > 0 ? 'text-primary' : 'text-ink-dim' }}" data-testid="normal-count">{{ sel.normal }}</span>
+                                                    <button type="button" aria-label="Recycler une copie normale de {{ card.name }}"
+                                                            data-action="live#action"
+                                                            data-live-action-param="addCopy"
+                                                            data-live-card-id-param="{{ card.id }}"
+                                                            data-live-kind-param="normal"
+                                                            data-testid="add-normal"
+                                                            {{ (not canAddMore or sel.normal >= normalOwned) ? 'disabled' }}
+                                                            class="border border-hairline px-2.5 py-0.5 font-mono text-sm text-ink-muted transition-colors hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-30">+</button>
+                                                </div>
+                                            </div>
+                                        {% endif %}
+                                        {% if row.holoQuantity > 0 %}
+                                            <div class="flex items-center justify-between gap-2">
+                                                <span class="chip-mono text-magenta">✦ Holo · {{ card.rarity.holoRecyclePoints }} pts</span>
+                                                <div class="flex items-center gap-1.5">
+                                                    <button type="button" aria-label="Retirer une copie holo de {{ card.name }}"
+                                                            data-action="live#action"
+                                                            data-live-action-param="removeCopy"
+                                                            data-live-card-id-param="{{ card.id }}"
+                                                            data-live-kind-param="holo"
+                                                            {{ sel.holo == 0 ? 'disabled' }}
+                                                            class="border border-hairline px-2.5 py-0.5 font-mono text-sm text-ink-muted transition-colors hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-30">−</button>
+                                                    <span class="w-6 text-center font-mono text-sm font-bold {{ sel.holo > 0 ? 'text-magenta' : 'text-ink-dim' }}" data-testid="holo-count">{{ sel.holo }}</span>
+                                                    <button type="button" aria-label="Recycler une copie holo de {{ card.name }}"
+                                                            data-action="live#action"
+                                                            data-live-action-param="addCopy"
+                                                            data-live-card-id-param="{{ card.id }}"
+                                                            data-live-kind-param="holo"
+                                                            data-testid="add-holo"
+                                                            {{ (not canAddMore or sel.holo >= row.holoQuantity) ? 'disabled' }}
+                                                            class="border border-hairline px-2.5 py-0.5 font-mono text-sm text-ink-muted transition-colors hover:border-primary hover:text-primary disabled:cursor-not-allowed disabled:opacity-30">+</button>
+                                                </div>
+                                            </div>
+                                        {% endif %}
+                                    </div>
+                                </article>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+
+                {# --------------------------------------------- Récapitulatif #}
+                <aside class="border border-hairline bg-surface p-5 lg:sticky lg:top-6" data-testid="recycle-summary">
+                    <h2 class="font-display text-sm font-bold uppercase tracking-[.1em] text-ink-strong">
+                        2 · Choisis ton pack
+                    </h2>
+
+                    {% if this.boosters is empty %}
+                        <p class="mt-4 text-sm text-ink-dim">Aucun pack disponible pour le moment.</p>
+                    {% else %}
+                        <div class="mt-4 flex flex-col gap-2" data-testid="booster-choice">
+                            {% for booster in this.boosters %}
+                                <label class="flex cursor-pointer items-center gap-3 border px-3 py-2.5 transition-colors {{ boosterId == (booster.id ~ '') ? 'border-primary bg-primary/10' : 'border-hairline hover:border-primary/60' }}">
+                                    <input type="radio"
+                                           name="recycle-booster"
+                                           value="{{ booster.id }}"
+                                           data-model="boosterId"
+                                           {{ boosterId == (booster.id ~ '') ? 'checked' }}
+                                           class="accent-[#a435f0]">
+                                    <span class="min-w-0">
+                                        <span class="block truncate font-display text-[13px] font-bold uppercase leading-tight text-ink-strong">{{ booster.displayName }}</span>
+                                        <span class="chip-mono text-ink-dim">Cartes de {{ booster.extension.name }}</span>
+                                    </span>
+                                </label>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+
+                    <div class="mt-5 border-t border-hairline pt-4">
+                        <div class="chip-mono mb-1 flex justify-between text-ink-muted">
+                            <span>{{ this.selectedCopies }} copie{{ this.selectedCopies > 1 ? 's' }}</span>
+                            <span>{{ this.points }} / {{ this.cost }} pts</span>
+                        </div>
+                        <div class="h-2 border border-hairline bg-bg">
+                            <div class="h-full bg-gradient-to-r from-primary to-magenta shadow-[0_0_10px_#a435f0]"
+                                 style="width: {{ min(100, (this.points / this.cost * 100)|round) }}%;"></div>
+                        </div>
+                        {% if this.surplus > 0 %}
+                            <p class="chip-mono mt-2 text-soon">⚠ {{ this.surplus }} pt{{ this.surplus > 1 ? 's' }} au-delà de {{ this.cost }} — perdu{{ this.surplus > 1 ? 's' }} au recyclage</p>
+                        {% endif %}
+
+                        {# plain label + opacity while loading: swapping two spans
+                           leaves the hidden one hidden after the re-render #}
+                        <button type="button"
+                                data-action="live#action"
+                                data-live-action-param="recycle"
+                                data-loading="addClass(opacity-50)"
+                                data-testid="recycle-confirm"
+                                {{ this.points < this.cost ? 'disabled' }}
+                                class="mt-4 w-full border border-primary bg-primary px-4 py-3 font-display text-xs font-bold uppercase tracking-[.12em] text-black transition hover:bg-transparent hover:text-primary disabled:cursor-not-allowed disabled:border-hairline disabled:bg-surface disabled:text-ink-dim">
+                            ♻ Recycler contre 1 pack
+                        </button>
+                        <p class="chip-mono mt-2 text-center text-ink-dim">Hors quota quotidien · irréversible</p>
+                    </div>
+                </aside>
+            </div>
+        </section>
+    </main>
+</div>

--- a/templates/pages/collection.html.twig
+++ b/templates/pages/collection.html.twig
@@ -46,6 +46,11 @@
                        class="border border-primary bg-black px-5 py-3.5 font-display text-[13px] font-bold uppercase tracking-[.15em] text-primary">
                         Ouvrir un pack ▸
                     </a>
+                    <a href="{{ path('recycle') }}"
+                       data-testid="recycle-link"
+                       class="border border-hairline bg-black px-5 py-3.5 font-display text-[13px] font-bold uppercase tracking-[.15em] text-ink-muted transition-colors hover:border-primary hover:text-primary">
+                        ♻ Recycler mes doublons
+                    </a>
                 </div>
             </div>
         </section>

--- a/templates/pages/recycle.html.twig
+++ b/templates/pages/recycle.html.twig
@@ -1,0 +1,9 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    YOUL TCG — Recyclage
+{% endblock %}
+
+{% block body %}
+    {{ component('RecycleHub') }}
+{% endblock %}

--- a/tests/Functional/RecycleHubComponentTest.php
+++ b/tests/Functional/RecycleHubComponentTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional;
+
+use App\Entity\Booster;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\Extension;
+use App\Entity\RecycleOperation;
+use App\Entity\UserBooster;
+use App\Entity\UserCard;
+use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
+use App\Twig\Components\RecycleHub;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\UX\LiveComponent\Test\InteractsWithLiveComponents;
+
+final class RecycleHubComponentTest extends WebTestCase
+{
+    use InteractsWithLiveComponents;
+    use JwtAuthTrait;
+
+    // Juju owns no fixture cards or boosters: every scenario starts clean.
+    private const string USER = '195659530363731968';
+
+    public function testThePageListsOnlyDuplicates(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER);
+        $scenario = $this->createScenario($user, [
+            ['name' => 'Dup card', 'rarity' => CardRarityEnum::COMMON, 'quantity' => 3, 'holoQuantity' => 1],
+            ['name' => 'Single card', 'rarity' => CardRarityEnum::RARE, 'quantity' => 1],
+        ]);
+
+        $client->request('GET', '/recyclage');
+
+        self::assertResponseIsSuccessful();
+        $content = (string) $client->getResponse()->getContent();
+        $this->assertStringContainsString('data-testid="recycle-grid"', $content);
+        $this->assertStringContainsString($scenario['cards'][0]->getName(), $content);
+        $this->assertStringNotContainsString($scenario['cards'][1]->getName(), $content, 'A card without duplicates is not recyclable.');
+    }
+
+    public function testTheEmptyStateShowsWithoutAnyDuplicate(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER);
+
+        $client->request('GET', '/recyclage');
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('data-testid="recycle-empty"', (string) $client->getResponse()->getContent());
+    }
+
+    public function testTheCollectionPageLinksToTheRecyclePage(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER);
+
+        $client->request('GET', '/collection');
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringContainsString('data-testid="recycle-link"', (string) $client->getResponse()->getContent());
+    }
+
+    public function testAddCopyClampsToTheRecyclableCopies(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER);
+        // 3 copies: only 2 are recyclable, the last one always stays
+        $scenario = $this->createScenario($user, [['name' => 'Clamp card', 'rarity' => CardRarityEnum::COMMON, 'quantity' => 3]]);
+        $cardId = (string) $scenario['cards'][0]->getId();
+
+        $component = $this->createLiveComponent(RecycleHub::class, client: $client);
+        foreach (range(1, 5) as $ignored) {
+            $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        }
+
+        $this->assertSame(['normal' => 2, 'holo' => 0], $component->component()->selection[$cardId]);
+    }
+
+    public function testAddCopyRespectsTheHoloSubCountAndTheKeepOneRule(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER);
+        // quantity 4 with 1 holo: 3 recyclable in total, at most 1 of them holo
+        $scenario = $this->createScenario($user, [['name' => 'Holo cap card', 'rarity' => CardRarityEnum::COMMON, 'quantity' => 4, 'holoQuantity' => 1]]);
+        $cardId = (string) $scenario['cards'][0]->getId();
+
+        $component = $this->createLiveComponent(RecycleHub::class, client: $client);
+        foreach (range(1, 3) as $ignored) {
+            $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'holo']);
+        }
+        foreach (range(1, 5) as $ignored) {
+            $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        }
+
+        // 1 holo (sub-count cap) then 2 normal (keep-one total cap), 4 points
+        $this->assertSame(['normal' => 2, 'holo' => 1], $component->component()->selection[$cardId]);
+        $this->assertStringContainsString('4 / 10 pts', (string) $component->render());
+    }
+
+    public function testRemoveCopyDropsTheLineAtZero(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER);
+        $scenario = $this->createScenario($user, [['name' => 'Remove card', 'rarity' => CardRarityEnum::COMMON, 'quantity' => 3]]);
+        $cardId = (string) $scenario['cards'][0]->getId();
+
+        $component = $this->createLiveComponent(RecycleHub::class, client: $client);
+        $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        $component->call('removeCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+
+        $this->assertSame([], $component->component()->selection);
+    }
+
+    public function testRecyclingCreditsTheChosenBoosterAndDebitsTheCopies(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER);
+        // 2 recyclable legendaries = exactly the 10-point cost
+        $scenario = $this->createScenario($user, [['name' => 'Legendary dup', 'rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 3]]);
+        $cardId = (string) $scenario['cards'][0]->getId();
+
+        $component = $this->createLiveComponent(RecycleHub::class, client: $client);
+        $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        $component->set('boosterId', (string) $scenario['booster']->getId());
+        $component->call('recycle');
+
+        $this->assertNull($component->component()->error);
+        $this->assertStringContainsString('ajouté à ton stock', (string) $component->component()->success);
+        $this->assertSame([], $component->component()->selection, 'The selection is emptied after a successful operation.');
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $userBooster = $entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $user, 'booster' => $scenario['booster']]);
+        $this->assertNotNull($userBooster);
+        $this->assertSame(1, $userBooster->getQuantity());
+
+        $userCard = $entityManager->getRepository(UserCard::class)->findOneBy(['discordUser' => $user, 'card' => $scenario['cards'][0]]);
+        $this->assertNotNull($userCard);
+        $this->assertSame(1, $userCard->getQuantity());
+
+        $operations = $entityManager->getRepository(RecycleOperation::class)->findBy(['discordUser' => $user]);
+        $this->assertCount(1, $operations);
+        $this->assertSame(10, $operations[0]->getPoints());
+    }
+
+    public function testTheSurplusIsAnnouncedInTheSuccessMessage(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER);
+        // 3 recyclable legendaries = 15 points: 5 lost
+        $scenario = $this->createScenario($user, [['name' => 'Surplus dup', 'rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 4]]);
+        $cardId = (string) $scenario['cards'][0]->getId();
+
+        $component = $this->createLiveComponent(RecycleHub::class, client: $client);
+        foreach (range(1, 3) as $ignored) {
+            $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        }
+        $component->set('boosterId', (string) $scenario['booster']->getId());
+        $component->call('recycle');
+
+        $this->assertStringContainsString('5 points de surplus perdus', (string) $component->component()->success);
+    }
+
+    public function testASelectionBelowTheCostIsRefused(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER);
+        $scenario = $this->createScenario($user, [['name' => 'Cheap dup', 'rarity' => CardRarityEnum::COMMON, 'quantity' => 3]]);
+        $cardId = (string) $scenario['cards'][0]->getId();
+
+        $component = $this->createLiveComponent(RecycleHub::class, client: $client);
+        $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        $component->set('boosterId', (string) $scenario['booster']->getId());
+        $component->call('recycle');
+
+        $this->assertStringContainsString('points', (string) $component->component()->error);
+        $this->assertNull($component->component()->success);
+        $this->assertNull(
+            static::getContainer()->get(EntityManagerInterface::class)
+                ->getRepository(UserBooster::class)
+                ->findOneBy(['discordUser' => $user, 'booster' => $scenario['booster']]),
+        );
+    }
+
+    public function testConfirmingWithoutABoosterAsksForOne(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER);
+        $scenario = $this->createScenario($user, [['name' => 'No booster dup', 'rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 3]]);
+        $cardId = (string) $scenario['cards'][0]->getId();
+
+        $component = $this->createLiveComponent(RecycleHub::class, client: $client);
+        $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        $component->call('recycle');
+
+        $this->assertSame('Choisis le pack à récupérer en échange.', $component->component()->error);
+    }
+
+    public function testANonClaimableBoosterIsNeitherListedNorAccepted(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER);
+        $scenario = $this->createScenario($user, [['name' => 'Event dup', 'rarity' => CardRarityEnum::LEGENDARY, 'quantity' => 3]]);
+        $cardId = (string) $scenario['cards'][0]->getId();
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $eventBooster = new Booster()
+            ->setName('Event only pack ' . uniqid())
+            ->setExtension($scenario['booster']->getExtension())
+            ->setClaimable(false)
+            ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]])
+        ;
+        $eventBooster->setImageName('default_card.png');
+        $entityManager->persist($eventBooster);
+        $entityManager->flush();
+
+        $component = $this->createLiveComponent(RecycleHub::class, client: $client);
+
+        $this->assertStringNotContainsString($eventBooster->getName() ?? '', (string) $component->render(), 'Event packs are not offered.');
+
+        // a forged id must be refused server-side, not just hidden in the UI
+        $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        $component->call('addCopy', ['cardId' => $cardId, 'kind' => 'normal']);
+        $component->set('boosterId', (string) $eventBooster->getId());
+        $component->call('recycle');
+
+        $this->assertStringContainsString('recyclage', (string) $component->component()->error);
+        $this->assertNull(
+            $entityManager->getRepository(UserBooster::class)->findOneBy(['discordUser' => $user, 'booster' => $eventBooster]),
+        );
+    }
+
+    /**
+     * @param list<array{name: string, rarity: CardRarityEnum, quantity: int, holoQuantity?: int}> $ownedCards
+     *
+     * @return array{booster: Booster, cards: list<Card>}
+     */
+    private function createScenario(DiscordUser $user, array $ownedCards): array
+    {
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+
+        $extension = new Extension()
+            ->setName('Recycle hub extension ' . uniqid())
+            ->setDescription('Test extension')
+            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+        ;
+        $entityManager->persist($extension);
+
+        $cards = [];
+        foreach ($ownedCards as $definition) {
+            $card = new Card()
+                ->setName($definition['name'] . ' ' . uniqid())
+                ->setDescription('Test card')
+                ->setStatus(CardStatusEnum::PUBLISHED)
+                ->setRarity($definition['rarity'])
+                ->setExtension($extension)
+            ;
+            $card->setImageName('default_card.png');
+            $entityManager->persist($card);
+            $cards[] = $card;
+
+            $userCard = new UserCard()
+                ->setDiscordUser($user)
+                ->setCard($card)
+                ->setQuantity($definition['quantity'])
+                ->setHoloQuantity($definition['holoQuantity'] ?? 0)
+            ;
+            $entityManager->persist($userCard);
+        }
+
+        $booster = new Booster()
+            ->setName('Recycle pack ' . uniqid())
+            ->setExtension($extension)
+            ->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 0]])
+        ;
+        $booster->setImageName('default_card.png');
+        $entityManager->persist($booster);
+
+        $entityManager->flush();
+
+        return ['booster' => $booster, 'cards' => $cards];
+    }
+}


### PR DESCRIPTION
Phase 9, PR 2/2, **empilée sur #144** (base `feat/phase-9-recyclage`) : la page « Recyclage » et son Live Component. À merger après #144.

## Ce que ça fait

**`/recyclage`** (`RecycleController` + Live Component `RecycleHub`), accessible depuis la page collection (bouton « ♻ Recycler mes doublons » dans le bandeau, à côté de « Ouvrir un pack » — pas dans le header, touché par les PRs parallèles).

- **Liste des doublons uniquement** (`UserCardRepository::findRecyclableWithCards`, `quantity > 1`, tri rareté puis nom) : artwork, rareté colorée, possédé `×N dont ✦H`, nombre recyclable (`quantity − 1`), et un stepper par sorte de copie — normale (barème de la rareté) et holo (barème + 1), chacun avec sa valeur en points affichée.
- **Steppers bornés côté serveur** dans les LiveActions `addCopy`/`removeCopy` : plafond global `quantity − 1` (garde du dernier exemplaire), plafond par sorte (`quantity − holoQuantity` normales / `holoQuantity` holos). Les `+` se désactivent au plafond, un compteur à 0/0 sort de la sélection.
- **Compteur de points en direct** (calcul 100 % serveur), barre de progression vers 10, et dès qu'on dépasse : « ⚠ N pts au-delà de 10 — perdus au recyclage » (hero + récap) — le surplus perdu est annoncé AVANT la confirmation et rappelé dans le message de succès.
- **Choix du pack** : radios sur les boosters claimables d'extensions publiées uniquement (le même ensemble que le claim quotidien) ; `boosterId` est un LiveProp writable validé côté serveur (uuid malformé → « introuvable », pack non claimable → refus du service, testé avec un id forgé).
- **Confirmation** : label statique + `data-loading="addClass(opacity-50)"` (le piège connu des spans hide/show), désactivée sous 10 points ; succès → sélection vidée, mémo des lignes invalidé, message avec nombre de copies, nom du pack et surplus perdu. État vide sympa quand aucun doublon.

## Sécurité / confiance client

La sélection vit dans un **LiveProp non-writable muté uniquement par les actions** : elle voyage checksummée, le client ne peut pas la forger. Et même forgée, `RecycleService` (PR #144) re-valide tout sous verrou — les points ne sont JAMAIS pris du client. Les caps des steppers ne sont qu'un confort UX, pas une frontière de sécurité.

## Tests

`tests/Functional/RecycleHubComponentTest.php` (11 tests) : page qui ne liste que les doublons, état vide, lien depuis la collection, **clamp au recyclable** (5 clics → 2 sélectionnées sur une carte ×3), **sous-compte holo + garde du dernier exemplaire combinés** (×4 dont ✦1 → max 1 holo + 2 normales, 4 pts au rendu), retrait jusqu'à disparition de la ligne, **happy path complet** (débit `UserCard`, crédit `UserBooster`, audit à 10 pts, sélection vidée, message), surplus annoncé (« 5 points de surplus perdus »), refus < 10 pts sans crédit, confirmation sans pack choisi, **pack event ni listé ni acceptable avec un id forgé**.

`make quality` OK, suite complète **371 tests / 2720 assertions au vert**. `make tailwind.build` passé. Vérification visuelle Playwright (desktop + mobile) sur la base dev : sélection réelle à 13/10 pts, avertissement de surplus, activation du bouton après choix du pack, zéro erreur console.

## À valider manuellement

- Le parcours complet en dev (recycler pour de vrai — les tests Playwright n'ont pas cliqué « Recycler » sur la base dev, données réelles).
- Sur mobile le récap (choix du pack + confirmation) passe sous la grille : OK pour une v1, un raccourci sticky pourrait venir plus tard.
