### PR TITLE
fix(admin): la colonne « Exemplaires » comptait les holos en double

### DIFF
--- a/src/Entity/DiscordUser.php
+++ b/src/Entity/DiscordUser.php
@@ -106,13 +106,14 @@ class DiscordUser implements UserInterface, \Stringable
 
     /**
      * Every copy owned, holo included: what the player would count if they
-     * laid their collection on the table.
+     * laid their collection on the table. quantity is already that total —
+     * holoQuantity is a sub-count of it, never an extra.
      */
     public function getCardCopyCount(): int
     {
         $total = 0;
         foreach ($this->userCards as $userCard) {
-            $total += $userCard->getQuantity() + $userCard->getHoloQuantity();
+            $total += $userCard->getQuantity();
         }
 
         return $total;

--- a/tests/Unit/Entity/DiscordUserTest.php
+++ b/tests/Unit/Entity/DiscordUserTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Entity;
+
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\UserCard;
+use PHPUnit\Framework\TestCase;
+
+final class DiscordUserTest extends TestCase
+{
+    public function testCardCopyCountDoesNotCountHoloCopiesTwice(): void
+    {
+        // quantity is the TOTAL of copies, holoQuantity a sub-count of it:
+        // 3 copies of which 2 are holo is 3 cards on the table, not 5.
+        $user = $this->userOwning([[3, 2], [1, 0]]);
+
+        $this->assertSame(4, $user->getCardCopyCount());
+    }
+
+    public function testCardCopyCountOfAFullyHoloCollection(): void
+    {
+        // the worst case of the double-count bug: every copy is holo
+        $user = $this->userOwning([[2, 2]]);
+
+        $this->assertSame(2, $user->getCardCopyCount());
+    }
+
+    public function testCountsAreZeroWithoutAnyCard(): void
+    {
+        $user = new DiscordUser();
+
+        $this->assertSame(0, $user->getCardCopyCount());
+        $this->assertSame(0, $user->getDistinctCardCount());
+    }
+
+    /**
+     * @param list<array{int, int}> $rows quantity / holoQuantity pairs
+     */
+    private function userOwning(array $rows): DiscordUser
+    {
+        $user = new DiscordUser()->setDiscordId('unit-test')->setUsername('Unit');
+
+        foreach ($rows as [$quantity, $holoQuantity]) {
+            $user->addUserCard(
+                new UserCard()
+                    ->setDiscordUser($user)
+                    ->setCard(new Card())
+                    ->setQuantity($quantity)
+                    ->setHoloQuantity($holoQuantity),
+            );
+        }
+
+        return $user;
+    }
+}


### PR DESCRIPTION
Quatrième et (a priori) dernière occurrence du même bug de sémantique, cherchée explicitement après les fixes #139 et #141.

## Le bug

`DiscordUser::getCardCopyCount()` sommait `quantity + holoQuantity`. Or `quantity` est **déjà** le total des exemplaires d'une carte et `holoQuantity` un **sous-compte** de ce total : chaque exemplaire holo était donc compté deux fois.

Alimentait la colonne **« Exemplaires »** du CRUD Joueurs (index + détail), dont l'aide affirmait pourtant « Total des exemplaires possédés, holos compris » — c'est-à-dire exactement `SUM(quantity)`.

## Constaté en dev

| Joueur | Exemplaires réels | Affiché en admin | Écart |
|---|---|---|---|
| Barlito | 154 | **177** | +23 = son nombre de holos |
| Compte de test (3 cartes dont 1 holo) | 3 | **4** | +1 |

Le 154 est confirmé par la page `/classement` (PR #140), qui calcule `SUM(quantity)` : deux écrans de la même app se contredisaient.

## Le fix

Une ligne : `$total += $userCard->getQuantity();`. Les stats voisines étaient déjà justes (`getBoosterCopyCount()` somme un `quantity` simple, `getDistinctCardCount()` compte des lignes).

## Tests

Nouveau `tests/Unit/Entity/DiscordUserTest.php` — aucun test ne couvrait cette méthode, d'où le bug passé inaperçu : 3 copies dont 2 holos = 3, une collection 100 % holo (le pire cas, ×2 avant le fix) = 2, et le cas vide.

Suite complète (342 tests) et `make quality` au vert.

## Hors périmètre, signalé au passage

- `getCardCopyCount()` hydrate toute la collection `userCards` **par ligne** de l'index EasyAdmin (N+1). Inoffensif aujourd'hui, à basculer en agrégat SQL si la liste des joueurs grossit.
- `getDistinctCardCount()` compte les lignes `UserCard` **y compris à `quantity = 0`**. Inerte tant que rien ne décrémente, mais les échanges (#146) et le recyclage (#144) décrémentent : à revoir en même temps que leur merge.