### PR TITLE
fix(deps): passe symfony/doctrine-bridge en 7.4.16 pour réparer la CI

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3847,16 +3847,16 @@
         },
         {
             "name": "symfony/doctrine-bridge",
-            "version": "v7.4.15",
+            "version": "v7.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/doctrine-bridge.git",
-                "reference": "76ebc0ca1680f766c57cf23d334784ef8e83a5e7"
+                "reference": "f69be90a9cc5ebf210414faa5c69a31b8b5a370f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/76ebc0ca1680f766c57cf23d334784ef8e83a5e7",
-                "reference": "76ebc0ca1680f766c57cf23d334784ef8e83a5e7",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/f69be90a9cc5ebf210414faa5c69a31b8b5a370f",
+                "reference": "f69be90a9cc5ebf210414faa5c69a31b8b5a370f",
                 "shasum": ""
             },
             "require": {
@@ -3936,7 +3936,7 @@
             "description": "Provides integration for Doctrine with various Symfony components",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/doctrine-bridge/tree/v7.4.15"
+                "source": "https://github.com/symfony/doctrine-bridge/tree/v7.4.16"
             },
             "funding": [
                 {
@@ -3956,7 +3956,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-21T15:13:06+00:00"
+            "time": "2026-08-06T07:14:37+00:00"
         },
         {
             "name": "symfony/dotenv",


### PR DESCRIPTION
## Le problème

`master` est rouge depuis le merge de #149 (`doctrine/orm 3.6.7 → 3.6.8`), qui a été mergée alors que son propre `test / tests` était déjà en échec. Le job meurt à l'étape **`Validate Doctrine schema`**, donc **phpunit ne tourne même pas** :

```
In GenerateSchemaEventArgs.php line 41:
  The setSchema() method requires the DBAL Schema::edit() API which is not
  available in the current DBAL version. This feature requires doctrine/dbal ^4.5 or higher.
```

Le mécanisme :

- `doctrine/orm 3.6.8` ajoute `GenerateSchemaEventArgs::setSchema()`, qui lève une exception tant que `doctrine/dbal < 4.5` — l'API `Schema::edit()` dont il dépend n'existe pas avant. Le lock est sur DBAL 4.4.4, et **il n'y a aucune 4.5 stable publiée** (seulement `4.5.x-dev`) : bumper DBAL n'est pas une option.
- `symfony/doctrine-bridge 7.4.15` appelle ce setter derrière un simple `method_exists($event, 'setSchema')`, sans rien vérifier côté DBAL. Avec l'ORM 3.6.8 la condition devient vraie → exception. Et l'appel est **inconditionnel en fin de listener**, même sans transport / lock / cache Doctrine configuré : un simple `doctrine:schema:validate` suffit à déclencher le crash.

## Le correctif

`symfony/doctrine-bridge 7.4.16` complète le garde dans les cinq listeners concernés :

```php
if (method_exists($schema, 'edit') && method_exists($event, 'setSchema')) {
```

Bump du lock uniquement — `composer update symfony/doctrine-bridge` ne déplace **aucun autre paquet** (`0 installs, 1 update, 0 removals`), et `composer.json` reste inchangé.

## Vérification

La validation se fait par la CI : c'est elle qui exécute `doctrine:schema:validate --env=test` sur un `composer install` propre, ce qui est exactement le scénario qui casse.

⚠️ À noter : cette étape masquait la suite du job. Le bump débloque `schema:validate`, mais **phpunit n'a pas tourné sur `master` depuis le merge de #131** — s'il reste autre chose de cassé derrière, c'est ce run qui le révélera.

Sans rapport avec cette PR : les checks `security / trivy` et `auto-merge` sont rouges sur les PRs dependabot depuis un moment, c'est un problème distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
