### PR TITLE
feat(profil): grille comparée avec les cartes manquantes

### DIFF
--- a/assets/controllers/profile_filter_controller.js
+++ b/assets/controllers/profile_filter_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Filters the compared collection of a player profile. Each tile carries its
+ * comparison state (common / profile-only / visitor-only / missing-both /
+ * mystery); this controller only hides tiles and the universes left empty — the
+ * whole catalogue is rendered once, no server round-trip.
+ */
+export default class extends Controller {
+    static targets = ['tile', 'universe', 'button'];
+
+    select(event) {
+        this.apply(event.currentTarget.dataset.state);
+    }
+
+    apply(state) {
+        this.buttonTargets.forEach((button) => {
+            const active = button.dataset.state === state;
+            button.classList.toggle('is-active', active);
+            button.setAttribute('aria-pressed', active ? 'true' : 'false');
+        });
+
+        this.tileTargets.forEach((tile) => {
+            tile.hidden = state !== 'all' && tile.dataset.state !== state;
+        });
+
+        this.universeTargets.forEach((universe) => {
+            universe.hidden = universe.querySelectorAll('[data-profile-filter-target="tile"]:not([hidden])').length === 0;
+        });
+    }
+}

--- a/assets/controllers/profile_filter_controller.js
+++ b/assets/controllers/profile_filter_controller.js
@@ -2,18 +2,21 @@ import { Controller } from '@hotwired/stimulus';
 
 /**
  * Filters the compared collection of a player profile. Each tile carries its
- * comparison state (common / profile-only / visitor-only / missing-both /
- * mystery); this controller only hides tiles and the universes left empty — the
- * whole catalogue is rendered once, no server round-trip.
+ * comparison state (common / profile-only / visitor-only / missing-both); this
+ * controller only hides tiles — the whole catalogue is rendered once, no server
+ * round-trip. Universe headings follow the filter so a "10 cartes" title never
+ * sits above a single tile.
  */
 export default class extends Controller {
-    static targets = ['tile', 'universe', 'button'];
+    static targets = ['tile', 'universe', 'button', 'count', 'counters', 'empty', 'status'];
 
     select(event) {
         this.apply(event.currentTarget.dataset.state);
     }
 
     apply(state) {
+        const filtering = state !== 'all';
+
         this.buttonTargets.forEach((button) => {
             const active = button.dataset.state === state;
             button.classList.toggle('is-active', active);
@@ -21,11 +24,29 @@ export default class extends Controller {
         });
 
         this.tileTargets.forEach((tile) => {
-            tile.hidden = state !== 'all' && tile.dataset.state !== state;
+            tile.hidden = filtering && tile.dataset.state !== state;
         });
 
+        let total = 0;
         this.universeTargets.forEach((universe) => {
-            universe.hidden = universe.querySelectorAll('[data-profile-filter-target="tile"]:not([hidden])').length === 0;
+            const visible = universe.querySelectorAll('[data-profile-filter-target="tile"]:not([hidden])').length;
+            universe.hidden = visible === 0;
+            total += visible;
+
+            const count = universe.querySelector('[data-profile-filter-target="count"]');
+            if (count) {
+                const all = Number(count.dataset.total);
+                count.textContent = filtering ? `${visible} sur ${all}` : `${all} carte${all > 1 ? 's' : ''}`;
+            }
+
+            universe.querySelector('[data-profile-filter-target="counters"]')?.classList.toggle('opacity-40', filtering);
         });
+
+        if (this.hasEmptyTarget) {
+            this.emptyTarget.hidden = total > 0;
+        }
+        if (this.hasStatusTarget) {
+            this.statusTarget.textContent = `${total} carte${total > 1 ? 's' : ''} affichée${total > 1 ? 's' : ''}.`;
+        }
     }
 }

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -45,6 +45,27 @@
         display: none;
     }
 
+    /* Filtre de la collection comparée (profil joueur) */
+    .filter-chip {
+        @apply border border-hairline bg-surface px-3 py-2 font-mono text-[10px] uppercase tracking-[.15em] text-ink-muted;
+    }
+
+    .filter-chip:hover {
+        @apply border-primary text-primary;
+    }
+
+    .filter-chip.is-active {
+        @apply border-primary bg-primary text-black;
+    }
+
+    .filter-chip__count {
+        @apply text-ink-dim;
+    }
+
+    .filter-chip.is-active .filter-chip__count {
+        @apply text-black/60;
+    }
+
     /* Piste sans le fondu latéral (héros pleine largeur : bannières d'univers) */
     .scrollbar-hidden {
         scrollbar-width: none;

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -47,11 +47,15 @@
 
     /* Filtre de la collection comparée (profil joueur) */
     .filter-chip {
-        @apply border border-hairline bg-surface px-3 py-2 font-mono text-[10px] uppercase tracking-[.15em] text-ink-muted;
+        @apply border border-hairline bg-surface px-3 py-3 font-mono text-[10px] uppercase tracking-[.15em] text-ink-muted md:py-2;
     }
 
-    .filter-chip:hover {
+    .filter-chip:hover:not(:disabled) {
         @apply border-primary text-primary;
+    }
+
+    .filter-chip:disabled {
+        @apply cursor-not-allowed opacity-40;
     }
 
     .filter-chip.is-active {
@@ -59,11 +63,11 @@
     }
 
     .filter-chip__count {
-        @apply text-ink-dim;
+        @apply text-ink-muted;
     }
 
     .filter-chip.is-active .filter-chip__count {
-        @apply text-black/60;
+        @apply text-black/80;
     }
 
     /* Piste sans le fondu latéral (héros pleine largeur : bannières d'univers) */
@@ -90,6 +94,11 @@
 }
 .card-tile:has(.card.interacting) .card-tile__chips {
     opacity: 0;
+}
+/* Sur le profil comparé, le chip n'est pas décoratif : il dit qui possède la
+ * carte. Il s'estompe pendant l'inspection mais ne disparaît jamais. */
+.card-tile:has(.card.interacting) .card-tile__chips--sticky {
+    opacity: .45;
 }
 
 /* Panneau « Taux » des cartes booster du hub (details/summary natif) */

--- a/fixtures/Card.yaml
+++ b/fixtures/Card.yaml
@@ -15,6 +15,7 @@ App\Entity\Card:
         description: 'Rogue is the queen of the Afterlife. She is a key figure in the game Cyberpunk 2077.'
         unique: false
         imageName: 'default_card.png'
+        status: 2
         rarity: 'rare'
     card_ichigo:
         name: 'Bleach Ichigo Kurosaki'
@@ -22,7 +23,26 @@ App\Entity\Card:
         description: 'Ichigo Kurosaki is the main character of the Bleach series. He is a teenager with the ability to see ghosts who gains the powers of a Soul Reaper after a fateful encounter with another Soul Reaper, Rukia Kuchiki.'
         unique: false
         imageName: 'default_card.png'
+        status: 2
         rarity: 'rare'
+    # possédée par Barlito seulement : l'état « seulement toi » de la grille comparée
+    card_cp_v:
+        name: 'Cyberpunk V'
+        extension: '@extension_cyberpunk'
+        description: 'V is the mercenary outlaw you play in Cyberpunk 2077, chasing a one-of-a-kind implant that is the key to immortality.'
+        unique: false
+        imageName: 'default_card.png'
+        status: 2
+        rarity: 'uncommon'
+    # possédée par personne : l'état « manquante aux deux »
+    card_bleach_rukia:
+        name: 'Bleach Rukia Kuchiki'
+        extension: '@extension_bleach'
+        description: 'Rukia Kuchiki is the Soul Reaper who gives Ichigo her powers, and one of the central characters of the Bleach series.'
+        unique: false
+        imageName: 'default_card.png'
+        status: 2
+        rarity: 'uncommon'
     card_cp_barlito:
         name: 'Cyberpunk Barlito'
         extension: '@extension_cyberpunk'
@@ -31,6 +51,7 @@ App\Entity\Card:
         imageName: 'default_card.png'
         status: 2
         rarity: 'common'
+    # 1/1 déjà attribuée : reste face cachée et hors décompte sur tous les profils
     card_cp_farf:
         name: 'Cyberpunk Farf'
         extension: '@extension_cyberpunk'
@@ -39,6 +60,7 @@ App\Entity\Card:
         imageName: 'default_card.png'
         status: 2
         rarity: 'rare'
+        claimedBy: '@discord_user_collectionneur'
     card_magic_king_julian:
         name: 'Magic King Julian'
         extension: '@extension_magic'

--- a/fixtures/Card.yaml
+++ b/fixtures/Card.yaml
@@ -17,13 +17,14 @@ App\Entity\Card:
         imageName: 'default_card.png'
         status: 2
         rarity: 'rare'
+    # brouillon volontaire : Bleach doit rester un univers SANS carte publiée
+    # (le hub le rend « à venir », cf. BoosterHubComponentTest)
     card_ichigo:
         name: 'Bleach Ichigo Kurosaki'
         extension: '@extension_bleach'
         description: 'Ichigo Kurosaki is the main character of the Bleach series. He is a teenager with the ability to see ghosts who gains the powers of a Soul Reaper after a fateful encounter with another Soul Reaper, Rukia Kuchiki.'
         unique: false
         imageName: 'default_card.png'
-        status: 2
         rarity: 'rare'
     # possédée par Barlito seulement : l'état « seulement toi » de la grille comparée
     card_cp_v:
@@ -35,10 +36,10 @@ App\Entity\Card:
         status: 2
         rarity: 'uncommon'
     # possédée par personne : l'état « manquante aux deux »
-    card_bleach_rukia:
-        name: 'Bleach Rukia Kuchiki'
-        extension: '@extension_bleach'
-        description: 'Rukia Kuchiki is the Soul Reaper who gives Ichigo her powers, and one of the central characters of the Bleach series.'
+    card_cp_orphan:
+        name: 'Cyberpunk Nomade Anonyme'
+        extension: '@extension_cyberpunk'
+        description: 'Un nomade des Badlands que personne ne semble avoir croisé. Sa carte circule pourtant.'
         unique: false
         imageName: 'default_card.png'
         status: 2

--- a/fixtures/UserCard.yaml
+++ b/fixtures/UserCard.yaml
@@ -1,12 +1,18 @@
 # Collections de démo. Le recouvrement est volontaire : sur le profil du
-# Collectionneur, Barlito voit en clair la carte qu'il possède aussi et face
-# cachée celles qu'il n'a pas — les deux cas du masquage sur un seul écran.
+# Collectionneur, Barlito retrouve les cinq états de la grille comparée sur un
+# seul écran — en commun (cp_barlito), seulement lui (rogue, ichigo), seulement
+# Barlito (cp_v), manquante aux deux (rukia) et la 1/1 mystère (cp_farf).
 App\Entity\UserCard:
   user_card_barlito_cp_barlito:
     discordUser: '@discord_user_barlito'
     card: '@card_cp_barlito'
     quantity: 3
     holoQuantity: 1
+
+  user_card_barlito_cp_v:
+    discordUser: '@discord_user_barlito'
+    card: '@card_cp_v'
+    quantity: 2
 
   user_card_collectionneur_cp_barlito:
     discordUser: '@discord_user_collectionneur'
@@ -24,3 +30,9 @@ App\Entity\UserCard:
     card: '@card_ichigo'
     quantity: 4
     holoQuantity: 2
+
+  # la 1/1 qu'il détient (cf. claimedBy dans Card.yaml)
+  user_card_collectionneur_farf:
+    discordUser: '@discord_user_collectionneur'
+    card: '@card_cp_farf'
+    quantity: 1

--- a/src/Controller/LeaderboardController.php
+++ b/src/Controller/LeaderboardController.php
@@ -5,27 +5,25 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Entity\DiscordUser;
-use App\Entity\Extension;
-use App\Entity\UserCard;
 use App\Repository\DiscordUserRepository;
-use App\Repository\UserCardRepository;
 use App\Service\Leaderboard\LeaderboardService;
+use App\Service\Leaderboard\ProfileComparisonService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 /**
- * The collectors leaderboard and the public player profiles. A profile only
- * reveals a card the visitor ALSO owns; everything else is masked (card back,
- * no name anywhere in the DOM) — the 1/1 mystery included.
+ * The collectors leaderboard and the public player profiles. A profile shows
+ * the whole published catalogue compared with the visitor's collection; the
+ * disclosure rules live in ProfileComparisonService.
  */
 class LeaderboardController extends AbstractController
 {
     public function __construct(
         private readonly LeaderboardService $leaderboardService,
         private readonly DiscordUserRepository $discordUserRepository,
-        private readonly UserCardRepository $userCardRepository,
+        private readonly ProfileComparisonService $profileComparisonService,
     ) {
     }
 
@@ -47,36 +45,10 @@ class LeaderboardController extends AbstractController
             throw $this->createNotFoundException(\sprintf('Unknown player "%s".', $discordId));
         }
 
-        $isSelf = $visitor->getDiscordId() === $profile->getDiscordId();
-        // cards the VISITOR owns: the reveal key of the masking rule
-        $visitorCardIds = $isSelf ? [] : array_flip($this->userCardRepository->findOwnedCardIds($visitor));
-
-        $universes = [];
-        $hiddenTotal = 0;
-        foreach ($this->userCardRepository->findOwnedWithCards($profile) as $userCard) {
-            $extension = $userCard->getCard()->getExtension();
-            if (!$extension instanceof Extension) {
-                continue;
-            }
-            $extensionId = (string) $extension->getId();
-            $visible = $isSelf || isset($visitorCardIds[(string) $userCard->getCard()->getId()]);
-
-            $universes[$extensionId] ??= ['extension' => $extension, 'cards' => [], 'hiddenCount' => 0];
-            $universes[$extensionId]['cards'][] = ['userCard' => $userCard, 'visible' => $visible];
-            $universes[$extensionId]['hiddenCount'] += $visible ? 0 : 1;
-            $hiddenTotal += $visible ? 0 : 1;
-        }
-
-        /** @var list<array{extension: Extension, cards: list<array{userCard: UserCard, visible: bool}>, hiddenCount: int}> $universes */
-        $universes = array_values($universes);
-        usort($universes, static fn (array $a, array $b): int => strcasecmp($a['extension']->getName(), $b['extension']->getName()));
-
         return $this->render('pages/player_profile.html.twig', [
             'profile' => $profile,
             'entry' => $this->leaderboardService->getEntryFor($profile),
-            'universes' => $universes,
-            'hiddenTotal' => $hiddenTotal,
-            'isSelf' => $isSelf,
+            'comparison' => $this->profileComparisonService->compare($profile, $visitor),
         ]);
     }
 }

