### PR TITLE
fix(ouverture): la carte d'un pack à 1 carte n'occupe plus tout le panneau

### DIFF
--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -392,6 +392,10 @@
     display: grid;
     grid-template-columns: repeat(var(--track-count, 3), minmax(0, 1fr));
     gap: 10px;
+    /* 1fr per slot blew a 1-card pack up to the whole panel width: cap the
+       grid so a tile keeps the size it has in a 5-card pack, then centre it */
+    max-width: calc(var(--track-count, 3) * 132px + (var(--track-count, 3) - 1) * 10px);
+    margin-inline: auto;
 }
 .opening__track-tile { min-width: 0; }
 .opening__track-img {


### PR DESCRIPTION
## Le problème

Le suivi de révélation (colonne de droite de la page d'ouverture) répartit ses emplacements en `repeat(var(--track-count), minmax(0, 1fr))`. Avec un pack à **une seule carte**, cette unique colonne prend donc toute la largeur du panneau : le dos de carte s'affiche en géant, sans rapport avec le reste de l'interface.

Constaté sur le pack « Bleach Rare » (1 carte).

## Le correctif

Trois lignes de CSS : la grille est bornée à la largeur qu'occuperaient ses tuiles à taille normale, puis centrée.

```css
max-width: calc(var(--track-count, 3) * 132px + (var(--track-count, 3) - 1) * 10px);
margin-inline: auto;
```

Le `1fr` reste en place, donc sur un écran étroit les tuiles se resserrent comme avant : le plafond ne fait que les empêcher de grossir au-delà de leur taille de référence.

## Mesuré au navigateur

Tuile mesurée sur les 18 packs du catalogue dev, avant/après :

| Pack | Avant | Après |
|---|---|---|
| 1 carte (Bleach Rare) | pleine largeur du panneau | **132 × 184 px** |
| 3 cartes (tous les autres) | 132 × 184 px | 132 × 184 px |

Les packs à plusieurs cartes sont inchangés au pixel près.

`make quality` OK, suite complète (370 tests) au vert — changement purement CSS, aucun test impacté.