### PR TITLE
fix(collection): rendre le toggle HOLO cliquable pendant l'inspection

### DIFF
--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -71,6 +71,20 @@
     opacity: 0;
 }
 
+/* Toggle HOLO : une commande, pas une décoration. Pendant l'inspection, la
+ * carte monte à z-index 120 (base.css) et son .card__rotator capte le clic —
+ * le bouton passe donc au-dessus, garde son opacité, et son ::after élargit la
+ * cible de 8px sans changer son apparence (elle ne fait que 25px de haut). */
+.card-tile__toggle {
+    z-index: 200;
+}
+
+.card-tile__toggle::after {
+    content: '';
+    position: absolute;
+    inset: -8px;
+}
+
 /* Panneau « Taux » des cartes booster du hub (details/summary natif) */
 .booster-rates > summary { list-style: none; }
 .booster-rates > summary::-webkit-details-marker { display: none; }

--- a/templates/pages/collection.html.twig
+++ b/templates/pages/collection.html.twig
@@ -153,9 +153,11 @@
                                     {% endif %}
                                 </div>
                                 {% if ownsHolo and ownsNormal %}
-                                    {# toggle OUTSIDE the .card element: a click on the card itself triggers the 3D zoom #}
+                                    {# toggle OUTSIDE the .card element: a click on the card itself triggers the 3D zoom.
+                                       card-tile__toggle (et pas card-tile__chips) : c'est une commande, elle ne
+                                       s'efface pas et reste au-dessus de la carte inclinée #}
                                     <button type="button"
-                                            class="card-tile__chips chip-mono absolute -left-2 -top-2 z-10 border border-hairline bg-black/90 px-2 py-1 font-bold text-ink-dim transition-colors hover:text-ink-strong aria-pressed:border-transparent aria-pressed:bg-gradient-to-r aria-pressed:from-primary aria-pressed:to-magenta aria-pressed:text-black"
+                                            class="card-tile__toggle chip-mono absolute -left-2 -top-2 border border-hairline bg-black/90 px-2 py-1 font-bold text-ink-dim transition-colors hover:text-ink-strong aria-pressed:border-transparent aria-pressed:bg-gradient-to-r aria-pressed:from-primary aria-pressed:to-magenta aria-pressed:text-black"
                                             aria-pressed="true"
                                             data-action="holo-toggle#toggle"
                                             data-holo-toggle-target="button"


### PR DESCRIPTION
## Le symptôme

Le badge ✦ HOLO d'une carte possédée en double (normale + holo) est difficile à cliquer dès qu'on fait bouger la carte. En pratique il est **injoignable** : il faut sortir la souris de la carte, attendre que le tilt retombe, puis revenir sur le badge par l'extérieur.

## Le diagnostic

Mesuré au navigateur pendant le tilt, `document.elementFromPoint()` au centre du bouton renvoyait `.card__rotator` — le clic n'atteignait jamais le bouton. Trois causes cumulées :

| cause | avant | après |
|---|---|---|
| il porte `card-tile__chips`, dont la règle de survol l'efface | `opacity: 0` | `opacity: 1` |
| la carte inclinée passe devant et capte le clic (`.card__rotator` est en `pointer-events: auto`) | carte `z-index: 120` vs bouton `10` | bouton `z-index: 200` |
| cible minuscule | 25 px de haut | +8 px tout autour via `::after`, aspect inchangé |

La règle qui l'effaçait vient de `/collection`, où les chips `×N` / `✦N` sont décoratifs et doivent s'écarter pendant l'inspection. Le toggle, lui, est une commande : il a désormais sa propre classe `card-tile__toggle` et ne suit plus ce sort.

## Vérification

Script `holo-hit.mjs` (Playwright) : survol de la carte, puis clic sur le toggle **sans quitter la carte**.

```
avant : elementAuPoint: "card__rotator", estLeBouton: false, opacity: 0
après : elementAuPoint: "holo-toggle",   estLeBouton: true,  opacity: 1
        clic pendant le tilt : holo true -> false (ok)
```

405 tests verts (dont `CollectionControllerTest`), `make quality` vert, Tailwind rebuild inclus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)