--- a/src/Dto/ProfileCardComparison.php
+++ b/src/Dto/ProfileCardComparison.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Entity\Card;
+use App\Entity\UserCard;
+use App\Enum\ProfileCardStateEnum;
+
+/**
+ * One catalogue card seen through the profile/visitor comparison. profileCard
+ * is only carried when the state reveals the card, so a masked tile has no
+ * quantity to leak.
+ */
+final readonly class ProfileCardComparison
+{
+    public function __construct(
+        public Card $card,
+        public ProfileCardStateEnum $state,
+        public ?UserCard $profileCard = null,
+    ) {
+    }
+}

--- a/src/Dto/ProfileComparison.php
+++ b/src/Dto/ProfileComparison.php
@@ -20,7 +20,6 @@ final readonly class ProfileComparison
         public int $profileOnly,
         public int $visitorOnly,
         public int $missingBoth,
-        public int $mysteryCount,
         public bool $isSelf,
     ) {
     }

--- a/src/Dto/ProfileComparison.php
+++ b/src/Dto/ProfileComparison.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+/**
+ * The whole published catalogue compared between a visited profile and its
+ * visitor, universe by universe, with the global counters of the filter bar.
+ */
+final readonly class ProfileComparison
+{
+    /**
+     * @param list<ProfileUniverseComparison> $universes
+     */
+    public function __construct(
+        public array $universes,
+        public int $total,
+        public int $common,
+        public int $profileOnly,
+        public int $visitorOnly,
+        public int $missingBoth,
+        public int $mysteryCount,
+        public bool $isSelf,
+    ) {
+    }
+}

--- a/src/Dto/ProfileUniverseComparison.php
+++ b/src/Dto/ProfileUniverseComparison.php
@@ -8,8 +8,7 @@ use App\Entity\Extension;
 
 /**
  * The compared set of one universe: every published card of the extension plus
- * the counters of the comparison. mysteryCount is the number of 1/1 tiles left
- * out of those counters.
+ * the counters of the comparison.
  */
 final readonly class ProfileUniverseComparison
 {
@@ -24,7 +23,6 @@ final readonly class ProfileUniverseComparison
         public int $profileOnly,
         public int $visitorOnly,
         public int $missingBoth,
-        public int $mysteryCount,
     ) {
     }
 }

--- a/src/Dto/ProfileUniverseComparison.php
+++ b/src/Dto/ProfileUniverseComparison.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Dto;
+
+use App\Entity\Extension;
+
+/**
+ * The compared set of one universe: every published card of the extension plus
+ * the counters of the comparison. mysteryCount is the number of 1/1 tiles left
+ * out of those counters.
+ */
+final readonly class ProfileUniverseComparison
+{
+    /**
+     * @param list<ProfileCardComparison> $cards
+     */
+    public function __construct(
+        public Extension $extension,
+        public array $cards,
+        public int $total,
+        public int $common,
+        public int $profileOnly,
+        public int $visitorOnly,
+        public int $missingBoth,
+        public int $mysteryCount,
+    ) {
+    }
+}

--- a/src/Enum/ProfileCardStateEnum.php
+++ b/src/Enum/ProfileCardStateEnum.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enum;
+
+/**
+ * How one catalogue card compares between the visited profile and the visitor.
+ * Drives both the tile rendering and the client-side filter (the value is the
+ * data-state attribute).
+ */
+enum ProfileCardStateEnum: string
+{
+    /** both own it — the only case where the profile's quantities are shown */
+    case COMMON = 'common';
+
+    /** the profile owns it, the visitor doesn't: masked, as it has always been */
+    case PROFILE_ONLY = 'profile-only';
+
+    /** the visitor owns it, the profile doesn't: nothing of the profile to hide */
+    case VISITOR_ONLY = 'visitor-only';
+
+    /** nobody owns it — the shared hunt */
+    case MISSING_BOTH = 'missing-both';
+
+    /** a 1/1 the visitor doesn't hold: never says whether the profile has it */
+    case MYSTERY = 'mystery';
+
+    /**
+     * Whether the artwork (and therefore the card name) may be rendered.
+     */
+    public function revealsCard(): bool
+    {
+        return self::COMMON === $this || self::VISITOR_ONLY === $this;
+    }
+
+    /**
+     * States kept out of the comparison counters: a 1/1 must stay a count, so
+     * a universe holding a single unique cannot be solved by subtraction.
+     */
+    public function isCountable(): bool
+    {
+        return self::MYSTERY !== $this;
+    }
+}

--- a/src/Enum/ProfileCardStateEnum.php
+++ b/src/Enum/ProfileCardStateEnum.php
@@ -8,6 +8,10 @@ namespace App\Enum;
  * How one catalogue card compares between the visited profile and the visitor.
  * Drives both the tile rendering and the client-side filter (the value is the
  * data-state attribute).
+ *
+ * 1/1 uniques follow the same states as any other card: the page is the base of
+ * the future trades, so knowing WHO holds one matters — the artwork and the name
+ * stay masked all the same.
  */
 enum ProfileCardStateEnum: string
 {
@@ -23,23 +27,11 @@ enum ProfileCardStateEnum: string
     /** nobody owns it — the shared hunt */
     case MISSING_BOTH = 'missing-both';
 
-    /** a 1/1 the visitor doesn't hold: never says whether the profile has it */
-    case MYSTERY = 'mystery';
-
     /**
      * Whether the artwork (and therefore the card name) may be rendered.
      */
     public function revealsCard(): bool
     {
         return self::COMMON === $this || self::VISITOR_ONLY === $this;
-    }
-
-    /**
-     * States kept out of the comparison counters: a 1/1 must stay a count, so
-     * a universe holding a single unique cannot be solved by subtraction.
-     */
-    public function isCountable(): bool
-    {
-        return self::MYSTERY !== $this;
     }
 }

