### PR TITLE
feat(ouverture): vrai rendu de carte dans le ruban et l'encart

### DIFF
--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -387,9 +387,10 @@ export default class extends Controller {
                 tile.style.setProperty('--tile-rar', `var(--rarity-${tile.dataset.rarity})`);
             }
             tile.querySelector('.opening__card-back')?.remove();
-            const img = tile.querySelector('img');
-            if (img) {
-                img.hidden = false;
+            // the rendered card, not an <img>: the component carries both faces
+            const render = tile.querySelector('.opening__card-render');
+            if (render) {
+                render.hidden = false;
             }
             const name = tile.querySelector('.opening__card-name');
             if (name && name.dataset.revealName) {

--- a/assets/controllers/booster_opening_controller.js
+++ b/assets/controllers/booster_opening_controller.js
@@ -50,6 +50,7 @@ export default class extends Controller {
 
     static values = {
         count: Number,
+        openingId: String,
     };
 
     connect() {
@@ -62,26 +63,60 @@ export default class extends Controller {
     }
 
     // The `.opening` root is stable across the live re-render of `open()`, so
-    // Stimulus does NOT re-run connect() — it fires this value-changed callback
-    // when the draw lands (count 0 → N) or is cleared on reset (N → 0). Note it
-    // can run before connect(), hence the explicit init guard.
+    // Stimulus does NOT re-run connect() — it fires these value-changed
+    // callbacks instead. Note they can run before connect(), hence the explicit
+    // init guard.
     countValueChanged(current, previous) {
         this._ensureInit();
 
         if (current > 0) {
-            // a fresh opening — reset the reveal state and let the pack be peeled
-            this._resetReveal();
-            this.lastIndex = current - 1;
-            window.dispatchEvent(new CustomEvent('pack3d:arm'));
-
-            if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-                this._after(0, () => this._revealAllAtOnce());
-            }
+            this._armDraw();
         } else if (previous > 0) {
-            // "open another": re-seal the (data-live-ignore) pack for the next draw
-            window.dispatchEvent(new CustomEvent('pack3d:reset'));
-            this._resetReveal();
+            this._sealPack();
         }
+    }
+
+    // Opening one pack right after another keeps the same card count, so the
+    // count alone can't tell a new draw from the previous one: the opening id
+    // is what changes. Without it, "open another" had to go through the sealed
+    // state first — one extra click per pack.
+    openingIdValueChanged(current, previous) {
+        this._ensureInit();
+
+        if (current) {
+            // a pack left torn by the previous draw has to be re-sealed first
+            this._armDraw(Boolean(previous));
+        } else if (previous) {
+            this._sealPack();
+        }
+    }
+
+    // Arms the (data-live-ignore) 3D pack for the draw on the table. Guarded by
+    // the opening id: count and id both land on the same re-render, whichever
+    // callback runs first wins and the other is a no-op.
+    _armDraw(reseal = false) {
+        if (this._armedOpeningId && this._armedOpeningId === this.openingIdValue) {
+            return;
+        }
+        this._armedOpeningId = this.openingIdValue;
+
+        if (reseal) {
+            window.dispatchEvent(new CustomEvent('pack3d:reset'));
+        }
+
+        this._resetReveal();
+        this.lastIndex = this.countValue - 1;
+        window.dispatchEvent(new CustomEvent('pack3d:arm'));
+
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+            this._after(0, () => this._revealAllAtOnce());
+        }
+    }
+
+    _sealPack() {
+        this._armedOpeningId = null;
+        window.dispatchEvent(new CustomEvent('pack3d:reset'));
+        this._resetReveal();
     }
 
     _ensureInit() {

--- a/assets/styles/cards/base.css
+++ b/assets/styles/cards/base.css
@@ -93,6 +93,18 @@
   
   }
   
+  /* Rendu figé (CardComponent avec interactive: false) : le cadre, le nom et le
+     filigrane, sans le survol scripté ci-dessus — les vignettes de l'ouverture
+     ne doivent ni bouger ni grossir pendant l'animation de révélation. */
+  .card.card--static:hover {
+    --card-scale: 1 !important;
+    --translate-x: 0px !important;
+    --translate-y: 0px !important;
+    --rotate-x: 0deg !important;
+    --rotate-y: 0deg !important;
+    --card-opacity: 0 !important;
+  }
+
   .card,
   .card__rotator {
     aspect-ratio: var(--card-aspect);

--- a/assets/styles/cards/frame.css
+++ b/assets/styles/cards/frame.css
@@ -247,48 +247,14 @@
 }
 
 /* =======================================================================
-   Mini frames — thumbnail tiles of the opening view (reveal tracker + set
-   contents list). Same mat + neon line at thumbnail scale, no chrome (the
-   tile prints the name below the artwork). Gated on the revealed/unmasked
-   states so the card-back mystery tiles stay frameless.
+   Vignettes de l'ouverture (ruban de révélation + encart « contenu du set ») :
+   elles rendent désormais le CardComponent figé, donc le vrai cadre — nom,
+   univers et filigrane compris. Le mini-cadre en pseudo-éléments qui vivait
+   ici faisait double emploi et a été retiré ; il ne reste que le contexte de
+   conteneur, sur lequel le cadre se dimensionne (cqi).
    ======================================================================= */
 
 .opening__track-img,
 .opening__card-art {
     container-type: inline-size;
-}
-
-.opening__track-tile.is-revealed .opening__track-img::before,
-.opening__card-tile:not(.is-masked) .opening__card-art::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    z-index: 1;
-    border-radius: inherit;
-    box-shadow:
-        inset 0 0 0 2.6cqi rgb(8 5 15 / 0.95),
-        inset 0 -9cqi 7cqi -6cqi rgb(8 5 15 / 0.85);
-}
-
-.opening__track-tile.is-revealed .opening__track-img::after,
-.opening__card-tile:not(.is-masked) .opening__card-art::after {
-    content: '';
-    position: absolute;
-    inset: 2cqi;
-    z-index: 1;
-    border-radius: 6px;
-    padding: 0.5cqi;
-    background: linear-gradient(
-        200deg,
-        var(--frame-line-1, rgb(70 230 230 / 0.85)),
-        var(--frame-line-2, rgb(255 62 165 / 0.9))
-    );
-    -webkit-mask:
-        linear-gradient(#000 0 0) content-box,
-        linear-gradient(#000 0 0);
-    -webkit-mask-composite: xor;
-    mask:
-        linear-gradient(#000 0 0) content-box,
-        linear-gradient(#000 0 0);
-    mask-composite: exclude;
 }

--- a/assets/styles/opening.css
+++ b/assets/styles/opening.css
@@ -413,15 +413,15 @@
     box-shadow: 0 0 14px -2px var(--slot-rar, transparent), 0 8px 18px #0008;
 }
 .opening__track-tile.is-popping .opening__track-img { animation: opening-slotPop .5s ease-out; }
-.opening__track-img img {
-    display: block;
+/* la carte rendue (CardComponent figé) remplace la vignette : c'est elle qui
+   porte le cadre, le nom et le filigrane */
+.opening__track-img .card {
     width: 100%;
     height: 100%;
-    object-fit: cover;
     opacity: 0;
     transition: opacity .4s ease;
 }
-.opening__track-tile.is-revealed .opening__track-img img { opacity: 1; }
+.opening__track-tile.is-revealed .opening__track-img .card { opacity: 1; }
 .opening__track-back {
     position: absolute;
     inset: 0;
@@ -580,7 +580,8 @@
     /* rarity halo */
     box-shadow: 0 0 16px -4px var(--tile-rar, transparent), 0 8px 18px #0007;
 }
-.opening__card-art img { display: block; width: 100%; height: 100%; object-fit: cover; }
+.opening__card-render,
+.opening__card-render .card { width: 100%; height: 100%; }
 /* masked (unowned) tile: card back, no halo, muted label */
 .opening__card-back {
     position: absolute;

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -13,6 +13,9 @@
     <div class="opening opening--page"
          data-controller="booster-opening"
          {% if opening %}data-booster-opening-count-value="{{ revealCards|length }}"{% endif %}
+         {#- l'id du tirage, pas son nombre de cartes : deux packs d'affilée ont
+             le même compte, seul l'id dit qu'un nouveau tirage est sur la table -#}
+         data-booster-opening-opening-id-value="{{ opening ? opening.id : '' }}"
          data-action="pack3d:opened->booster-opening#startReveal pack3d:ready->booster-opening#syncPack">
 
         {# ====================================================== LEFT: the pack #}
@@ -88,8 +91,11 @@
                     {% if opening %}
                         <footer class="opening__foot" data-booster-opening-target="foot" hidden>
                             {% if ownedCount > 0 %}
-                                <button type="button" data-action="live#action" data-live-action-param="reset" class="btn-arcade">
-                                    Ouvrir un autre ▸
+                                {# open, pas reset : le tirage suivant part du même clic #}
+                                <button type="button" data-action="live#action" data-live-action-param="open"
+                                        class="btn-arcade" data-testid="open-another">
+                                    <span data-loading="hide">Ouvrir un autre ▸</span>
+                                    <span data-loading="show" class="hidden">···</span>
                                 </button>
                                 <a href="{{ path('boosters') }}" class="opening__skip">← Tous les packs</a>
                             {% else %}

--- a/templates/components/BoosterOpening.html.twig
+++ b/templates/components/BoosterOpening.html.twig
@@ -158,8 +158,13 @@
                                 <div class="opening__track-img">
                                     <span class="opening__track-back" aria-hidden="true"
                                           style="background-image: url('{{ asset('images/card-back.svg') }}');"></span>
-                                    <img loading="lazy" src="{{ vich_uploader_asset(reveal.card) }}" alt=""
-                                         onerror="this.onerror=null;this.src='{{ asset('images/default_card.png') }}';">
+                                    {{ include('components/CardComponent.html.twig', {
+                                        card: reveal.card,
+                                        holo: reveal.holo,
+                                        interactive: false,
+                                        lazy: true,
+                                        id: 'track-card-' ~ loop.index0,
+                                    }) }}
                                     {% if reveal.holo %}<span class="opening__track-holo">HOLO</span>{% endif %}
                                     {% if reveal.card.id ~ '' in newCardIds %}<span class="opening__track-new">NOUVEAU</span>{% endif %}
                                 </div>
@@ -230,9 +235,16 @@
                                      {% if isOwned %}style="--tile-rar: var(--rarity-{{ rarity }});"{% endif %}>
                                 <div class="opening__card-art">
                                     {% if isOwned or isPending %}
-                                        <img loading="lazy" src="{{ vich_uploader_asset(card) }}" alt="{{ isOwned ? card.name : '' }}"
-                                             {% if isPending %}hidden{% endif %}
-                                             onerror="this.onerror=null;this.src='{{ asset('images/default_card.png') }}';">
+                                        {# wrapper dédié : c'est lui que le contrôleur dévoile à la
+                                           révélation, le composant contient plusieurs <img> #}
+                                        <div class="opening__card-render"{% if isPending %} hidden{% endif %}>
+                                            {{ include('components/CardComponent.html.twig', {
+                                                card: card,
+                                                interactive: false,
+                                                lazy: true,
+                                                id: 'set-card-' ~ cardId,
+                                            }) }}
+                                        </div>
                                     {% endif %}
                                     {% if not isOwned %}
                                         <span class="opening__card-back" aria-hidden="true"

--- a/templates/components/CardComponent.html.twig
+++ b/templates/components/CardComponent.html.twig
@@ -2,6 +2,12 @@
 {#- lazy: opt-in for grid usages (collection / univers) — keep the default
     eager where the card is visible immediately (homepage, opening reveal) -#}
 {%- set lazy = lazy|default(false) -%}
+{#- interactive: false = rendu figé (cadre, nom, filigrane) sans contrôleur de
+    tilt ni survol, pour les vignettes de l'ouverture où des dizaines de cartes
+    coexistent avec l'animation de révélation -#}
+{%- set interactive = interactive is defined ? interactive : true -%}
+{#- id explicite obligatoire quand la même carte est rendue deux fois dans la
+    page (ruban + encart) : sans ça les id se dupliquent -#}
 {%- set id = id|default(card.id) -%}
 {%- set visual = card_visual(card) -%}
 {#- CSS frame variant (cards/frame.css): resolved through the visual-config
@@ -22,9 +28,9 @@
    cascade resolves no preset falls back to the basic recipe #}
 {%- set holoClass = visual.holoEffect ? visual.holoEffect.cssClass : (holo ? 'holo--basic' : null) -%}
 <div id="{{ id }}"
-     class="card interactive{{ visual.hasMask ? ' masked' }}{{ holo ? ' holo' }}{{ card.isUnique ? ' unique' }}{{ frame ? ' framed' }}{{ visual.cssClass ? ' ' ~ visual.cssClass }}{{ holoClass ? ' ' ~ holoClass }}"
+     class="card {{ interactive ? 'interactive' : 'card--static' }}{{ visual.hasMask ? ' masked' }}{{ holo ? ' holo' }}{{ card.isUnique ? ' unique' }}{{ frame ? ' framed' }}{{ visual.cssClass ? ' ' ~ visual.cssClass }}{{ holoClass ? ' ' ~ holoClass }}"
      data-rarity="{{ card.rarity.value }}"
-     data-controller="card"
+     {%- if interactive %} data-controller="card"{% endif %}
      {%- if styleVars is not empty %} style="{{ styleVars|join('; ') }}"{% endif %}>
     <div class="card__translater">
         <div class="card__rotator">

--- a/tests/Functional/BoosterOpeningComponentTest.php
+++ b/tests/Functional/BoosterOpeningComponentTest.php
@@ -118,7 +118,9 @@ final class BoosterOpeningComponentTest extends WebTestCase
             $this->assertContains((string) $tile->attr('data-card-id'), $newCardIds);
             $this->assertNotSame('', (string) $tile->attr('data-pending-name'));
             $this->assertNotSame('', (string) $tile->attr('data-pending-rarity'));
-            $this->assertNotNull($tile->filter('img')->attr('hidden'), 'Pending artwork must stay hidden until the flip.');
+            // the whole rendered card is hidden: the component carries several
+            // <img> (front face + card back), the wrapper is the reveal hook
+            $this->assertNotNull($tile->filter('.opening__card-render')->attr('hidden'), 'Pending artwork must stay hidden until the flip.');
         });
     }
 

--- a/tests/Functional/BoosterOpeningComponentTest.php
+++ b/tests/Functional/BoosterOpeningComponentTest.php
@@ -180,7 +180,7 @@ final class BoosterOpeningComponentTest extends WebTestCase
         $this->assertSame('Tu ne possèdes pas ce booster.', $opening->error);
     }
 
-    public function testResetAllowsOpeningAnotherPack(): void
+    public function testOpeningAnotherPackDrawsInOneClick(): void
     {
         $client = static::createClient();
         $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
@@ -195,15 +195,49 @@ final class BoosterOpeningComponentTest extends WebTestCase
         );
 
         $component->call('open');
-        $this->assertNotNull($component->component()->opening, 'first open');
+        $first = $component->component()->opening;
+        $this->assertNotNull($first, 'first open');
+        $firstId = (string) $first->getId();
+
+        // « Ouvrir un autre » appelle open directement : plus de passage par
+        // l'état scellé, donc un seul clic par pack
+        $component->call('open');
+        $second = $component->component();
+        $this->assertNull($second->error, 'second open must not error');
+        $this->assertNotNull($second->opening, 'second open');
+        $this->assertNotSame($firstId, (string) $second->opening->getId(), 'a second draw, not the first one again');
+
+        // c'est cet id que le contrôleur JS surveille pour ré-armer le pack :
+        // le nombre de cartes, lui, est identique d'un pack à l'autre
+        $rendered = new Crawler((string) $component->render());
+        $this->assertSame(
+            (string) $second->opening->getId(),
+            $rendered->filter('.opening')->attr('data-booster-opening-opening-id-value'),
+        );
+    }
+
+    public function testResetClearsTheTable(): void
+    {
+        $client = static::createClient();
+        $user = $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+        $booster = $this->firstPublishedBooster();
+        $this->claim($user, $booster);
+
+        $component = $this->createLiveComponent(
+            BoosterOpening::class,
+            data: ['boosterId' => (string) $booster->getId()],
+            client: $client,
+        );
+
+        $component->call('open');
+        $this->assertNotNull($component->component()->opening);
 
         $component->call('reset');
         $this->assertNull($component->component()->opening, 'reset clears the opening');
-
-        $component->call('open');
-        $secondOpening = $component->component();
-        $this->assertNull($secondOpening->error, 'second open must not error');
-        $this->assertNotNull($secondOpening->opening, 'second open');
+        $this->assertSame(
+            '',
+            new Crawler((string) $component->render())->filter('.opening')->attr('data-booster-opening-opening-id-value'),
+        );
     }
 
     private function claim(DiscordUser $user, Booster $booster): void


### PR DESCRIPTION
## Avant / après

Les deux zones de la page d'ouverture affichaient de l'artwork nu sous un mini-cadre en pseudo-éléments, sans nom ni logo, avec le nom imprimé sous la tuile :

| zone | avant | après |
|---|---|---|
| ruban « Révélé N/N » | `<img>` + mat CSS | `CardComponent` — cadre, nom, univers, filigrane |
| encart « contenu du set » | `<img>` + mat CSS | idem |

Le rendu vient maintenant de la même cascade visuelle que la collection, le profil et `/univers` : une seule source de vérité, `card_visual()` → `CardComponent`.

## Mode figé

`CardComponent` gagne un paramètre `interactive` (défaut `true`). À `false` : pas de `data-controller="card"`, et une classe `card--static` qui neutralise le survol scripté de `base.css`. L'encart affiche jusqu'à 44 cartes pendant l'animation de révélation — on garde le CPU pour la révélation.

Mesuré : 14 cartes rendues dans l'encart, **0** contrôleur de tilt, tuile immobile au survol (mêmes largeur, hauteur et position).

## Masquage inchangé

- une carte non possédée ne rend **aucune** carte (dos seul, ni nom ni rareté dans le DOM) — vérifié : 0 `.card` dans les tuiles masquées ;
- une carte fraîchement tirée reste cachée derrière son wrapper jusqu'à son retournement. Le contrôleur cible désormais ce wrapper (`.opening__card-render`) et non un `<img>` : le composant en contient plusieurs, dont le dos de carte.

Les ids sont préfixés (`track-card-N`, `set-card-<uuid>`) — la même carte peut apparaître dans le ruban et dans l'encart.

## Vérification

Ouverture complète rejouée au navigateur (`cadres-ouverture.mjs`) :

```
encart : 44 tuiles, 9 masquées, 35 avec cadre+nom
cartes rendues dans une tuile masquée : 0
ruban : 5 révélées, 5 avec cadre+nom
encart après ouverture : 0 encore pending, 0 rendus masqués
erreurs : aucune
```

405 tests verts, `make quality` vert, Tailwind rebuild inclus.

## À trancher

Le nom apparaît maintenant deux fois sur les tuiles révélées : sur la carte (dans le cadre) et dans la légende sous la tuile. J'ai gardé la légende — elle sert de retour de révélation (« Non révélée » → nom) et reste plus lisible à la volée que le nom du cadre à cette taille. Un mot et je la retire pour les cartes révélées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Ajout : enchaîner les packs en un seul clic

« Ouvrir un autre ▸ » appelait l'action `reset`, qui remettait la table à zéro et faisait réapparaître « Ouvrir ce pack ▸ » : **deux clics par pack** quand on en enchaîne plusieurs. Le bouton appelle maintenant `open` directement.

Ce détour n'était pas gratuit. Le contrôleur s'armait sur le **nombre** de cartes tirées (`countValue`), identique d'un pack à l'autre : un second tirage ne changeait donc aucune valeur, et sans changement de valeur, pas de remise à zéro de la révélation ni de ré-armement du pack 3D (qui vit dans un sous-arbre `data-live-ignore` et survit au re-render).

Le composant expose donc l'**id du tirage**, qui change à chaque ouverture, et c'est lui qui pilote la séquence : un pack laissé déchiré est re-scellé avant d'être ré-armé. Un garde sur cet id évite le double armement quand `count` et `openingId` arrivent au même rendu.

L'action `reset` reste en place — elle vide la table et une page déjà ouverte avant déploiement continue de fonctionner.

Vérifié au navigateur (`ouvrir-a-la-suite.mjs`) :

```
pack 1 : 5 cartes révélées
nouveau tirage après UN seul clic : true
  bouton « Ouvrir ce pack » réapparu (= clic en trop) : false
  pack re-scellé et prêt : TIRE LE RUBAN VERS LA DROITE → POUR DÉCHIRER
pack 2 : 5 cartes révélées
erreurs : aucune
```

406 tests verts (dont un qui vérifie que deux `open` d'affilée produisent bien deux tirages distincts, et que l'id rendu suit).
