### PR TITLE
feat(collection): fusionner le profil joueur dans « Ma collection »

### DIFF
--- a/src/Controller/CollectionController.php
+++ b/src/Controller/CollectionController.php
@@ -4,31 +4,45 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Dto\ProfileUniverseComparison;
 use App\Entity\DiscordUser;
 use App\Entity\Extension;
 use App\Repository\CardRepository;
-use App\Repository\ExtensionRepository;
-use App\Repository\UserCardRepository;
 use App\Service\Booster\BoosterClaimQuotaInterface;
+use App\Service\Leaderboard\LeaderboardService;
+use App\Service\Leaderboard\ProfileComparisonService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
+/**
+ * « Ma collection »: the player's own pokédex — the whole published catalogue
+ * split by universe, the cards not owned yet face down. It also carries the
+ * profile stats (rank, holos, uniques, opened packs), so a player never needs
+ * to visit their own /joueur/{id} page, which redirects here.
+ *
+ * The comparison of the user with themselves is the same one the public
+ * profiles use: same states, same grid, one service.
+ */
 class CollectionController extends AbstractController
 {
+    public function __construct(
+        private readonly CardRepository $cardRepository,
+        private readonly ProfileComparisonService $profileComparisonService,
+        private readonly LeaderboardService $leaderboardService,
+        private readonly BoosterClaimQuotaInterface $boosterClaimQuota,
+    ) {
+    }
+
     #[Route('/collection/{slug}', name: 'collection', requirements: ['slug' => '[a-z0-9-]+'], defaults: ['slug' => null])]
     public function __invoke(
         Request $request,
         #[CurrentUser] DiscordUser $user,
-        UserCardRepository $userCardRepository,
-        ExtensionRepository $extensionRepository,
-        CardRepository $cardRepository,
-        BoosterClaimQuotaInterface $boosterClaimQuota,
         ?string $slug = null,
     ): Response {
-        $extensions = $extensionRepository->findPublishedWithPublishedCardCount();
+        $comparison = $this->profileComparisonService->compare($user, $user);
 
         // Legacy pre-slug urls (/collection?extension=<uuid>): redirect to the slug
         // route instead of silently ignoring the filter; unknown id stays a 404,
@@ -37,54 +51,67 @@ class CollectionController extends AbstractController
         if (null === $slug && '' !== $legacyId) {
             return $this->redirectToRoute(
                 'collection',
-                ['slug' => $this->resolveLegacyExtensionId($legacyId, $extensions)->getSlug()],
+                ['slug' => $this->resolveLegacyExtensionId($legacyId, $comparison->universes)->getSlug()],
                 Response::HTTP_MOVED_PERMANENTLY,
             );
         }
 
-        $currentExtension = $this->resolveExtensionFilter($slug, $extensions);
+        $currentExtension = $this->resolveExtensionFilter($slug, $comparison->universes);
+        $visibleUniverses = $this->filterUniverses($comparison->universes, $currentExtension);
 
-        $ownedByExtension = $userCardRepository->countOwnedGroupedByExtension($user);
         // fond des tuiles du carrousel quand l'extension n'a pas d'image uploadée
-        $coverImages = $cardRepository->findCoverImageNamesByExtension();
+        $coverImages = $this->cardRepository->findCoverImageNamesByExtension();
 
-        $universes = array_map(static function (array $item) use ($ownedByExtension, $coverImages): array {
-            $extensionId = (string) $item['extension']->getId();
-            $owned = $ownedByExtension[$extensionId] ?? 0;
-
-            return [
-                'extension' => $item['extension'],
-                'total' => $item['cardCount'],
-                'owned' => $owned,
-                'percentage' => $item['cardCount'] > 0 ? (int) round($owned / $item['cardCount'] * 100) : 0,
-                'coverImage' => $coverImages[$extensionId] ?? null,
-            ];
-        }, $extensions);
-
-        $totalPublished = array_sum(array_column($extensions, 'cardCount'));
-        $ownedTotalDistinct = array_sum($ownedByExtension);
+        $strip = array_map(static fn (ProfileUniverseComparison $universe): array => [
+            'extension' => $universe->extension,
+            'total' => $universe->total,
+            'owned' => $universe->common,
+            'percentage' => $universe->total > 0 ? (int) round($universe->common / $universe->total * 100) : 0,
+            'coverImage' => $coverImages[(string) $universe->extension->getId()] ?? null,
+        ], $comparison->universes);
 
         return $this->render('pages/collection.html.twig', [
-            'universes' => $universes,
+            'entry' => $this->leaderboardService->getEntryFor($user),
+            'universes' => $strip,
+            'visibleUniverses' => $visibleUniverses,
             'currentExtension' => $currentExtension,
-            'userCards' => $userCardRepository->findOwnedWithCards($user, $currentExtension),
-            'ownedTotalDistinct' => $ownedTotalDistinct,
-            'ownedTotalQuantity' => $userCardRepository->sumOwnedQuantities($user),
-            'totalPublished' => $totalPublished,
-            'completionPct' => $totalPublished > 0 ? (int) round($ownedTotalDistinct / $totalPublished * 100) : 0,
-            'remainingClaims' => $boosterClaimQuota->getRemainingClaims($user),
+            'ownedTotalDistinct' => $comparison->common,
+            'totalPublished' => $comparison->total,
+            'completionPct' => $comparison->total > 0 ? (int) round($comparison->common / $comparison->total * 100) : 0,
+            // filter chip counters follow the grid actually rendered, not the catalogue
+            'visibleTotal' => array_sum(array_map(static fn (ProfileUniverseComparison $u): int => $u->total, $visibleUniverses)),
+            'visibleOwned' => array_sum(array_map(static fn (ProfileUniverseComparison $u): int => $u->common, $visibleUniverses)),
+            'visibleMissing' => array_sum(array_map(static fn (ProfileUniverseComparison $u): int => $u->missingBoth, $visibleUniverses)),
+            'remainingClaims' => $this->boosterClaimQuota->getRemainingClaims($user),
             'dailyLimit' => BoosterClaimQuotaInterface::DAILY_LIMIT,
         ]);
     }
 
     /**
-     * @param list<array{extension: Extension, cardCount: int}> $extensions
+     * @param list<ProfileUniverseComparison> $universes
+     *
+     * @return list<ProfileUniverseComparison>
      */
-    private function resolveLegacyExtensionId(string $id, array $extensions): Extension
+    private function filterUniverses(array $universes, ?Extension $currentExtension): array
     {
-        foreach ($extensions as $item) {
-            if (((string) $item['extension']->getId()) === $id) {
-                return $item['extension'];
+        if (!$currentExtension instanceof Extension) {
+            return $universes;
+        }
+
+        return array_values(array_filter(
+            $universes,
+            static fn (ProfileUniverseComparison $universe): bool => $universe->extension->getId() === $currentExtension->getId(),
+        ));
+    }
+
+    /**
+     * @param list<ProfileUniverseComparison> $universes
+     */
+    private function resolveLegacyExtensionId(string $id, array $universes): Extension
+    {
+        foreach ($universes as $universe) {
+            if (((string) $universe->extension->getId()) === $id) {
+                return $universe->extension;
             }
         }
 
@@ -92,20 +119,20 @@ class CollectionController extends AbstractController
     }
 
     /**
-     * Resolves the {slug} route parameter against the published extensions already
-     * loaded: no extra Doctrine lookup, and an unknown slug is a plain 404.
+     * Resolves the {slug} route parameter against the compared universes already
+     * built: no extra Doctrine lookup, and an unknown slug is a plain 404.
      *
-     * @param list<array{extension: Extension, cardCount: int}> $extensions
+     * @param list<ProfileUniverseComparison> $universes
      */
-    private function resolveExtensionFilter(?string $slug, array $extensions): ?Extension
+    private function resolveExtensionFilter(?string $slug, array $universes): ?Extension
     {
         if (null === $slug || '' === $slug) {
             return null;
         }
 
-        foreach ($extensions as $item) {
-            if ($item['extension']->getSlug() === $slug) {
-                return $item['extension'];
+        foreach ($universes as $universe) {
+            if ($universe->extension->getSlug() === $slug) {
+                return $universe->extension;
             }
         }
 

--- a/src/Controller/LeaderboardController.php
+++ b/src/Controller/LeaderboardController.php
@@ -39,6 +39,11 @@ class LeaderboardController extends AbstractController
     #[Route('/joueur/{discordId}', name: 'leaderboard_player', requirements: ['discordId' => '\d+'])]
     public function player(#[CurrentUser] DiscordUser $visitor, string $discordId): Response
     {
+        // your own profile IS your collection page: one page, not two
+        if ($visitor->getDiscordId() === $discordId) {
+            return $this->redirectToRoute('collection');
+        }
+
         $profile = $this->discordUserRepository->find($discordId);
 
         if (!$profile instanceof DiscordUser) {

--- a/src/Dto/ProfileComparison.php
+++ b/src/Dto/ProfileComparison.php
@@ -20,7 +20,6 @@ final readonly class ProfileComparison
         public int $profileOnly,
         public int $visitorOnly,
         public int $missingBoth,
-        public bool $isSelf,
     ) {
     }
 }

--- a/src/Repository/UserCardRepository.php
+++ b/src/Repository/UserCardRepository.php
@@ -142,19 +142,4 @@ class UserCardRepository extends ServiceEntityRepository
 
         return $stats;
     }
-
-    /**
-     * Total number of cards owned (collection banner stat). quantity already
-     * counts holo copies (holoQuantity is a sub-count, not an extra).
-     */
-    public function sumOwnedQuantities(DiscordUser $discordUser): int
-    {
-        return (int) $this->createQueryBuilder('uc')
-            ->select('COALESCE(SUM(uc.quantity), 0)')
-            ->andWhere('uc.discordUser = :user')
-            ->setParameter('user', $discordUser)
-            ->getQuery()
-            ->getSingleScalarResult()
-        ;
-    }
 }

--- a/src/Service/Leaderboard/ProfileComparisonService.php
+++ b/src/Service/Leaderboard/ProfileComparisonService.php
@@ -16,7 +16,8 @@ use App\Repository\UserCardRepository;
 /**
  * Crosses the published catalogue with two collections — the visited profile's
  * and the visitor's — so a profile also shows what its owner is MISSING, and
- * what both are still hunting.
+ * what both are still hunting. Comparing a player with themselves is how the
+ * « Ma collection » page builds its own pokédex.
  *
  * Disclosure rules, in one place:
  *  - a card of the profile is revealed only when the visitor owns it too (the
@@ -95,7 +96,6 @@ final readonly class ProfileComparisonService
             profileOnly: $totals['profileOnly'],
             visitorOnly: $totals['visitorOnly'],
             missingBoth: $totals['missingBoth'],
-            isSelf: $isSelf,
         );
     }
 

--- a/templates/pages/collection.html.twig
+++ b/templates/pages/collection.html.twig
@@ -32,7 +32,13 @@
                                  style="width: {{ completionPct }}%;"></div>
                         </div>
                     </div>
-                    <p class="chip-mono mt-2 text-ink-dim">Cartes possédées · {{ ownedTotalQuantity }}</p>
+
+                    <div class="chip-mono mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-ink-muted" data-testid="profile-stats">
+                        <span>◈ {{ entry.totalCards }} carte{{ entry.totalCards > 1 ? 's' }} au total</span>
+                        <span class="{{ entry.holoCards > 0 ? 'text-primary' : '' }}">✦ {{ entry.holoCards }} holo{{ entry.holoCards > 1 ? 's' }}</span>
+                        <span class="{{ entry.uniqueCards > 0 ? 'text-magenta' : '' }}">◆ {{ entry.uniqueCards }} unique{{ entry.uniqueCards > 1 ? 's' }} 1/1</span>
+                        <span>▣ {{ entry.openedBoosters }} pack{{ entry.openedBoosters > 1 ? 's' }} ouvert{{ entry.openedBoosters > 1 ? 's' }}</span>
+                    </div>
                 </div>
 
                 <div class="flex flex-col items-start gap-2.5 md:items-end">
@@ -50,6 +56,11 @@
                        class="chip-mono text-ink-dim transition-colors hover:text-primary"
                        data-testid="history-link">
                         ◎ Mes ouvertures ▸
+                    </a>
+                    <a href="{{ path('leaderboard') }}"
+                       class="chip-mono text-ink-dim transition-colors hover:text-primary"
+                       data-testid="leaderboard-link">
+                        ▲ #{{ entry.rank }} au classement ▸
                     </a>
                 </div>
             </div>
@@ -125,56 +136,135 @@
         </section>
 
         {# ---------------------------------------------------------- Grille #}
-        <section class="px-6 pb-24 pt-8 lg:px-12">
+        <section class="px-6 pb-24 pt-8 lg:px-12" data-controller="profile-filter">
             <div class="mx-auto max-w-7xl">
-                <div class="mb-6 flex items-center justify-between">
-                    <h2 class="font-display text-sm font-bold uppercase tracking-[.1em] text-ink-strong">
-                        {{ currentExtension is not null ? currentExtension.name : 'Toutes les cartes' }}
-                    </h2>
-                    <span class="font-mono text-[11px] tracking-[.15em] text-ink-dim">TRI: RARETÉ ↓</span>
-                </div>
-                {% if userCards is not empty %}
-                    <div class="grid grid-cols-2 gap-6 md:grid-cols-3 xl:grid-cols-5" data-testid="collection-grid">
-                        {% for userCard in userCards %}
-                            {% set ownsHolo = userCard.holoQuantity > 0 %}
-                            {# quantity is the TOTAL (holo copies included): a normal
-                               copy exists only when quantity > holoQuantity. The
-                               toggle only makes sense when BOTH versions are owned. #}
-                            {% set ownsNormal = userCard.quantity > userCard.holoQuantity %}
-                            <div class="card-tile relative"
-                                 {%- if ownsHolo and ownsNormal %} data-controller="holo-toggle"
-                                 data-holo-toggle-holo-class-value="{{ card_visual(userCard.card).holoEffect.cssClass ?? 'holo--basic' }}"
-                                 {%- endif %}>
-                                {{ include('components/CardComponent.html.twig', { card: userCard.card, holo: ownsHolo, lazy: true }) }}
-                                <div class="card-tile__chips pointer-events-none absolute -right-2 -top-2 z-10 flex gap-1.5">
-                                    <span class="chip-mono bg-black/90 px-2 py-1 font-bold text-white">×{{ userCard.quantity }}</span>
-                                    {% if ownsHolo %}
-                                        <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">✦{{ userCard.holoQuantity }}</span>
-                                    {% endif %}
-                                </div>
-                                {% if ownsHolo and ownsNormal %}
-                                    {# toggle OUTSIDE the .card element: a click on the card itself triggers the 3D zoom.
-                                       card-tile__toggle (et pas card-tile__chips) : c'est une commande, elle ne
-                                       s'efface pas et reste au-dessus de la carte inclinée #}
-                                    <button type="button"
-                                            class="card-tile__toggle chip-mono absolute -left-2 -top-2 border border-hairline bg-black/90 px-2 py-1 font-bold text-ink-dim transition-colors hover:text-ink-strong aria-pressed:border-transparent aria-pressed:bg-gradient-to-r aria-pressed:from-primary aria-pressed:to-magenta aria-pressed:text-black"
-                                            aria-pressed="true"
-                                            data-action="holo-toggle#toggle"
-                                            data-holo-toggle-target="button"
-                                            data-testid="holo-toggle">
-                                        ✦ HOLO
-                                    </button>
-                                {% endif %}
-                            </div>
-                        {% endfor %}
-                    </div>
-                {% else %}
-                    <div class="border border-dashed border-hairline px-8 py-20 text-center text-ink-dim" data-testid="empty-state">
+                {% if visibleOwned == 0 %}
+                    <div class="mb-10 border border-dashed border-hairline px-8 py-16 text-center text-ink-dim" data-testid="empty-state">
                         <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Vide.</p>
-                        <p class="mt-3 text-sm">Aucune carte de cet univers. Ouvre un pack, gros youl.</p>
+                        <p class="mt-3 text-sm">
+                            {{ currentExtension is not null ? 'Aucune carte de cet univers. Ouvre un pack, gros youl.' : 'Aucune carte pour le moment. Ouvre un pack, gros youl.' }}
+                        </p>
                         <a href="{{ path('boosters') }}" class="btn-arcade mt-8">Ouvrir un pack ▸</a>
                     </div>
                 {% endif %}
+
+                {% if visibleTotal > 0 %}
+                    <div class="mb-8 flex flex-wrap items-center gap-2" role="group" aria-label="Filtrer la collection" data-testid="collection-filters">
+                        {% for filter in [
+                            { state: 'all', label: 'Tout', count: visibleTotal },
+                            { state: 'common', label: 'Possédées', count: visibleOwned },
+                            { state: 'missing-both', label: 'Manquantes', count: visibleMissing },
+                        ] %}
+                            {# un filtre à 0 n'a rien à montrer : il reste lisible mais inactif #}
+                            <button type="button"
+                                    class="filter-chip{{ loop.first ? ' is-active' }}"
+                                    data-state="{{ filter.state }}"
+                                    data-profile-filter-target="button"
+                                    data-action="profile-filter#select"
+                                    aria-pressed="{{ loop.first ? 'true' : 'false' }}"
+                                    {{ filter.count == 0 and not loop.first ? 'disabled' }}>
+                                {{ filter.label }} <span class="filter-chip__count">{{ filter.count }}</span>
+                            </button>
+                        {% endfor %}
+                    </div>
+
+                    <p class="chip-mono mb-8 border border-hairline bg-surface px-3 py-2 text-ink-muted" data-testid="masking-hint">
+                        Face cachée = carte pas encore trouvée. <span class="text-magenta">◆ 1/1</span> = carte unique.
+                    </p>
+                {% endif %}
+
+                {# annonce le résultat du filtrage aux lecteurs d'écran #}
+                <p class="sr-only" aria-live="polite" data-profile-filter-target="status"></p>
+
+                {% for universe in visibleUniverses %}
+                    <div class="mb-12" data-profile-filter-target="universe" data-testid="collection-universe">
+                        <div class="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+                            <h2 class="font-display text-sm font-bold uppercase tracking-[.1em] text-ink-strong">
+                                <a href="{{ path('universes_show', { slug: universe.extension.slug }) }}"
+                                   class="transition-colors hover:text-primary">{{ universe.extension.name }}</a>
+                            </h2>
+                            <span class="chip-mono text-ink-muted"
+                                  data-profile-filter-target="count"
+                                  data-total="{{ universe.total }}"
+                                  data-testid="universe-count">
+                                {{ universe.total }} carte{{ universe.total > 1 ? 's' }}
+                            </span>
+                        </div>
+
+                        {# compteurs du catalogue complet : estompés dès qu'un filtre restreint la grille #}
+                        <div class="chip-mono mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-ink-muted transition-opacity"
+                             data-profile-filter-target="counters"
+                             data-testid="universe-compare">
+                            <span>◈ {{ universe.common }} possédée{{ universe.common > 1 ? 's' }}</span>
+                            <span>✕ {{ universe.missingBoth }} manquante{{ universe.missingBoth > 1 ? 's' }}</span>
+                        </div>
+
+                        <div class="mt-6 grid grid-cols-2 gap-6 md:grid-cols-3 xl:grid-cols-5" data-testid="collection-grid">
+                            {% for item in universe.cards %}
+                                {% set userCard = item.profileCard %}
+                                {% set ownsHolo = userCard is not null and userCard.holoQuantity > 0 %}
+                                {# quantity is the TOTAL (holo copies included): a normal
+                                   copy exists only when quantity > holoQuantity. The
+                                   toggle only makes sense when BOTH versions are owned. #}
+                                {% set ownsNormal = userCard is not null and userCard.quantity > userCard.holoQuantity %}
+                                <div class="card-tile relative"
+                                     data-state="{{ item.state.value }}"
+                                     data-profile-filter-target="tile"
+                                     data-testid="collection-tile"
+                                     {%- if ownsHolo and ownsNormal %} data-controller="holo-toggle"
+                                     data-holo-toggle-holo-class-value="{{ card_visual(item.card).holoEffect.cssClass ?? 'holo--basic' }}"
+                                     {%- endif %}>
+                                    {# le voile des manquantes va sur la carte, jamais sur la tuile :
+                                       il éteindrait les chips, qui portent toute l'information #}
+                                    <div class="{{ userCard is null ? 'opacity-60' }}">
+                                        {% if userCard is not null %}
+                                            {{ include('components/CardComponent.html.twig', { card: item.card, holo: ownsHolo, lazy: true }) }}
+                                        {% else %}
+                                            {{ include('parts/_masked_card.html.twig') }}
+                                        {% endif %}
+                                    </div>
+
+                                    <div class="card-tile__chips pointer-events-none absolute -right-2 -top-2 z-10 flex max-w-full flex-col items-end gap-1.5 sm:flex-row sm:flex-wrap sm:justify-end">
+                                        {% if item.card.isUnique %}
+                                            <span class="chip-mono border border-magenta bg-black/90 px-2 py-1 font-bold text-magenta" data-testid="chip-unique">
+                                                ◆<span class="sr-only sm:not-sr-only sm:ml-1">1/1</span>
+                                            </span>
+                                        {% endif %}
+                                        {% if userCard is not null %}
+                                            <span class="chip-mono bg-black/90 px-2 py-1 font-bold text-white">×{{ userCard.quantity }}</span>
+                                            {% if ownsHolo %}
+                                                <span class="chip-mono bg-gradient-to-r from-primary to-magenta px-2 py-1 font-bold text-black">✦{{ userCard.holoQuantity }}</span>
+                                            {% endif %}
+                                        {% endif %}
+                                    </div>
+
+                                    {% if ownsHolo and ownsNormal %}
+                                        {# toggle OUTSIDE the .card element: a click on the card itself triggers the 3D zoom.
+                                           card-tile__toggle (et pas card-tile__chips) : c'est une commande, elle ne
+                                           s'efface pas et reste au-dessus de la carte inclinée #}
+                                        <button type="button"
+                                                class="card-tile__toggle chip-mono absolute -left-2 -top-2 border border-hairline bg-black/90 px-2 py-1 font-bold text-ink-dim transition-colors hover:text-ink-strong aria-pressed:border-transparent aria-pressed:bg-gradient-to-r aria-pressed:from-primary aria-pressed:to-magenta aria-pressed:text-black"
+                                                aria-pressed="true"
+                                                data-action="holo-toggle#toggle"
+                                                data-holo-toggle-target="button"
+                                                data-testid="holo-toggle">
+                                            ✦ HOLO
+                                        </button>
+                                    {% endif %}
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endfor %}
+
+                {# filtre qui ne ramène rien : sans ça la page tombe dans le vide #}
+                <div class="border border-dashed border-hairline px-8 py-16 text-center text-ink-dim"
+                     data-profile-filter-target="empty"
+                     data-testid="filter-empty"
+                     hidden>
+                    <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Rien dans cet état.</p>
+                    <p class="mt-3 text-sm">Choisis un autre filtre.</p>
+                </div>
             </div>
         </section>
     </main>

--- a/templates/pages/player_profile.html.twig
+++ b/templates/pages/player_profile.html.twig
@@ -5,7 +5,6 @@
 {% endblock %}
 
 {% block body %}
-    {% set isSelf = comparison.isSelf %}
     <main>
         {# --------------------------------------------------- Bandeau joueur #}
         <section class="relative border-b border-hairline px-6 py-10 lg:px-12">
@@ -21,7 +20,6 @@
                     <p class="eyebrow">Profil joueur</p>
                     <h1 class="mt-1 font-display text-4xl font-bold uppercase tracking-[-0.04em] text-ink-strong md:text-5xl">
                         {{ profile.username }}
-                        {% if isSelf %}<span class="align-middle font-mono text-xs tracking-[.2em] text-primary">· TOI</span>{% endif %}
                     </h1>
                     <p class="mt-1.5 font-mono text-xs text-ink-dim">joueur depuis {{ profile.createdAt|date('m/Y') }}</p>
 
@@ -53,6 +51,11 @@
                        class="border border-primary bg-black px-5 py-3.5 font-display text-[13px] font-bold uppercase tracking-[.15em] text-primary">
                         ◂ Le classement
                     </a>
+                    <a href="{{ path('collection') }}"
+                       class="chip-mono text-ink-dim transition-colors hover:text-primary"
+                       data-testid="collection-link">
+                        ◈ Ma collection ▸
+                    </a>
                 </div>
             </div>
         </section>
@@ -63,29 +66,22 @@
                 {% if entry.distinctCards == 0 %}
                     <div class="mb-10 border border-dashed border-hairline px-8 py-16 text-center text-ink-dim" data-testid="empty-state">
                         <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Collection vide.</p>
-                        <p class="mt-3 text-sm">{{ isSelf ? 'Aucune carte pour le moment. Ouvre un pack, gros youl.' : 'Ce joueur n\'a encore aucune carte.' }}</p>
+                        <p class="mt-3 text-sm">Ce joueur n'a encore aucune carte.</p>
                     </div>
                 {% endif %}
 
                 {% if comparison.total > 0 %}
                     {# pseudo tronqué : un pseudo Discord long ferait déborder la barre en mobile #}
                     {% set shortName = profile.username|slice(0, 12) ~ (profile.username|length > 12 ? '…' : '') %}
-                    {% set filters = isSelf
-                        ? [
-                            { state: 'all', label: 'Tout', count: comparison.total },
-                            { state: 'common', label: 'Possédées', count: comparison.common },
-                            { state: 'missing-both', label: 'Manquantes', count: comparison.missingBoth },
-                        ]
-                        : [
+
+                    <div class="mb-8 flex flex-wrap items-center gap-2" role="group" aria-label="Filtrer la collection" data-testid="profile-filters">
+                        {% for filter in [
                             { state: 'all', label: 'Tout', count: comparison.total },
                             { state: 'common', label: 'En commun', count: comparison.common },
                             { state: 'profile-only', label: 'Seulement ' ~ shortName, count: comparison.profileOnly },
                             { state: 'visitor-only', label: 'Seulement toi', count: comparison.visitorOnly },
                             { state: 'missing-both', label: 'Manquantes aux deux', count: comparison.missingBoth },
                         ] %}
-
-                    <div class="mb-8 flex flex-wrap items-center gap-2" role="group" aria-label="Filtrer la collection" data-testid="profile-filters">
-                        {% for filter in filters %}
                             {# un filtre à 0 n'a rien à montrer : il reste lisible mais inactif #}
                             <button type="button"
                                     class="filter-chip{{ loop.first ? ' is-active' }}"
@@ -100,11 +96,7 @@
                     </div>
 
                     <p class="chip-mono mb-8 border border-hairline bg-surface px-3 py-2 text-ink-muted" data-testid="masking-hint">
-                        {% if isSelf %}
-                            Face cachée = carte pas encore trouvée.
-                        {% else %}
-                            Face cachée = tu ne l'as pas encore. <span class="text-primary">◈ Sa collection</span> = {{ profile.username }} l'a, toi non. Éteinte = personne ne l'a.
-                        {% endif %}
+                        Face cachée = tu ne l'as pas encore. <span class="text-primary">◈ Sa collection</span> = {{ profile.username }} l'a, toi non. Éteinte = personne ne l'a.
                         <span class="text-magenta">◆ 1/1</span> = carte unique.
                     </p>
                 {% endif %}
@@ -130,12 +122,10 @@
                         <div class="chip-mono mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-ink-muted transition-opacity"
                              data-profile-filter-target="counters"
                              data-testid="universe-compare">
-                            <span>◈ {{ universe.common }} {{ isSelf ? 'possédée' ~ (universe.common > 1 ? 's') : 'en commun' }}</span>
-                            {% if not isSelf %}
-                                <span>▲ {{ universe.profileOnly }} seulement {{ profile.username }}</span>
-                                <span>▼ {{ universe.visitorOnly }} seulement toi</span>
-                            {% endif %}
-                            <span>✕ {{ universe.missingBoth }} manquante{{ universe.missingBoth > 1 ? 's' }}{{ isSelf ? '' : ' aux deux' }}</span>
+                            <span>◈ {{ universe.common }} en commun</span>
+                            <span>▲ {{ universe.profileOnly }} seulement {{ profile.username }}</span>
+                            <span>▼ {{ universe.visitorOnly }} seulement toi</span>
+                            <span>✕ {{ universe.missingBoth }} manquante{{ universe.missingBoth > 1 ? 's' }} aux deux</span>
                         </div>
 
                         <div class="mt-6 grid grid-cols-2 gap-6 md:grid-cols-3 xl:grid-cols-5" data-testid="profile-grid">

--- a/templates/pages/universe.html.twig
+++ b/templates/pages/universe.html.twig
@@ -88,7 +88,14 @@
                     <h2 class="font-display text-sm font-bold uppercase tracking-[.1em] text-ink-strong">
                         Le set · {{ totalCount }} cartes
                     </h2>
-                    <span class="font-mono text-[11px] tracking-[.15em] text-ink-dim">TRI: RARETÉ ↓</span>
+                    <div class="flex items-center gap-5">
+                        <a href="{{ path('collection', { slug: extension.slug }) }}"
+                           class="chip-mono text-ink-dim transition-colors hover:text-primary"
+                           data-testid="collection-link">
+                            ◈ Voir dans ma collection ▸
+                        </a>
+                        <span class="font-mono text-[11px] tracking-[.15em] text-ink-dim">TRI: RARETÉ ↓</span>
+                    </div>
                 </div>
 
                 <div class="mt-8 grid grid-cols-2 gap-6 md:grid-cols-3 xl:grid-cols-5" data-testid="set-grid">

--- a/tests/Functional/CollectionControllerTest.php
+++ b/tests/Functional/CollectionControllerTest.php
@@ -16,6 +16,10 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\DomCrawler\Crawler;
 
+/**
+ * « Ma collection »: the merged page — profile stats, completion strip and the
+ * whole published catalogue split by universe, the cards not owned yet masked.
+ */
 final class CollectionControllerTest extends WebTestCase
 {
     use JwtAuthTrait;
@@ -47,7 +51,7 @@ final class CollectionControllerTest extends WebTestCase
         $this->createScenario();
     }
 
-    public function testBannerShowsUserAndRealQuota(): void
+    public function testBannerShowsUserQuotaAndProfileStats(): void
     {
         $crawler = $this->client->request('GET', '/collection');
 
@@ -58,11 +62,24 @@ final class CollectionControllerTest extends WebTestCase
         $this->assertStringContainsString('2', $quota);
         $this->assertStringContainsString('/ 2', $quota);
 
-        // 3 (1 holo copy included) + 1 + 0: quantity is the total per card
-        $this->assertStringContainsString(
-            'Cartes possédées · 4',
-            $crawler->filter('main')->text(),
-        );
+        // the profile stats moved in with the merge: 3 (1 holo copy included) + 1 + 0
+        $stats = $crawler->filter('[data-testid="profile-stats"]')->text();
+        $this->assertStringContainsString('4 cartes au total', $stats);
+        $this->assertStringContainsString('1 holo', $stats);
+        $this->assertStringContainsString('0 unique 1/1', $stats);
+        $this->assertStringContainsString('0 pack ouvert', $stats);
+    }
+
+    public function testBannerLinksToTheHistoryAndTheLeaderboard(): void
+    {
+        $crawler = $this->client->request('GET', '/collection');
+
+        self::assertResponseIsSuccessful();
+        $this->assertSame('/mes-ouvertures', $crawler->filter('[data-testid="history-link"]')->attr('href'));
+
+        $rank = $crawler->filter('[data-testid="leaderboard-link"]');
+        $this->assertSame('/classement', $rank->attr('href'));
+        $this->assertMatchesRegularExpression('/#\d+ au classement/', $rank->text());
     }
 
     public function testCompletionStripShowsPerUniverseNumbers(): void
@@ -97,16 +114,51 @@ final class CollectionControllerTest extends WebTestCase
         $crawler = $this->client->request('GET', '/collection');
 
         self::assertResponseIsSuccessful();
-        $grid = $crawler->filter('[data-testid="collection-grid"]');
+        $grid = $this->universeBlock($crawler, $this->extensionA)->filter('[data-testid="collection-grid"]');
         $this->assertStringContainsString('×3', $grid->text());
         $this->assertStringContainsString('✦1', $grid->text());
-        // The zero-quantity inventory row must not produce a card.
-        $this->assertCount(0, $grid->filter(\sprintf('img[alt="%s"]', $this->cardsA[2]->getName())));
+    }
+
+    public function testCardsNotOwnedAreMaskedWithoutLeakingTheirNames(): void
+    {
+        $crawler = $this->client->request('GET', '/collection');
+
+        self::assertResponseIsSuccessful();
+        $block = $this->universeBlock($crawler, $this->extensionA);
+
+        // 4 published cards, 2 owned: the zero-quantity row counts as missing
+        $this->assertCount(2, $block->filter('[data-testid="collection-tile"][data-state="common"]'));
+        $this->assertCount(2, $block->filter('[data-testid="collection-tile"][data-state="missing-both"]'));
+        $this->assertCount(2, $block->filter('[data-testid="masked-card"]'));
+
+        $html = (string) $this->client->getResponse()->getContent();
+        $this->assertStringNotContainsString($this->cardsA[2]->getName(), $html);
+        $this->assertStringNotContainsString($this->cardsA[3]->getName(), $html);
+    }
+
+    public function testFilterBarCountsOwnedAndMissingCards(): void
+    {
+        $crawler = $this->client->request('GET', '/collection/' . $this->extensionA->getSlug());
+
+        self::assertResponseIsSuccessful();
+        $filters = $crawler->filter('[data-testid="collection-filters"] button');
+        $states = $filters->each(static fn (Crawler $node): string => (string) $node->attr('data-state'));
+        $this->assertSame(['all', 'common', 'missing-both'], $states);
+
+        // scoped to the filtered universe, not to the whole catalogue
+        $this->assertStringContainsString('4', $filters->eq(0)->text());
+        $this->assertStringContainsString('2', $filters->eq(1)->text());
+        $this->assertStringContainsString('2', $filters->eq(2)->text());
+
+        // the client-side fallback exists (hidden until a filter empties the grid)
+        $fallback = $crawler->filter('[data-testid="filter-empty"]');
+        $this->assertCount(1, $fallback);
+        $this->assertNotNull($fallback->attr('hidden'));
     }
 
     public function testHoloOwnedTileRendersToggleAndHoloCard(): void
     {
-        $crawler = $this->client->request('GET', '/collection');
+        $crawler = $this->client->request('GET', '/collection/' . $this->extensionA->getSlug());
 
         self::assertResponseIsSuccessful();
         $grid = $crawler->filter('[data-testid="collection-grid"]');
@@ -137,41 +189,37 @@ final class CollectionControllerTest extends WebTestCase
         $this->createUserCard($card, quantity: 2, holoQuantity: 2);
         $this->entityManager->flush();
 
-        $crawler = $this->client->request('GET', '/collection');
+        $crawler = $this->client->request('GET', '/collection/' . $this->extensionA->getSlug());
 
         self::assertResponseIsSuccessful();
-        $tile = $crawler->filter('[data-testid="collection-grid"] > div')->reduce(
-            fn (Crawler $node): bool => $node->filter(\sprintf('img[alt="%s"]', $card->getName()))->count() > 0,
-        );
-        $this->assertCount(1, $tile);
+        $tile = $this->tileOf($crawler, $card);
         $this->assertCount(0, $tile->filter('button[data-testid="holo-toggle"]'));
         $this->assertStringContainsString('holo--', (string) $tile->filter('.card')->attr('class'));
     }
 
     public function testCardWithoutHoloCopyHasNoToggleAndRendersNormal(): void
     {
-        $crawler = $this->client->request('GET', '/collection');
+        $crawler = $this->client->request('GET', '/collection/' . $this->extensionA->getSlug());
 
         self::assertResponseIsSuccessful();
 
         // cardsA[1] is owned without any holo copy: normal rendering, no toggle on its tile.
-        $tile = $crawler->filter('[data-testid="collection-grid"] > div')->reduce(
-            fn (Crawler $node): bool => $node->filter(\sprintf('img[alt="%s"]', $this->cardsA[1]->getName()))->count() > 0,
-        );
-        $this->assertCount(1, $tile);
+        $tile = $this->tileOf($crawler, $this->cardsA[1]);
         $this->assertCount(0, $tile->filter('button[data-testid="holo-toggle"]'));
         $this->assertNull($tile->attr('data-controller'));
         $this->assertStringNotContainsString('holo', (string) $tile->filter('.card')->attr('class'));
     }
 
-    public function testExtensionFilterOnlyShowsItsCards(): void
+    public function testExtensionFilterOnlyShowsItsUniverse(): void
     {
         $crawler = $this->client->request('GET', '/collection/' . $this->extensionA->getSlug());
 
         self::assertResponseIsSuccessful();
-        $grid = $crawler->filter('[data-testid="collection-grid"]');
-        $this->assertCount(1, $grid->filter(\sprintf('img[alt="%s"]', $this->cardsA[0]->getName())));
-        $this->assertCount(1, $grid->filter(\sprintf('img[alt="%s"]', $this->cardsA[1]->getName())));
+        // a single universe block, the filtered one — the rest of the catalogue is gone
+        $blocks = $crawler->filter('[data-testid="collection-universe"]');
+        $this->assertCount(1, $blocks);
+        $this->assertStringContainsString($this->extensionA->getName(), $blocks->filter('h2')->text());
+        $this->assertCount(1, $blocks->filter(\sprintf('img[alt="%s"]', $this->cardsA[0]->getName())));
 
         // The filtered universe's tile is the active one in the completion strip.
         $this->assertStringContainsString(
@@ -180,13 +228,30 @@ final class CollectionControllerTest extends WebTestCase
         );
     }
 
-    public function testEmptyStateWhenNoCardOwnedInExtension(): void
+    public function testExtensionWithNothingOwnedStillShowsItsMaskedSet(): void
     {
         $crawler = $this->client->request('GET', '/collection/' . $this->extensionB->getSlug());
 
         self::assertResponseIsSuccessful();
-        $this->assertCount(0, $crawler->filter('[data-testid="collection-grid"]'));
+        // the empty state nudges to open a pack, the catalogue stays behind it
         $this->assertStringContainsString('Vide.', $crawler->filter('[data-testid="empty-state"]')->text());
+        $this->assertCount(2, $crawler->filter('[data-testid="collection-tile"][data-state="missing-both"]'));
+        $this->assertCount(0, $crawler->filter('[data-testid="collection-tile"][data-state="common"]'));
+
+        // « Possédées » has nothing to show: readable but not clickable
+        $owned = $crawler->filter('[data-testid="collection-filters"] button[data-state="common"]');
+        $this->assertNotNull($owned->attr('disabled'));
+    }
+
+    public function testUniverseHeadingLinksToTheUniversePage(): void
+    {
+        $crawler = $this->client->request('GET', '/collection/' . $this->extensionA->getSlug());
+
+        self::assertResponseIsSuccessful();
+        $this->assertSame(
+            '/univers/' . $this->extensionA->getSlug(),
+            $crawler->filter('[data-testid="collection-universe"] h2 a')->attr('href'),
+        );
     }
 
     public function testUnknownExtensionIsNotFound(): void
@@ -220,7 +285,24 @@ final class CollectionControllerTest extends WebTestCase
         self::assertResponseStatusCodeSame(404);
     }
 
-    public function testGridOrdersOwnedCardsRarestFirst(): void
+    public function testUnpublishedContentNeverReachesTheGrid(): void
+    {
+        $draftExtension = $this->createExtension('Univers brouillon ' . uniqid(), ExtensionStatusEnum::DRAFT);
+        $hidden = $this->createCard($draftExtension, 'Carte cachée ' . uniqid());
+        $this->createUserCard($hidden, quantity: 1);
+        $this->entityManager->flush();
+
+        $crawler = $this->client->request('GET', '/collection');
+
+        self::assertResponseIsSuccessful();
+        $html = (string) $this->client->getResponse()->getContent();
+        // the draft card of the scenario is not part of extension A's published set
+        $this->assertStringContainsString('4 cartes', $this->universeBlock($crawler, $this->extensionA)->filter('[data-testid="universe-count"]')->text());
+        $this->assertStringNotContainsString($draftExtension->getName(), $html);
+        $this->assertStringNotContainsString($hidden->getName(), $html);
+    }
+
+    public function testGridOrdersCardsRarestFirst(): void
     {
         // a legendary and a rare on top of the owned commons — the grid must lead with them
         $legendary = $this->createCard($this->extensionA, 'Rarity test legendary ' . uniqid(), rarity: CardRarityEnum::LEGENDARY);
@@ -229,14 +311,41 @@ final class CollectionControllerTest extends WebTestCase
         $this->createUserCard($rare, quantity: 1);
         $this->entityManager->flush();
 
-        $crawler = $this->client->request('GET', '/collection');
+        $crawler = $this->client->request('GET', '/collection/' . $this->extensionA->getSlug());
 
         self::assertResponseIsSuccessful();
+        // masked tiles carry no artwork: only the revealed cards are named here
         $names = $crawler->filter('[data-testid="collection-grid"] img[alt]')->extract(['alt']);
         $names = array_values(array_filter($names, static fn (string $name): bool => '' !== $name));
 
         $this->assertSame($legendary->getName(), $names[0] ?? null, 'Rarest card must come first.');
         $this->assertSame($rare->getName(), $names[1] ?? null, 'Then the rare, before the commons.');
+    }
+
+    /**
+     * The universe block of an extension: /collection renders the whole
+     * catalogue, so every grid assertion is scoped to the scenario.
+     */
+    private function universeBlock(Crawler $crawler, Extension $extension): Crawler
+    {
+        $block = $crawler->filter('[data-testid="collection-universe"]')->reduce(
+            static fn (Crawler $node): bool => str_contains($node->filter('h2')->text(), $extension->getName()),
+        );
+
+        $this->assertCount(1, $block, 'The scenario universe must appear exactly once in the grid.');
+
+        return $block;
+    }
+
+    private function tileOf(Crawler $crawler, Card $card): Crawler
+    {
+        $tile = $crawler->filter('[data-testid="collection-tile"]')->reduce(
+            static fn (Crawler $node): bool => $node->filter(\sprintf('img[alt="%s"]', $card->getName()))->count() > 0,
+        );
+
+        $this->assertCount(1, $tile, \sprintf('Card "%s" must appear exactly once in the grid.', $card->getName()));
+
+        return $tile;
     }
 
     /**
@@ -265,12 +374,12 @@ final class CollectionControllerTest extends WebTestCase
         $this->entityManager->flush();
     }
 
-    private function createExtension(string $name): Extension
+    private function createExtension(string $name, ExtensionStatusEnum $status = ExtensionStatusEnum::PUBLISHED): Extension
     {
         $extension = new Extension()
             ->setName($name)
             ->setDescription('Test extension')
-            ->setStatus(ExtensionStatusEnum::PUBLISHED)
+            ->setStatus($status)
         ;
         $this->entityManager->persist($extension);
 

--- a/tests/Functional/PlayerProfileTest.php
+++ b/tests/Functional/PlayerProfileTest.php
@@ -197,31 +197,20 @@ final class PlayerProfileTest extends WebTestCase
         $this->assertNotNull($fallback->attr('hidden'));
     }
 
-    public function testOwnProfileShowsEverythingOwnedInClear(): void
+    public function testOwnProfileRedirectsToTheCollectionPage(): void
     {
-        // the rival visits their own profile: their cards are all in clear, the
-        // 1/1 included, and only what they miss stays face down
-        $this->authenticateClient($this->client, $this->rival->getDiscordId());
+        // your own profile IS « Ma collection »: same stats, same catalogue, one page
+        $this->client->request('GET', '/joueur/' . $this->user->getDiscordId());
+
+        self::assertResponseRedirects('/collection');
+    }
+
+    public function testProfileLinksBackToTheVisitorsOwnCollection(): void
+    {
         $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
 
         self::assertResponseIsSuccessful();
-        $this->assertCount(1, $crawler->filter(\sprintf('img[alt="%s"]', $this->secretCard->getName())));
-        $this->assertCount(1, $crawler->filter(\sprintf('img[alt="%s"]', $this->uniqueCard->getName())));
-
-        // the two cards they don't own (the visitor's one and the orphan one)
-        $block = $this->universeBlock($crawler);
-        $this->assertCount(2, $block->filter('[data-testid="masked-card"]'));
-        $this->assertCount(2, $block->filter('[data-testid="profile-tile"][data-state="missing-both"]'));
-        // the legend still explains the card backs, without the comparison wording
-        $hint = $crawler->filter('[data-testid="masking-hint"]');
-        $this->assertCount(1, $hint);
-        $this->assertStringContainsString('pas encore trouvée', $hint->text());
-        $this->assertStringNotContainsString('Sa collection', $hint->text());
-
-        $counters = $block->filter('[data-testid="universe-compare"]')->text();
-        $this->assertStringContainsString('3 possédées', $counters);
-        $this->assertStringContainsString('2 manquantes', $counters);
-        $this->assertStringNotContainsString('seulement', $counters);
+        $this->assertSame('/collection', $crawler->filter('[data-testid="collection-link"]')->attr('href'));
     }
 
     public function testAnotherPlayersUniqueShowsAsOwnedButIsNeverNamed(): void


### PR DESCRIPTION
## Contexte

`/collection` et `/joueur/{moi}` affichaient la même chose sous deux mises en page : mes cartes, ma complétion, mes stats. La seconde apportait en plus le catalogue complet avec les manquantes masquées et les filtres.

## Ce que fait la PR

`/collection` devient **la** page perso — le pokédex du joueur :

- bandeau de choix des extensions conservé tel quel (tuile « Tout » + une tuile par univers)
- stats du profil rapatriées dans le hero : total de cartes, holos, uniques 1/1, packs ouverts
- boutons conservés : `Ouvrir un pack`, `Mes ouvertures`, et le rang `#N au classement` qui pointe vers `/classement`
- la grille affiche **le catalogue publié complet**, split par univers, les cartes pas encore trouvées face cachée
- filtres `Tout` / `Possédées` / `Manquantes` (contrôleur Stimulus `profile-filter` réutilisé tel quel, zéro modif JS)
- cliquer une tuile du bandeau filtre la page sur cette extension : un seul bloc d'univers, et les compteurs des chips suivent

## Déduplication

- `/joueur/{moi}` redirige vers `/collection` → `player_profile.html.twig` ne sert plus qu'à la comparaison avec un autre joueur, toutes ses branches `isSelf` disparaissent, ainsi que `ProfileComparison::$isSelf` devenu write-only
- `UserCardRepository::sumOwnedQuantities()` supprimé : doublon exact de `aggregateOwnedByUser()`, plus aucun appelant
- liens croisés ajoutés : titre d'univers → `/univers/{slug}`, `/univers/{slug}` → `/collection/{slug}`, profil d'un autre joueur → `/collection`

## Point laissé de côté

`/univers/{slug}` garde sa complétion perso et sa grille masquée. La retirer aurait vidé la page de son intérêt (le masquage EST la dimension perso) ; les deux pages se différencient désormais par le rôle : `/univers` = vitrine (bannières, description, boosters), `/collection` = inventaire (exemplaires, holos, filtres). À rediscuter si le doublon te gêne encore.

## Tests

- `CollectionControllerTest` réécrit : stats, liens, bandeau, masquage sans fuite de nom, filtres et leurs compteurs, filtre par extension, tri par rareté, contenu non publié, 404 et redirect legacy
- `PlayerProfileTest` : redirection du profil self + lien retour vers ma collection, le reste des règles de divulgation inchangé
- suite complète : 418 tests / 2923 assertions ✅ · `make quality` ✅
- vérif visuelle Playwright (desktop + mobile) : 0 erreur console, 0 débordement horizontal, 9 requêtes SQL sur la vue globale