--- a/src/Repository/CardRepository.php
+++ b/src/Repository/CardRepository.php
@@ -65,6 +65,54 @@ class CardRepository extends ServiceEntityRepository
     }
 
     /**
+     * The whole published catalogue (published cards of published extensions),
+     * grouped by extension — the reference set the compared profile grid is
+     * built on. One query, extensions hydrated by the join.
+     *
+     * @return list<array{extension: Extension, cards: list<Card>}>
+     */
+    public function findPublishedGroupedByExtension(): array
+    {
+        /** @var list<Card> $cards */
+        $cards = $this->createQueryBuilder('c')
+            ->join('c.extension', 'e')
+            ->addSelect('e')
+            ->andWhere('c.status = :cardStatus')
+            ->andWhere('e.status = :extensionStatus')
+            ->setParameter('cardStatus', CardStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
+            ->setParameter('extensionStatus', ExtensionStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
+            ->orderBy('e.name', 'ASC')
+            ->addOrderBy('c.name', 'ASC')
+            ->getQuery()
+            ->getResult()
+        ;
+
+        $groups = [];
+        foreach ($cards as $card) {
+            $extension = $card->getExtension();
+            if (!$extension instanceof Extension) {
+                continue;
+            }
+
+            $extensionId = (string) $extension->getId();
+            $groups[$extensionId] ??= ['extension' => $extension, 'cards' => []];
+            $groups[$extensionId]['cards'][] = $card;
+        }
+
+        // rarity is a string-backed enum: rank it in PHP, name already sorted by SQL
+        foreach ($groups as $extensionId => $group) {
+            $groupCards = $group['cards'];
+            usort(
+                $groupCards,
+                static fn (Card $a, Card $b): int => CardRarityEnum::compareRarestFirst($a->getRarity(), $b->getRarity()),
+            );
+            $groups[$extensionId]['cards'] = $groupCards;
+        }
+
+        return array_values($groups);
+    }
+
+    /**
      * The draw pool of an extension: published cards, EXCLUDING one-of-one
      * unique cards that are already claimed (so a claimed unique can never be
      * drawn again). Available (unclaimed) uniques stay in the pool.

--- a/src/Service/Leaderboard/ProfileComparisonService.php
+++ b/src/Service/Leaderboard/ProfileComparisonService.php
@@ -7,7 +7,6 @@ namespace App\Service\Leaderboard;
 use App\Dto\ProfileCardComparison;
 use App\Dto\ProfileComparison;
 use App\Dto\ProfileUniverseComparison;
-use App\Entity\Card;
 use App\Entity\DiscordUser;
 use App\Entity\UserCard;
 use App\Enum\ProfileCardStateEnum;
@@ -24,9 +23,8 @@ use App\Repository\UserCardRepository;
  *    historical masking rule, untouched);
  *  - a card the profile does NOT own has nothing to hide, so it may be revealed
  *    as soon as the visitor owns it;
- *  - a 1/1 the visitor doesn't hold stays a MYSTERY tile: neither the artwork
- *    nor the ownership bit, and it is excluded from the counters so that a
- *    universe with a single unique cannot be solved by subtraction.
+ *  - 1/1 uniques are compared like the rest: the page feeds the trades, so who
+ *    holds one is shown, while the artwork and the name stay masked.
  *
  * Three queries whatever the catalogue size — never one per card or per player.
  */
@@ -54,16 +52,16 @@ final readonly class ProfileComparisonService
             : array_flip($this->userCardRepository->findOwnedCardIds($visitor));
 
         $universes = [];
-        $totals = ['total' => 0, 'common' => 0, 'profileOnly' => 0, 'visitorOnly' => 0, 'missingBoth' => 0, 'mystery' => 0];
+        $totals = ['total' => 0, 'common' => 0, 'profileOnly' => 0, 'visitorOnly' => 0, 'missingBoth' => 0];
 
         foreach ($this->cardRepository->findPublishedGroupedByExtension() as $group) {
             $cards = [];
-            $counts = ['common' => 0, 'profileOnly' => 0, 'visitorOnly' => 0, 'missingBoth' => 0, 'mystery' => 0];
+            $counts = ['common' => 0, 'profileOnly' => 0, 'visitorOnly' => 0, 'missingBoth' => 0];
 
             foreach ($group['cards'] as $card) {
                 $cardId = (string) $card->getId();
                 $profileCard = $profileCards[$cardId] ?? null;
-                $state = $this->resolveState($card, null !== $profileCard, isset($visitorCards[$cardId]), $isSelf);
+                $state = $this->resolveState(null !== $profileCard, isset($visitorCards[$cardId]));
 
                 $cards[] = new ProfileCardComparison(
                     card: $card,
@@ -82,7 +80,6 @@ final readonly class ProfileComparisonService
                 profileOnly: $counts['profileOnly'],
                 visitorOnly: $counts['visitorOnly'],
                 missingBoth: $counts['missingBoth'],
-                mysteryCount: $counts['mystery'],
             );
 
             $totals['total'] += \count($cards);
@@ -98,17 +95,12 @@ final readonly class ProfileComparisonService
             profileOnly: $totals['profileOnly'],
             visitorOnly: $totals['visitorOnly'],
             missingBoth: $totals['missingBoth'],
-            mysteryCount: $totals['mystery'],
             isSelf: $isSelf,
         );
     }
 
-    private function resolveState(Card $card, bool $profileOwns, bool $visitorOwns, bool $isSelf): ProfileCardStateEnum
+    private function resolveState(bool $profileOwns, bool $visitorOwns): ProfileCardStateEnum
     {
-        if (!$isSelf && $card->isUnique() && !$visitorOwns) {
-            return ProfileCardStateEnum::MYSTERY;
-        }
-
         return match (true) {
             $profileOwns && $visitorOwns => ProfileCardStateEnum::COMMON,
             $profileOwns => ProfileCardStateEnum::PROFILE_ONLY,
@@ -118,7 +110,7 @@ final readonly class ProfileComparisonService
     }
 
     /**
-     * @return 'common'|'profileOnly'|'visitorOnly'|'missingBoth'|'mystery'
+     * @return 'common'|'profileOnly'|'visitorOnly'|'missingBoth'
      */
     private function counterKey(ProfileCardStateEnum $state): string
     {
@@ -127,7 +119,6 @@ final readonly class ProfileComparisonService
             ProfileCardStateEnum::PROFILE_ONLY => 'profileOnly',
             ProfileCardStateEnum::VISITOR_ONLY => 'visitorOnly',
             ProfileCardStateEnum::MISSING_BOTH => 'missingBoth',
-            ProfileCardStateEnum::MYSTERY => 'mystery',
         };
     }
 }

--- a/src/Service/Leaderboard/ProfileComparisonService.php
+++ b/src/Service/Leaderboard/ProfileComparisonService.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Leaderboard;
+
+use App\Dto\ProfileCardComparison;
+use App\Dto\ProfileComparison;
+use App\Dto\ProfileUniverseComparison;
+use App\Entity\Card;
+use App\Entity\DiscordUser;
+use App\Entity\UserCard;
+use App\Enum\ProfileCardStateEnum;
+use App\Repository\CardRepository;
+use App\Repository\UserCardRepository;
+
+/**
+ * Crosses the published catalogue with two collections — the visited profile's
+ * and the visitor's — so a profile also shows what its owner is MISSING, and
+ * what both are still hunting.
+ *
+ * Disclosure rules, in one place:
+ *  - a card of the profile is revealed only when the visitor owns it too (the
+ *    historical masking rule, untouched);
+ *  - a card the profile does NOT own has nothing to hide, so it may be revealed
+ *    as soon as the visitor owns it;
+ *  - a 1/1 the visitor doesn't hold stays a MYSTERY tile: neither the artwork
+ *    nor the ownership bit, and it is excluded from the counters so that a
+ *    universe with a single unique cannot be solved by subtraction.
+ *
+ * Three queries whatever the catalogue size — never one per card or per player.
+ */
+final readonly class ProfileComparisonService
+{
+    public function __construct(
+        private CardRepository $cardRepository,
+        private UserCardRepository $userCardRepository,
+    ) {
+    }
+
+    public function compare(DiscordUser $profile, DiscordUser $visitor): ProfileComparison
+    {
+        $isSelf = $profile->getDiscordId() === $visitor->getDiscordId();
+
+        /** @var array<string, UserCard> $profileCards */
+        $profileCards = [];
+        foreach ($this->userCardRepository->findOwnedWithCards($profile) as $userCard) {
+            $profileCards[(string) $userCard->getCard()->getId()] = $userCard;
+        }
+
+        // on your own profile you are your own reveal key: everything is in clear
+        $visitorCards = $isSelf
+            ? $profileCards
+            : array_flip($this->userCardRepository->findOwnedCardIds($visitor));
+
+        $universes = [];
+        $totals = ['total' => 0, 'common' => 0, 'profileOnly' => 0, 'visitorOnly' => 0, 'missingBoth' => 0, 'mystery' => 0];
+
+        foreach ($this->cardRepository->findPublishedGroupedByExtension() as $group) {
+            $cards = [];
+            $counts = ['common' => 0, 'profileOnly' => 0, 'visitorOnly' => 0, 'missingBoth' => 0, 'mystery' => 0];
+
+            foreach ($group['cards'] as $card) {
+                $cardId = (string) $card->getId();
+                $profileCard = $profileCards[$cardId] ?? null;
+                $state = $this->resolveState($card, null !== $profileCard, isset($visitorCards[$cardId]), $isSelf);
+
+                $cards[] = new ProfileCardComparison(
+                    card: $card,
+                    state: $state,
+                    profileCard: $state->revealsCard() ? $profileCard : null,
+                );
+
+                ++$counts[$this->counterKey($state)];
+            }
+
+            $universes[] = new ProfileUniverseComparison(
+                extension: $group['extension'],
+                cards: $cards,
+                total: \count($cards),
+                common: $counts['common'],
+                profileOnly: $counts['profileOnly'],
+                visitorOnly: $counts['visitorOnly'],
+                missingBoth: $counts['missingBoth'],
+                mysteryCount: $counts['mystery'],
+            );
+
+            $totals['total'] += \count($cards);
+            foreach ($counts as $key => $value) {
+                $totals[$key] += $value;
+            }
+        }
+
+        return new ProfileComparison(
+            universes: $universes,
+            total: $totals['total'],
+            common: $totals['common'],
+            profileOnly: $totals['profileOnly'],
+            visitorOnly: $totals['visitorOnly'],
+            missingBoth: $totals['missingBoth'],
+            mysteryCount: $totals['mystery'],
+            isSelf: $isSelf,
+        );
+    }
+
+    private function resolveState(Card $card, bool $profileOwns, bool $visitorOwns, bool $isSelf): ProfileCardStateEnum
+    {
+        if (!$isSelf && $card->isUnique() && !$visitorOwns) {
+            return ProfileCardStateEnum::MYSTERY;
+        }
+
+        return match (true) {
+            $profileOwns && $visitorOwns => ProfileCardStateEnum::COMMON,
+            $profileOwns => ProfileCardStateEnum::PROFILE_ONLY,
+            $visitorOwns => ProfileCardStateEnum::VISITOR_ONLY,
+            default => ProfileCardStateEnum::MISSING_BOTH,
+        };
+    }
+
+    /**
+     * @return 'common'|'profileOnly'|'visitorOnly'|'missingBoth'|'mystery'
+     */
+    private function counterKey(ProfileCardStateEnum $state): string
+    {
+        return match ($state) {
+            ProfileCardStateEnum::COMMON => 'common',
+            ProfileCardStateEnum::PROFILE_ONLY => 'profileOnly',
+            ProfileCardStateEnum::VISITOR_ONLY => 'visitorOnly',
+            ProfileCardStateEnum::MISSING_BOTH => 'missingBoth',
+            ProfileCardStateEnum::MYSTERY => 'mystery',
+        };
+    }
+}

--- a/templates/pages/player_profile.html.twig
+++ b/templates/pages/player_profile.html.twig
@@ -97,8 +97,7 @@
 
                     {% if not isSelf %}
                         <p class="chip-mono mb-8 border border-hairline bg-surface px-3 py-2 text-ink-muted" data-testid="masking-hint">
-                            Face cachée = tu ne l'as pas encore. <span class="text-primary">◈ Sa collection</span> = {{ profile.username }} l'a, toi non. Éteinte = personne ne l'a.
-                            {%- if comparison.mysteryCount > 0 %} <span class="text-magenta">◆ 1/1</span> : détenteur jamais révélé, donc hors décompte.{% endif %}
+                            Face cachée = tu ne l'as pas encore. <span class="text-primary">◈ Sa collection</span> = {{ profile.username }} l'a, toi non. Éteinte = personne ne l'a. <span class="text-magenta">◆ 1/1</span> = carte unique.
                         </p>
                     {% endif %}
                 {% endif %}
@@ -121,9 +120,6 @@
                                 <span>▼ {{ universe.visitorOnly }} seulement toi</span>
                             {% endif %}
                             <span>✕ {{ universe.missingBoth }} manquante{{ universe.missingBoth > 1 ? 's' }}{{ isSelf ? '' : ' aux deux' }}</span>
-                            {% if universe.mysteryCount > 0 %}
-                                <span class="text-magenta">◆ {{ universe.mysteryCount }} × 1/1 hors décompte</span>
-                            {% endif %}
                         </div>
 
                         <div class="mt-6 grid grid-cols-2 gap-6 md:grid-cols-3 xl:grid-cols-5" data-testid="profile-grid">
@@ -135,30 +131,28 @@
                                      data-testid="profile-tile">
                                     {% if item.state.revealsCard %}
                                         {{ include('components/CardComponent.html.twig', { card: item.card, holo: item.profileCard and item.profileCard.holoQuantity > 0, lazy: true }) }}
-                                        <div class="card-tile__chips pointer-events-none absolute -right-2 -top-2 z-10 flex gap-1.5">
-                                            {% if item.profileCard %}
-                                                <span class="chip-mono bg-black/90 px-2 py-1 font-bold text-white">×{{ item.profileCard.quantity }}</span>
-                                                {% if item.profileCard.holoQuantity > 0 %}
-                                                    <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">✦{{ item.profileCard.holoQuantity }}</span>
-                                                {% endif %}
-                                            {% else %}
-                                                <span class="chip-mono border border-hairline bg-black/90 px-2 py-1 font-bold text-ink-muted">Manque</span>
-                                            {% endif %}
-                                        </div>
                                     {% else %}
-                                        {# dos de carte : l'état est signalé par l'habillage, jamais par la carte —
-                                           une 1/1 garde le même badge qu'elle soit détenue ou non #}
-                                        <div class="{{ item.state.value == 'profile-only' ? 'ring-1 ring-primary/60' : (item.state.value == 'mystery' ? 'ring-1 ring-magenta/50' : 'opacity-45') }}">
+                                        {# dos de carte : seule la possession est signalée, jamais la carte #}
+                                        <div class="{{ item.state.value == 'profile-only' ? 'ring-1 ring-primary/60' : 'opacity-45' }}">
                                             {{ include('parts/_masked_card.html.twig') }}
                                         </div>
-                                        <div class="card-tile__chips pointer-events-none absolute -right-2 -top-2 z-10 flex gap-1.5">
-                                            {% if item.state.value == 'profile-only' %}
-                                                <span class="chip-mono border border-primary bg-black/90 px-2 py-1 font-bold text-primary" data-testid="chip-owned">◈ Sa collection</span>
-                                            {% elseif item.state.value == 'mystery' %}
-                                                <span class="chip-mono border border-magenta bg-black/90 px-2 py-1 font-bold text-magenta" data-testid="chip-mystery">◆ 1/1</span>
-                                            {% endif %}
-                                        </div>
                                     {% endif %}
+
+                                    <div class="card-tile__chips pointer-events-none absolute -right-2 -top-2 z-10 flex flex-wrap justify-end gap-1.5">
+                                        {% if item.card.isUnique %}
+                                            <span class="chip-mono border border-magenta bg-black/90 px-2 py-1 font-bold text-magenta" data-testid="chip-unique">◆ 1/1</span>
+                                        {% endif %}
+                                        {% if item.state.value == 'common' %}
+                                            <span class="chip-mono bg-black/90 px-2 py-1 font-bold text-white">×{{ item.profileCard.quantity }}</span>
+                                            {% if item.profileCard.holoQuantity > 0 %}
+                                                <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">✦{{ item.profileCard.holoQuantity }}</span>
+                                            {% endif %}
+                                        {% elseif item.state.value == 'profile-only' %}
+                                            <span class="chip-mono border border-primary bg-black/90 px-2 py-1 font-bold text-primary" data-testid="chip-owned">◈ Sa collection</span>
+                                        {% elseif item.state.value == 'visitor-only' %}
+                                            <span class="chip-mono border border-hairline bg-black/90 px-2 py-1 font-bold text-ink-muted" data-testid="chip-wanted">Lui manque</span>
+                                        {% endif %}
+                                    </div>
                                 </div>
                             {% endfor %}
                         </div>

--- a/templates/pages/player_profile.html.twig
+++ b/templates/pages/player_profile.html.twig
@@ -68,6 +68,8 @@
                 {% endif %}
 
                 {% if comparison.total > 0 %}
+                    {# pseudo tronqué : un pseudo Discord long ferait déborder la barre en mobile #}
+                    {% set shortName = profile.username|slice(0, 12) ~ (profile.username|length > 12 ? '…' : '') %}
                     {% set filters = isSelf
                         ? [
                             { state: 'all', label: 'Tout', count: comparison.total },
@@ -77,44 +79,58 @@
                         : [
                             { state: 'all', label: 'Tout', count: comparison.total },
                             { state: 'common', label: 'En commun', count: comparison.common },
-                            { state: 'profile-only', label: 'Seulement ' ~ profile.username, count: comparison.profileOnly },
+                            { state: 'profile-only', label: 'Seulement ' ~ shortName, count: comparison.profileOnly },
                             { state: 'visitor-only', label: 'Seulement toi', count: comparison.visitorOnly },
                             { state: 'missing-both', label: 'Manquantes aux deux', count: comparison.missingBoth },
                         ] %}
 
-                    <div class="mb-8 flex flex-wrap items-center gap-2" data-testid="profile-filters">
+                    <div class="mb-8 flex flex-wrap items-center gap-2" role="group" aria-label="Filtrer la collection" data-testid="profile-filters">
                         {% for filter in filters %}
+                            {# un filtre à 0 n'a rien à montrer : il reste lisible mais inactif #}
                             <button type="button"
                                     class="filter-chip{{ loop.first ? ' is-active' }}"
                                     data-state="{{ filter.state }}"
                                     data-profile-filter-target="button"
                                     data-action="profile-filter#select"
-                                    aria-pressed="{{ loop.first ? 'true' : 'false' }}">
+                                    aria-pressed="{{ loop.first ? 'true' : 'false' }}"
+                                    {{ filter.count == 0 and not loop.first ? 'disabled' }}>
                                 {{ filter.label }} <span class="filter-chip__count">{{ filter.count }}</span>
                             </button>
                         {% endfor %}
                     </div>
 
-                    {% if not isSelf %}
-                        <p class="chip-mono mb-8 border border-hairline bg-surface px-3 py-2 text-ink-muted" data-testid="masking-hint">
-                            Face cachée = tu ne l'as pas encore. <span class="text-primary">◈ Sa collection</span> = {{ profile.username }} l'a, toi non. Éteinte = personne ne l'a. <span class="text-magenta">◆ 1/1</span> = carte unique.
-                        </p>
-                    {% endif %}
+                    <p class="chip-mono mb-8 border border-hairline bg-surface px-3 py-2 text-ink-muted" data-testid="masking-hint">
+                        {% if isSelf %}
+                            Face cachée = carte pas encore trouvée.
+                        {% else %}
+                            Face cachée = tu ne l'as pas encore. <span class="text-primary">◈ Sa collection</span> = {{ profile.username }} l'a, toi non. Éteinte = personne ne l'a.
+                        {% endif %}
+                        <span class="text-magenta">◆ 1/1</span> = carte unique.
+                    </p>
                 {% endif %}
+
+                {# annonce le résultat du filtrage aux lecteurs d'écran #}
+                <p class="sr-only" aria-live="polite" data-profile-filter-target="status"></p>
 
                 {% for universe in comparison.universes %}
                     <div class="mb-12" data-profile-filter-target="universe" data-testid="profile-universe">
-                        <div class="flex flex-wrap items-baseline justify-between gap-2">
+                        <div class="flex flex-wrap items-baseline gap-x-4 gap-y-1">
                             <h2 class="font-display text-sm font-bold uppercase tracking-[.1em] text-ink-strong">
                                 {{ universe.extension.name }}
                             </h2>
-                            <span class="chip-mono text-ink-dim" data-testid="universe-count">
+                            <span class="chip-mono text-ink-muted"
+                                  data-profile-filter-target="count"
+                                  data-total="{{ universe.total }}"
+                                  data-testid="universe-count">
                                 {{ universe.total }} carte{{ universe.total > 1 ? 's' }}
                             </span>
                         </div>
 
-                        <div class="chip-mono mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-ink-dim" data-testid="universe-compare">
-                            <span class="{{ universe.common > 0 ? 'text-ink-muted' }}">◈ {{ universe.common }} {{ isSelf ? 'possédée' ~ (universe.common > 1 ? 's') : 'en commun' }}</span>
+                        {# compteurs du catalogue complet : estompés dès qu'un filtre restreint la grille #}
+                        <div class="chip-mono mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-ink-muted transition-opacity"
+                             data-profile-filter-target="counters"
+                             data-testid="universe-compare">
+                            <span>◈ {{ universe.common }} {{ isSelf ? 'possédée' ~ (universe.common > 1 ? 's') : 'en commun' }}</span>
                             {% if not isSelf %}
                                 <span>▲ {{ universe.profileOnly }} seulement {{ profile.username }}</span>
                                 <span>▼ {{ universe.visitorOnly }} seulement toi</span>
@@ -124,23 +140,27 @@
 
                         <div class="mt-6 grid grid-cols-2 gap-6 md:grid-cols-3 xl:grid-cols-5" data-testid="profile-grid">
                             {% for item in universe.cards %}
-                                {# une tuile révélée sans profileCard = le visiteur l'a, le profil non #}
-                                <div class="card-tile relative{{ item.state.value == 'visitor-only' ? ' opacity-50 grayscale' }}"
+                                <div class="card-tile relative"
                                      data-state="{{ item.state.value }}"
                                      data-profile-filter-target="tile"
                                      data-testid="profile-tile">
-                                    {% if item.state.revealsCard %}
-                                        {{ include('components/CardComponent.html.twig', { card: item.card, holo: item.profileCard and item.profileCard.holoQuantity > 0, lazy: true }) }}
-                                    {% else %}
-                                        {# dos de carte : seule la possession est signalée, jamais la carte #}
-                                        <div class="{{ item.state.value == 'profile-only' ? 'ring-1 ring-primary/60' : 'opacity-45' }}">
+                                    {# le voile des états va sur la carte, jamais sur la tuile :
+                                       il éteindrait les chips, qui portent toute l'information #}
+                                    <div class="{{ item.state.value == 'visitor-only' ? 'opacity-50 grayscale' }}{{ item.state.value == 'profile-only' ? 'ring-1 ring-primary/60' }}{{ item.state.value == 'missing-both' ? 'opacity-60' }}">
+                                        {% if item.state.revealsCard %}
+                                            {{ include('components/CardComponent.html.twig', { card: item.card, holo: item.profileCard and item.profileCard.holoQuantity > 0, lazy: true }) }}
+                                        {% else %}
                                             {{ include('parts/_masked_card.html.twig') }}
-                                        </div>
-                                    {% endif %}
+                                        {% endif %}
+                                    </div>
 
-                                    <div class="card-tile__chips pointer-events-none absolute -right-2 -top-2 z-10 flex flex-wrap justify-end gap-1.5">
+                                    {# libellés en toutes lettres à partir de sm : sur 2 colonnes ils
+                                       recouvriraient le nom de la carte #}
+                                    <div class="card-tile__chips card-tile__chips--sticky pointer-events-none absolute -right-2 -top-2 z-10 flex max-w-full flex-col items-end gap-1.5 sm:flex-row sm:flex-wrap sm:justify-end">
                                         {% if item.card.isUnique %}
-                                            <span class="chip-mono border border-magenta bg-black/90 px-2 py-1 font-bold text-magenta" data-testid="chip-unique">◆ 1/1</span>
+                                            <span class="chip-mono border border-magenta bg-black/90 px-2 py-1 font-bold text-magenta" data-testid="chip-unique">
+                                                ◆<span class="sr-only sm:not-sr-only sm:ml-1">1/1</span>
+                                            </span>
                                         {% endif %}
                                         {% if item.state.value == 'common' %}
                                             <span class="chip-mono bg-black/90 px-2 py-1 font-bold text-white">×{{ item.profileCard.quantity }}</span>
@@ -148,9 +168,13 @@
                                                 <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">✦{{ item.profileCard.holoQuantity }}</span>
                                             {% endif %}
                                         {% elseif item.state.value == 'profile-only' %}
-                                            <span class="chip-mono border border-primary bg-black/90 px-2 py-1 font-bold text-primary" data-testid="chip-owned">◈ Sa collection</span>
+                                            <span class="chip-mono border border-primary bg-black/90 px-2 py-1 font-bold text-primary" data-testid="chip-owned">
+                                                ◈<span class="sr-only sm:not-sr-only sm:ml-1">Sa collection</span>
+                                            </span>
                                         {% elseif item.state.value == 'visitor-only' %}
-                                            <span class="chip-mono border border-hairline bg-black/90 px-2 py-1 font-bold text-ink-muted" data-testid="chip-wanted">Lui manque</span>
+                                            <span class="chip-mono border border-hairline bg-black/90 px-2 py-1 font-bold text-ink-muted" data-testid="chip-wanted">
+                                                ✕<span class="sr-only sm:not-sr-only sm:ml-1">Lui manque</span>
+                                            </span>
                                         {% endif %}
                                     </div>
                                 </div>
@@ -158,6 +182,15 @@
                         </div>
                     </div>
                 {% endfor %}
+
+                {# filtre qui ne ramène rien : sans ça la page tombe dans le vide #}
+                <div class="border border-dashed border-hairline px-8 py-16 text-center text-ink-dim"
+                     data-profile-filter-target="empty"
+                     data-testid="filter-empty"
+                     hidden>
+                    <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Rien dans cet état.</p>
+                    <p class="mt-3 text-sm">Choisis un autre filtre.</p>
+                </div>
             </div>
         </section>
     </main>

--- a/templates/pages/player_profile.html.twig
+++ b/templates/pages/player_profile.html.twig
@@ -97,8 +97,8 @@
 
                     {% if not isSelf %}
                         <p class="chip-mono mb-8 border border-hairline bg-surface px-3 py-2 text-ink-muted" data-testid="masking-hint">
-                            Face cachée = tu ne l'as pas encore.
-                            {%- if comparison.mysteryCount > 0 %} Les {{ comparison.mysteryCount }} carte{{ comparison.mysteryCount > 1 ? 's' }} 1/1 restent hors décompte : leur détenteur ne se devine pas.{% endif %}
+                            Face cachée = tu ne l'as pas encore. <span class="text-primary">◈ Sa collection</span> = {{ profile.username }} l'a, toi non. Éteinte = personne ne l'a.
+                            {%- if comparison.mysteryCount > 0 %} <span class="text-magenta">◆ 1/1</span> : détenteur jamais révélé, donc hors décompte.{% endif %}
                         </p>
                     {% endif %}
                 {% endif %}
@@ -146,7 +146,18 @@
                                             {% endif %}
                                         </div>
                                     {% else %}
-                                        {{ include('parts/_masked_card.html.twig') }}
+                                        {# dos de carte : l'état est signalé par l'habillage, jamais par la carte —
+                                           une 1/1 garde le même badge qu'elle soit détenue ou non #}
+                                        <div class="{{ item.state.value == 'profile-only' ? 'ring-1 ring-primary/60' : (item.state.value == 'mystery' ? 'ring-1 ring-magenta/50' : 'opacity-45') }}">
+                                            {{ include('parts/_masked_card.html.twig') }}
+                                        </div>
+                                        <div class="card-tile__chips pointer-events-none absolute -right-2 -top-2 z-10 flex gap-1.5">
+                                            {% if item.state.value == 'profile-only' %}
+                                                <span class="chip-mono border border-primary bg-black/90 px-2 py-1 font-bold text-primary" data-testid="chip-owned">◈ Sa collection</span>
+                                            {% elseif item.state.value == 'mystery' %}
+                                                <span class="chip-mono border border-magenta bg-black/90 px-2 py-1 font-bold text-magenta" data-testid="chip-mystery">◆ 1/1</span>
+                                            {% endif %}
+                                        </div>
                                     {% endif %}
                                 </div>
                             {% endfor %}

--- a/templates/pages/player_profile.html.twig
+++ b/templates/pages/player_profile.html.twig
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block body %}
+    {% set isSelf = comparison.isSelf %}
     <main>
         {# --------------------------------------------------- Bandeau joueur #}
         <section class="relative border-b border-hairline px-6 py-10 lg:px-12">
@@ -56,36 +57,92 @@
             </div>
         </section>
 
-        {# ------------------------------------------- Collection par univers #}
-        <section class="px-6 pb-24 pt-8 lg:px-12">
+        {# --------------------------------------- Collection comparée par univers #}
+        <section class="px-6 pb-24 pt-8 lg:px-12" data-controller="profile-filter">
             <div class="mx-auto max-w-7xl">
-                {% if not isSelf and hiddenTotal > 0 %}
-                    <p class="chip-mono mb-8 inline-block border border-hairline bg-surface px-3 py-2 text-ink-muted" data-testid="masking-hint">
-                        Les cartes que tu ne possèdes pas encore restent face cachée. À toi de les trouver.
-                    </p>
+                {% if entry.distinctCards == 0 %}
+                    <div class="mb-10 border border-dashed border-hairline px-8 py-16 text-center text-ink-dim" data-testid="empty-state">
+                        <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Collection vide.</p>
+                        <p class="mt-3 text-sm">{{ isSelf ? 'Aucune carte pour le moment. Ouvre un pack, gros youl.' : 'Ce joueur n\'a encore aucune carte.' }}</p>
+                    </div>
                 {% endif %}
 
-                {% for universe in universes %}
-                    {% set universeCount = universe.cards|length %}
-                    <div class="mb-12" data-testid="profile-universe">
+                {% if comparison.total > 0 %}
+                    {% set filters = isSelf
+                        ? [
+                            { state: 'all', label: 'Tout', count: comparison.total },
+                            { state: 'common', label: 'Possédées', count: comparison.common },
+                            { state: 'missing-both', label: 'Manquantes', count: comparison.missingBoth },
+                        ]
+                        : [
+                            { state: 'all', label: 'Tout', count: comparison.total },
+                            { state: 'common', label: 'En commun', count: comparison.common },
+                            { state: 'profile-only', label: 'Seulement ' ~ profile.username, count: comparison.profileOnly },
+                            { state: 'visitor-only', label: 'Seulement toi', count: comparison.visitorOnly },
+                            { state: 'missing-both', label: 'Manquantes aux deux', count: comparison.missingBoth },
+                        ] %}
+
+                    <div class="mb-8 flex flex-wrap items-center gap-2" data-testid="profile-filters">
+                        {% for filter in filters %}
+                            <button type="button"
+                                    class="filter-chip{{ loop.first ? ' is-active' }}"
+                                    data-state="{{ filter.state }}"
+                                    data-profile-filter-target="button"
+                                    data-action="profile-filter#select"
+                                    aria-pressed="{{ loop.first ? 'true' : 'false' }}">
+                                {{ filter.label }} <span class="filter-chip__count">{{ filter.count }}</span>
+                            </button>
+                        {% endfor %}
+                    </div>
+
+                    {% if not isSelf %}
+                        <p class="chip-mono mb-8 border border-hairline bg-surface px-3 py-2 text-ink-muted" data-testid="masking-hint">
+                            Face cachée = tu ne l'as pas encore.
+                            {%- if comparison.mysteryCount > 0 %} Les {{ comparison.mysteryCount }} carte{{ comparison.mysteryCount > 1 ? 's' }} 1/1 restent hors décompte : leur détenteur ne se devine pas.{% endif %}
+                        </p>
+                    {% endif %}
+                {% endif %}
+
+                {% for universe in comparison.universes %}
+                    <div class="mb-12" data-profile-filter-target="universe" data-testid="profile-universe">
                         <div class="flex flex-wrap items-baseline justify-between gap-2">
                             <h2 class="font-display text-sm font-bold uppercase tracking-[.1em] text-ink-strong">
                                 {{ universe.extension.name }}
                             </h2>
                             <span class="chip-mono text-ink-dim" data-testid="universe-count">
-                                {{ universeCount }} carte{{ universeCount > 1 ? 's' }}{% if universe.hiddenCount > 0 %} dont {{ universe.hiddenCount }} que tu n'as pas encore{% endif %}
+                                {{ universe.total }} carte{{ universe.total > 1 ? 's' }}
                             </span>
+                        </div>
+
+                        <div class="chip-mono mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-ink-dim" data-testid="universe-compare">
+                            <span class="{{ universe.common > 0 ? 'text-ink-muted' }}">◈ {{ universe.common }} {{ isSelf ? 'possédée' ~ (universe.common > 1 ? 's') : 'en commun' }}</span>
+                            {% if not isSelf %}
+                                <span>▲ {{ universe.profileOnly }} seulement {{ profile.username }}</span>
+                                <span>▼ {{ universe.visitorOnly }} seulement toi</span>
+                            {% endif %}
+                            <span>✕ {{ universe.missingBoth }} manquante{{ universe.missingBoth > 1 ? 's' }}{{ isSelf ? '' : ' aux deux' }}</span>
+                            {% if universe.mysteryCount > 0 %}
+                                <span class="text-magenta">◆ {{ universe.mysteryCount }} × 1/1 hors décompte</span>
+                            {% endif %}
                         </div>
 
                         <div class="mt-6 grid grid-cols-2 gap-6 md:grid-cols-3 xl:grid-cols-5" data-testid="profile-grid">
                             {% for item in universe.cards %}
-                                <div class="card-tile relative">
-                                    {% if item.visible %}
-                                        {{ include('components/CardComponent.html.twig', { card: item.userCard.card, holo: item.userCard.holoQuantity > 0, lazy: true }) }}
+                                {# une tuile révélée sans profileCard = le visiteur l'a, le profil non #}
+                                <div class="card-tile relative{{ item.state.value == 'visitor-only' ? ' opacity-50 grayscale' }}"
+                                     data-state="{{ item.state.value }}"
+                                     data-profile-filter-target="tile"
+                                     data-testid="profile-tile">
+                                    {% if item.state.revealsCard %}
+                                        {{ include('components/CardComponent.html.twig', { card: item.card, holo: item.profileCard and item.profileCard.holoQuantity > 0, lazy: true }) }}
                                         <div class="card-tile__chips pointer-events-none absolute -right-2 -top-2 z-10 flex gap-1.5">
-                                            <span class="chip-mono bg-black/90 px-2 py-1 font-bold text-white">×{{ item.userCard.quantity }}</span>
-                                            {% if item.userCard.holoQuantity > 0 %}
-                                                <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">✦{{ item.userCard.holoQuantity }}</span>
+                                            {% if item.profileCard %}
+                                                <span class="chip-mono bg-black/90 px-2 py-1 font-bold text-white">×{{ item.profileCard.quantity }}</span>
+                                                {% if item.profileCard.holoQuantity > 0 %}
+                                                    <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">✦{{ item.profileCard.holoQuantity }}</span>
+                                                {% endif %}
+                                            {% else %}
+                                                <span class="chip-mono border border-hairline bg-black/90 px-2 py-1 font-bold text-ink-muted">Manque</span>
                                             {% endif %}
                                         </div>
                                     {% else %}
@@ -94,11 +151,6 @@
                                 </div>
                             {% endfor %}
                         </div>
-                    </div>
-                {% else %}
-                    <div class="border border-dashed border-hairline px-8 py-20 text-center text-ink-dim" data-testid="empty-state">
-                        <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Collection vide.</p>
-                        <p class="mt-3 text-sm">{{ isSelf ? 'Aucune carte pour le moment. Ouvre un pack, gros youl.' : 'Ce joueur n\'a encore aucune carte.' }}</p>
                     </div>
                 {% endfor %}
             </div>

--- a/tests/Functional/LeaderboardControllerTest.php
+++ b/tests/Functional/LeaderboardControllerTest.php
@@ -48,14 +48,15 @@ final class LeaderboardControllerTest extends WebTestCase
     public function testRanksCollectorsByCompletionWithTheirMetrics(): void
     {
         $rival = $this->createPlayer('Rival');
-        $cards = [$this->createCard(), $this->createCard(), $this->createCard()];
+        $cards = array_map(fn (): Card => $this->createCard(), range(1, 6));
 
-        // rival: 3 distinct cards (4 copies, 1 holo) + 1 opened pack; me: 1 distinct
-        // card. The gap stays wide enough that the demo fixture collections
-        // cannot flip the order.
+        // rival: 6 distinct cards (7 copies, 1 holo) + 1 opened pack; me: 1 distinct
+        // card. The rival is given more cards than the whole demo catalogue holds,
+        // so no fixture collection can flip the order.
         $this->giveCard($rival, $cards[0], quantity: 2, holoQuantity: 1);
-        $this->giveCard($rival, $cards[1]);
-        $this->giveCard($rival, $cards[2]);
+        foreach (\array_slice($cards, 1) as $card) {
+            $this->giveCard($rival, $card);
+        }
         $this->giveCard($this->user, $cards[0]);
 
         $booster = new Booster()
@@ -75,7 +76,7 @@ final class LeaderboardControllerTest extends WebTestCase
         $this->assertLessThan($this->positionOf($rows, $this->user->getUsername()), $rivalPosition);
 
         $rivalRow = $rows->eq($rivalPosition);
-        $this->assertStringContainsString('3 distinctes', $rivalRow->text());
+        $this->assertStringContainsString('6 distinctes', $rivalRow->text());
         $this->assertStringContainsString('✦1', $rivalRow->text());
         // ▣N is the mobile summary of the opened packs count
         $this->assertStringContainsString('▣1', $rivalRow->text());

--- a/tests/Functional/PlayerProfileTest.php
+++ b/tests/Functional/PlayerProfileTest.php
@@ -174,6 +174,29 @@ final class PlayerProfileTest extends WebTestCase
         $this->assertSame(['all', 'common', 'profile-only', 'visitor-only', 'missing-both'], $states);
     }
 
+    public function testAFilterWithNothingToShowIsDisabledAndHasAFallback(): void
+    {
+        // a player owning nothing shares no card with the visitor
+        $empty = new DiscordUser()
+            ->setDiscordId((string) random_int(300000000000000000, 999999999999999999))
+            ->setUsername('Empty ' . uniqid())
+        ;
+        $this->entityManager->persist($empty);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/joueur/' . $empty->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $common = $crawler->filter('[data-testid="profile-filters"] button[data-state="common"]');
+        $this->assertCount(1, $common);
+        $this->assertNotNull($common->attr('disabled'), 'A filter counting zero card must not be clickable.');
+
+        // the client-side fallback exists (hidden until a filter empties the grid)
+        $fallback = $crawler->filter('[data-testid="filter-empty"]');
+        $this->assertCount(1, $fallback);
+        $this->assertNotNull($fallback->attr('hidden'));
+    }
+
     public function testOwnProfileShowsEverythingOwnedInClear(): void
     {
         // the rival visits their own profile: their cards are all in clear, the
@@ -189,7 +212,11 @@ final class PlayerProfileTest extends WebTestCase
         $block = $this->universeBlock($crawler);
         $this->assertCount(2, $block->filter('[data-testid="masked-card"]'));
         $this->assertCount(2, $block->filter('[data-testid="profile-tile"][data-state="missing-both"]'));
-        $this->assertCount(0, $crawler->filter('[data-testid="masking-hint"]'));
+        // the legend still explains the card backs, without the comparison wording
+        $hint = $crawler->filter('[data-testid="masking-hint"]');
+        $this->assertCount(1, $hint);
+        $this->assertStringContainsString('pas encore trouvée', $hint->text());
+        $this->assertStringNotContainsString('Sa collection', $hint->text());
 
         $counters = $block->filter('[data-testid="universe-compare"]')->text();
         $this->assertStringContainsString('3 possédées', $counters);

--- a/tests/Functional/PlayerProfileTest.php
+++ b/tests/Functional/PlayerProfileTest.php
@@ -126,6 +126,31 @@ final class PlayerProfileTest extends WebTestCase
         }
     }
 
+    public function testMaskedTilesTellOwnershipApartWithoutNamingTheCard(): void
+    {
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $block = $this->universeBlock($crawler);
+
+        // "they own it" is not a new disclosure: before the comparison grid, the
+        // profile listed their cards only, so every card back already meant that
+        $owned = $block->filter('[data-testid="profile-tile"][data-state="profile-only"]');
+        $this->assertCount(1, $owned->filter('[data-testid="chip-owned"]'));
+        $this->assertCount(1, $owned->filter('[data-testid="masked-card"]'));
+        $this->assertStringNotContainsString($this->secretCard->getName(), (string) $owned->html());
+
+        // the 1/1 wears the same badge whether it is held or not: no holder leak
+        $mystery = $block->filter('[data-testid="profile-tile"][data-state="mystery"]');
+        $this->assertCount(1, $mystery->filter('[data-testid="chip-mystery"]'));
+        $this->assertCount(0, $mystery->filter('[data-testid="chip-owned"]'));
+
+        // nobody owns it: no ownership chip at all
+        $orphan = $block->filter('[data-testid="profile-tile"][data-state="missing-both"]');
+        $this->assertCount(0, $orphan->filter('[data-testid="chip-owned"]'));
+        $this->assertCount(0, $orphan->filter('[data-testid="chip-mystery"]'));
+    }
+
     public function testUniverseCountersCompareBothCollections(): void
     {
         $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());

--- a/tests/Functional/PlayerProfileTest.php
+++ b/tests/Functional/PlayerProfileTest.php
@@ -14,11 +14,13 @@ use App\Enum\Entity\ExtensionStatusEnum;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DomCrawler\Crawler;
 
 /**
- * The player profile masking rule: a card of the profile is only shown in
- * clear when the visitor ALSO owns it — otherwise card back, and the name must
- * not leak anywhere in the DOM (no text, no alt, no title, no aria).
+ * The compared profile grid: the whole published catalogue, crossed with the
+ * visitor's collection. A card of the profile is only revealed when the visitor
+ * owns it too; a card the profile does NOT own may be revealed (nothing to
+ * hide); a 1/1 the visitor doesn't hold stays a mystery, out of the counters.
  */
 final class PlayerProfileTest extends WebTestCase
 {
@@ -37,6 +39,10 @@ final class PlayerProfileTest extends WebTestCase
     private Card $sharedCard;
 
     private Card $secretCard;
+
+    private Card $visitorCard;
+
+    private Card $missingCard;
 
     private Card $uniqueCard;
 
@@ -73,7 +79,8 @@ final class PlayerProfileTest extends WebTestCase
         self::assertResponseIsSuccessful();
         $this->assertCount(1, $crawler->filter(\sprintf('img[alt="%s"]', $this->sharedCard->getName())));
         // the profile's own quantities are public: ×2 and one holo chip
-        $this->assertStringContainsString('×2', $crawler->filter('[data-testid="profile-grid"]')->text());
+        $this->assertStringContainsString('×2', $this->universeBlock($crawler)->filter('[data-testid="profile-grid"]')->text());
+        $this->assertStringContainsString('✦1', $this->universeBlock($crawler)->filter('[data-testid="profile-grid"]')->text());
     }
 
     public function testUnsharedCardsAreMaskedWithoutLeakingTheirNames(): void
@@ -81,37 +88,94 @@ final class PlayerProfileTest extends WebTestCase
         $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
 
         self::assertResponseIsSuccessful();
-        // secret + unique: two card backs
-        $this->assertCount(2, $crawler->filter('[data-testid="masked-card"]'));
+        // secret (their card) + unique (mystery) + missing (nobody's): three card backs
+        $this->assertCount(3, $this->universeBlock($crawler)->filter('[data-testid="masked-card"]'));
 
         // no leak at all in the HTML — covers text, alt, title and aria attributes
         $html = (string) $this->client->getResponse()->getContent();
         $this->assertStringNotContainsString($this->secretCard->getName(), $html);
         $this->assertStringNotContainsString($this->uniqueCard->getName(), $html);
+        $this->assertStringNotContainsString($this->missingCard->getName(), $html);
     }
 
-    public function testCardCountsStayVisibleOnMaskedUniverses(): void
+    public function testCardMissingFromTheProfileIsShownWhenTheVisitorOwnsIt(): void
     {
         $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
 
         self::assertResponseIsSuccessful();
-        $this->assertStringContainsString(
-            "3 cartes dont 2 que tu n'as pas encore",
-            $crawler->filter('[data-testid="universe-count"]')->text(),
-        );
+        // nothing of the profile to hide here: the visitor already knows the card
+        $this->assertCount(1, $crawler->filter(\sprintf('img[alt="%s"]', $this->visitorCard->getName())));
+
+        $tile = $this->universeBlock($crawler)->filter('[data-testid="profile-tile"][data-state="visitor-only"]');
+        $this->assertCount(1, $tile);
+        $this->assertStringContainsString('Manque', $tile->text());
     }
 
-    public function testOwnProfileShowsEverythingInClear(): void
+    public function testEveryComparisonStateIsExposedOnTheTiles(): void
     {
-        // the rival visits their own profile: nothing is masked, the 1/1 included
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $block = $this->universeBlock($crawler);
+        foreach (['common', 'profile-only', 'visitor-only', 'missing-both', 'mystery'] as $state) {
+            $this->assertCount(
+                1,
+                $block->filter(\sprintf('[data-testid="profile-tile"][data-state="%s"]', $state)),
+                \sprintf('Exactly one tile is expected in state "%s".', $state),
+            );
+        }
+    }
+
+    public function testUniverseCountersCompareBothCollections(): void
+    {
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $block = $this->universeBlock($crawler);
+        $this->assertStringContainsString('5 cartes', $block->filter('[data-testid="universe-count"]')->text());
+
+        $counters = $block->filter('[data-testid="universe-compare"]')->text();
+        $this->assertStringContainsString('1 en commun', $counters);
+        $this->assertStringContainsString('1 seulement ' . $this->rival->getUsername(), $counters);
+        $this->assertStringContainsString('1 seulement toi', $counters);
+        $this->assertStringContainsString('1 manquante aux deux', $counters);
+        // the 1/1 is counted apart, so a single unique can't be solved by subtraction
+        $this->assertStringContainsString('1 × 1/1 hors décompte', $counters);
+    }
+
+    public function testFilterBarOffersEveryBucket(): void
+    {
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $states = $crawler->filter('[data-testid="profile-filters"] button')->each(
+            static fn (Crawler $node): string => (string) $node->attr('data-state'),
+        );
+
+        $this->assertSame(['all', 'common', 'profile-only', 'visitor-only', 'missing-both'], $states);
+    }
+
+    public function testOwnProfileShowsEverythingOwnedInClear(): void
+    {
+        // the rival visits their own profile: their cards are all in clear, the
+        // 1/1 included, and only what they miss stays face down
         $this->authenticateClient($this->client, $this->rival->getDiscordId());
         $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
 
         self::assertResponseIsSuccessful();
-        $this->assertCount(0, $crawler->filter('[data-testid="masked-card"]'));
         $this->assertCount(1, $crawler->filter(\sprintf('img[alt="%s"]', $this->secretCard->getName())));
         $this->assertCount(1, $crawler->filter(\sprintf('img[alt="%s"]', $this->uniqueCard->getName())));
-        $this->assertStringNotContainsString("que tu n'as pas encore", $crawler->filter('main')->text());
+
+        // the two cards they don't own (the visitor's one and the orphan one)
+        $block = $this->universeBlock($crawler);
+        $this->assertCount(2, $block->filter('[data-testid="masked-card"]'));
+        $this->assertCount(2, $block->filter('[data-testid="profile-tile"][data-state="missing-both"]'));
+        $this->assertCount(0, $crawler->filter('[data-testid="masking-hint"]'));
+
+        $counters = $block->filter('[data-testid="universe-compare"]')->text();
+        $this->assertStringContainsString('3 possédées', $counters);
+        $this->assertStringContainsString('2 manquantes', $counters);
+        $this->assertStringNotContainsString('seulement', $counters);
     }
 
     public function testAnotherPlayersUniqueIsAlwaysMaskedForVisitors(): void
@@ -126,7 +190,7 @@ final class PlayerProfileTest extends WebTestCase
         );
     }
 
-    public function testEmptyProfileShowsAnEmptyState(): void
+    public function testEmptyProfileStillShowsTheCatalogueBehindAnEmptyState(): void
     {
         $empty = new DiscordUser()
             ->setDiscordId((string) random_int(300000000000000000, 999999999999999999))
@@ -139,6 +203,42 @@ final class PlayerProfileTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         $this->assertCount(1, $crawler->filter('[data-testid="empty-state"]'));
+        // the comparison still stands: the two cards the visitor owns are shown
+        $this->assertCount(2, $this->universeBlock($crawler)->filter('[data-testid="profile-tile"][data-state="visitor-only"]'));
+    }
+
+    public function testUnpublishedContentNeverReachesTheGrid(): void
+    {
+        $draftCard = $this->createCard('Brouillon ' . uniqid());
+        $draftCard->setStatus(CardStatusEnum::DRAFT);
+
+        $draftExtension = new Extension()
+            ->setName('Univers brouillon ' . uniqid())
+            ->setDescription('Univers non publié')
+            ->setStatus(ExtensionStatusEnum::DRAFT)
+        ;
+        $this->entityManager->persist($draftExtension);
+
+        $hiddenCard = new Card()
+            ->setName('Carte cachée ' . uniqid())
+            ->setDescription('Test card')
+            ->setStatus(CardStatusEnum::PUBLISHED)
+            ->setRarity(CardRarityEnum::COMMON)
+            ->setExtension($draftExtension)
+        ;
+        $hiddenCard->setImageName('default_card.png');
+        $this->entityManager->persist($hiddenCard);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        // the draft card is not part of the published set of its (published) universe
+        $this->assertStringContainsString('5 cartes', $this->universeBlock($crawler)->filter('[data-testid="universe-count"]')->text());
+
+        $html = (string) $this->client->getResponse()->getContent();
+        $this->assertStringNotContainsString($draftCard->getName(), $html);
+        $this->assertStringNotContainsString($draftExtension->getName(), $html);
     }
 
     public function testUnknownPlayerIsNotFound(): void
@@ -156,8 +256,24 @@ final class PlayerProfileTest extends WebTestCase
     }
 
     /**
-     * A rival with 3 cards: one the visitor also owns (shared), one the
-     * visitor doesn't (secret), and a claimed 1/1 (unique).
+     * The universe block of the scenario: the test database also holds the dev
+     * catalogue, so every grid assertion is scoped to it.
+     */
+    private function universeBlock(Crawler $crawler): Crawler
+    {
+        $block = $crawler->filter('[data-testid="profile-universe"]')->reduce(
+            fn (Crawler $node): bool => str_contains($node->filter('h2')->text(), $this->extension->getName()),
+        );
+
+        $this->assertCount(1, $block, 'The scenario universe must appear exactly once in the grid.');
+
+        return $block;
+    }
+
+    /**
+     * A published universe of 5 cards covering every comparison state: shared
+     * (both), secret (rival only), visitor (visitor only), missing (nobody) and
+     * a 1/1 claimed by the rival.
      */
     private function createScenario(): void
     {
@@ -176,6 +292,8 @@ final class PlayerProfileTest extends WebTestCase
 
         $this->sharedCard = $this->createCard('Carte Partagée ' . uniqid());
         $this->secretCard = $this->createCard('Carte Secrète ' . uniqid());
+        $this->visitorCard = $this->createCard('Carte Visiteur ' . uniqid());
+        $this->missingCard = $this->createCard('Carte Orpheline ' . uniqid());
         $this->uniqueCard = $this->createCard('Unique Mystère ' . uniqid(), CardRarityEnum::LEGENDARY);
         $this->uniqueCard->setUnique(true);
         $this->uniqueCard->setClaimedBy($this->rival);
@@ -184,6 +302,7 @@ final class PlayerProfileTest extends WebTestCase
         $this->giveCard($this->rival, $this->secretCard);
         $this->giveCard($this->rival, $this->uniqueCard);
         $this->giveCard($this->user, $this->sharedCard);
+        $this->giveCard($this->user, $this->visitorCard);
 
         $this->entityManager->flush();
     }

--- a/tests/Functional/PlayerProfileTest.php
+++ b/tests/Functional/PlayerProfileTest.php
@@ -108,7 +108,7 @@ final class PlayerProfileTest extends WebTestCase
 
         $tile = $this->universeBlock($crawler)->filter('[data-testid="profile-tile"][data-state="visitor-only"]');
         $this->assertCount(1, $tile);
-        $this->assertStringContainsString('Manque', $tile->text());
+        $this->assertStringContainsString('Lui manque', $tile->text());
     }
 
     public function testEveryComparisonStateIsExposedOnTheTiles(): void
@@ -117,11 +117,12 @@ final class PlayerProfileTest extends WebTestCase
 
         self::assertResponseIsSuccessful();
         $block = $this->universeBlock($crawler);
-        foreach (['common', 'profile-only', 'visitor-only', 'missing-both', 'mystery'] as $state) {
+        // the 1/1 is compared like any other card, hence two "profile only" tiles
+        foreach (['common' => 1, 'profile-only' => 2, 'visitor-only' => 1, 'missing-both' => 1] as $state => $expected) {
             $this->assertCount(
-                1,
+                $expected,
                 $block->filter(\sprintf('[data-testid="profile-tile"][data-state="%s"]', $state)),
-                \sprintf('Exactly one tile is expected in state "%s".', $state),
+                \sprintf('%d tile(s) expected in state "%s".', $expected, $state),
             );
         }
     }
@@ -136,19 +137,14 @@ final class PlayerProfileTest extends WebTestCase
         // "they own it" is not a new disclosure: before the comparison grid, the
         // profile listed their cards only, so every card back already meant that
         $owned = $block->filter('[data-testid="profile-tile"][data-state="profile-only"]');
-        $this->assertCount(1, $owned->filter('[data-testid="chip-owned"]'));
-        $this->assertCount(1, $owned->filter('[data-testid="masked-card"]'));
+        $this->assertCount(2, $owned->filter('[data-testid="chip-owned"]'));
+        $this->assertCount(2, $owned->filter('[data-testid="masked-card"]'));
         $this->assertStringNotContainsString($this->secretCard->getName(), (string) $owned->html());
-
-        // the 1/1 wears the same badge whether it is held or not: no holder leak
-        $mystery = $block->filter('[data-testid="profile-tile"][data-state="mystery"]');
-        $this->assertCount(1, $mystery->filter('[data-testid="chip-mystery"]'));
-        $this->assertCount(0, $mystery->filter('[data-testid="chip-owned"]'));
 
         // nobody owns it: no ownership chip at all
         $orphan = $block->filter('[data-testid="profile-tile"][data-state="missing-both"]');
         $this->assertCount(0, $orphan->filter('[data-testid="chip-owned"]'));
-        $this->assertCount(0, $orphan->filter('[data-testid="chip-mystery"]'));
+        $this->assertCount(0, $orphan->filter('[data-testid="chip-wanted"]'));
     }
 
     public function testUniverseCountersCompareBothCollections(): void
@@ -161,11 +157,9 @@ final class PlayerProfileTest extends WebTestCase
 
         $counters = $block->filter('[data-testid="universe-compare"]')->text();
         $this->assertStringContainsString('1 en commun', $counters);
-        $this->assertStringContainsString('1 seulement ' . $this->rival->getUsername(), $counters);
+        $this->assertStringContainsString('2 seulement ' . $this->rival->getUsername(), $counters);
         $this->assertStringContainsString('1 seulement toi', $counters);
         $this->assertStringContainsString('1 manquante aux deux', $counters);
-        // the 1/1 is counted apart, so a single unique can't be solved by subtraction
-        $this->assertStringContainsString('1 × 1/1 hors décompte', $counters);
     }
 
     public function testFilterBarOffersEveryBucket(): void
@@ -203,12 +197,20 @@ final class PlayerProfileTest extends WebTestCase
         $this->assertStringNotContainsString('seulement', $counters);
     }
 
-    public function testAnotherPlayersUniqueIsAlwaysMaskedForVisitors(): void
+    public function testAnotherPlayersUniqueShowsAsOwnedButIsNeverNamed(): void
     {
-        // nobody but the claimer can own a 1/1, so it can never be shown to a visitor
-        $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+        // the trades need to know WHO holds a 1/1; the card itself stays masked
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
 
         self::assertResponseIsSuccessful();
+        $unique = $this->universeBlock($crawler)->filter('[data-testid="profile-tile"]')->reduce(
+            static fn (Crawler $node): bool => 1 === $node->filter('[data-testid="chip-unique"]')->count(),
+        );
+
+        $this->assertCount(1, $unique);
+        $this->assertSame('profile-only', $unique->attr('data-state'));
+        $this->assertCount(1, $unique->filter('[data-testid="chip-owned"]'));
+        $this->assertCount(1, $unique->filter('[data-testid="masked-card"]'));
         $this->assertStringNotContainsString(
             $this->uniqueCard->getName(),
             (string) $this->client->getResponse()->getContent(),


### PR DESCRIPTION
## Ce que ça change

Le profil d'un joueur (`/joueur/{discordId}`) n'affiche plus seulement sa collection : il croise **tout le catalogue publié** avec celle du visiteur, pour montrer aussi ce qui manque — et surtout ce qui manque aux deux.

Quatre états par tuile :

| état | rendu |
|---|---|
| `common` | carte en clair + chips ×N / ✦N du profil |
| `profile-only` | dos de carte, liseré violet, chip « ◈ Sa collection » |
| `visitor-only` | carte en clair désaturée + chip « Lui manque » |
| `missing-both` | dos de carte éteint, aucun chip — la chasse commune |

Les cartes 1/1 portent en plus un chip « ◆ 1/1 ». Compteurs par univers (`◈ en commun / ▲ seulement lui / ▼ seulement toi / ✕ manquantes aux deux`) et barre de filtres cliquable (contrôleur Stimulus, pur client, aucune requête supplémentaire). Sur son propre profil, les libellés basculent en « Possédées / Manquantes ».

## Divulgation

Toutes les règles vivent dans `ProfileComparisonService` :

- une carte du profil n'est révélée que si le visiteur la possède aussi (règle historique, inchangée) ;
- une carte que le profil ne possède PAS n'a rien à cacher : elle peut être révélée dès que le visiteur l'a ;
- les 1/1 suivent les mêmes états que le reste. La page sert de base aux futurs échanges : savoir **qui** détient une unique est le premier besoin, et seuls l'artwork et le nom restent masqués.

Distinguer « il l'a » de « personne ne l'a » sur les dos de carte ne divulgue rien de neuf : avant cette PR, la page ne listait QUE ses cartes, donc chaque tuile signifiait déjà « il l'a ».

Les libellés n'emploient aucun pronom genré (« seulement <pseudo> », « seulement toi »).

## Perf

3 requêtes quels que soient la taille du catalogue et le nombre de cartes possédées (catalogue groupé par extension, collection du profil, ids du visiteur) — jamais une requête par carte ou par joueur.

## À noter

Une carte possédée dont la carte ou l'univers est repassé en brouillon n'apparaît plus sur le profil : le catalogue publié fait référence, comme pour `/univers` et le dénominateur du classement.

## Tests

- `tests/Functional/PlayerProfileTest.php` : un cas par état, non-leak des noms masqués (texte, alt, title, aria), 1/1 possédée mais jamais nommée, compteurs, barre de filtres, profil perso, contenu non publié, profil vide.
- Suite complète : 410 tests verts **après rechargement réel des fixtures** (comme en CI) — c'est ce qui a révélé que publier Ichigo pour la démo cassait le contrat « univers sans carte publiée » de `BoosterHubComponentTest`, corrigé ici.
- `make quality` vert, Tailwind rebuild inclus, passage Playwright sur un profil comparé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
