### PR TITLE
feat(profil): bandeau d'univers sur les profils joueur + compteurs inline

### DIFF
--- a/src/Controller/CollectionController.php
+++ b/src/Controller/CollectionController.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
-use App\Dto\ProfileUniverseComparison;
+use App\Dto\ProfileComparison;
 use App\Entity\DiscordUser;
 use App\Entity\Extension;
-use App\Repository\CardRepository;
 use App\Service\Booster\BoosterClaimQuotaInterface;
+use App\Service\Collection\CompletionStripBuilder;
 use App\Service\Leaderboard\LeaderboardService;
 use App\Service\Leaderboard\ProfileComparisonService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -24,13 +24,13 @@ use Symfony\Component\Security\Http\Attribute\CurrentUser;
  * to visit their own /joueur/{id} page, which redirects here.
  *
  * The comparison of the user with themselves is the same one the public
- * profiles use: same states, same grid, one service.
+ * profiles use: same states, same grid, same strip, one service.
  */
 class CollectionController extends AbstractController
 {
     public function __construct(
-        private readonly CardRepository $cardRepository,
         private readonly ProfileComparisonService $profileComparisonService,
+        private readonly CompletionStripBuilder $stripBuilder,
         private readonly LeaderboardService $leaderboardService,
         private readonly BoosterClaimQuotaInterface $boosterClaimQuota,
     ) {
@@ -49,93 +49,40 @@ class CollectionController extends AbstractController
         // the contract the query-param version already had.
         $legacyId = $request->query->getString('extension');
         if (null === $slug && '' !== $legacyId) {
+            $legacyExtension = $comparison->extensionById($legacyId);
+
+            if (!$legacyExtension instanceof Extension) {
+                throw $this->createNotFoundException(\sprintf('Unknown extension "%s".', $legacyId));
+            }
+
             return $this->redirectToRoute(
                 'collection',
-                ['slug' => $this->resolveLegacyExtensionId($legacyId, $comparison->universes)->getSlug()],
+                ['slug' => $legacyExtension->getSlug()],
                 Response::HTTP_MOVED_PERMANENTLY,
             );
         }
 
-        $currentExtension = $this->resolveExtensionFilter($slug, $comparison->universes);
-        $visibleUniverses = $this->filterUniverses($comparison->universes, $currentExtension);
-
-        // fond des tuiles du carrousel quand l'extension n'a pas d'image uploadée
-        $coverImages = $this->cardRepository->findCoverImageNamesByExtension();
-
-        $strip = array_map(static fn (ProfileUniverseComparison $universe): array => [
-            'extension' => $universe->extension,
-            'total' => $universe->total,
-            'owned' => $universe->common,
-            'percentage' => $universe->total > 0 ? (int) round($universe->common / $universe->total * 100) : 0,
-            'coverImage' => $coverImages[(string) $universe->extension->getId()] ?? null,
-        ], $comparison->universes);
+        $currentExtension = $this->resolveExtensionFilter($comparison, $slug);
 
         return $this->render('pages/collection.html.twig', [
             'entry' => $this->leaderboardService->getEntryFor($user),
-            'universes' => $strip,
-            'visibleUniverses' => $visibleUniverses,
+            'comparison' => $comparison,
+            // grid and filter chips follow the extension actually rendered
+            'visible' => $this->profileComparisonService->restrictTo($comparison, $currentExtension),
+            'strip' => $this->stripBuilder->build($comparison->universes),
             'currentExtension' => $currentExtension,
-            'ownedTotalDistinct' => $comparison->common,
-            'totalPublished' => $comparison->total,
-            'completionPct' => $comparison->total > 0 ? (int) round($comparison->common / $comparison->total * 100) : 0,
-            // filter chip counters follow the grid actually rendered, not the catalogue
-            'visibleTotal' => array_sum(array_map(static fn (ProfileUniverseComparison $u): int => $u->total, $visibleUniverses)),
-            'visibleOwned' => array_sum(array_map(static fn (ProfileUniverseComparison $u): int => $u->common, $visibleUniverses)),
-            'visibleMissing' => array_sum(array_map(static fn (ProfileUniverseComparison $u): int => $u->missingBoth, $visibleUniverses)),
             'remainingClaims' => $this->boosterClaimQuota->getRemainingClaims($user),
             'dailyLimit' => BoosterClaimQuotaInterface::DAILY_LIMIT,
         ]);
     }
 
-    /**
-     * @param list<ProfileUniverseComparison> $universes
-     *
-     * @return list<ProfileUniverseComparison>
-     */
-    private function filterUniverses(array $universes, ?Extension $currentExtension): array
-    {
-        if (!$currentExtension instanceof Extension) {
-            return $universes;
-        }
-
-        return array_values(array_filter(
-            $universes,
-            static fn (ProfileUniverseComparison $universe): bool => $universe->extension->getId() === $currentExtension->getId(),
-        ));
-    }
-
-    /**
-     * @param list<ProfileUniverseComparison> $universes
-     */
-    private function resolveLegacyExtensionId(string $id, array $universes): Extension
-    {
-        foreach ($universes as $universe) {
-            if (((string) $universe->extension->getId()) === $id) {
-                return $universe->extension;
-            }
-        }
-
-        throw $this->createNotFoundException(\sprintf('Unknown extension "%s".', $id));
-    }
-
-    /**
-     * Resolves the {slug} route parameter against the compared universes already
-     * built: no extra Doctrine lookup, and an unknown slug is a plain 404.
-     *
-     * @param list<ProfileUniverseComparison> $universes
-     */
-    private function resolveExtensionFilter(?string $slug, array $universes): ?Extension
+    private function resolveExtensionFilter(ProfileComparison $comparison, ?string $slug): ?Extension
     {
         if (null === $slug || '' === $slug) {
             return null;
         }
 
-        foreach ($universes as $universe) {
-            if ($universe->extension->getSlug() === $slug) {
-                return $universe->extension;
-            }
-        }
-
-        throw $this->createNotFoundException(\sprintf('Unknown extension "%s".', $slug));
+        return $comparison->extensionBySlug($slug)
+            ?? throw $this->createNotFoundException(\sprintf('Unknown extension "%s".', $slug));
     }
 }

--- a/src/Controller/LeaderboardController.php
+++ b/src/Controller/LeaderboardController.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use App\Dto\ProfileComparison;
 use App\Entity\DiscordUser;
+use App\Entity\Extension;
 use App\Repository\DiscordUserRepository;
+use App\Service\Collection\CompletionStripBuilder;
 use App\Service\Leaderboard\LeaderboardService;
 use App\Service\Leaderboard\ProfileComparisonService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -24,6 +27,7 @@ class LeaderboardController extends AbstractController
         private readonly LeaderboardService $leaderboardService,
         private readonly DiscordUserRepository $discordUserRepository,
         private readonly ProfileComparisonService $profileComparisonService,
+        private readonly CompletionStripBuilder $stripBuilder,
     ) {
     }
 
@@ -36,12 +40,17 @@ class LeaderboardController extends AbstractController
         ]);
     }
 
-    #[Route('/joueur/{discordId}', name: 'leaderboard_player', requirements: ['discordId' => '\d+'])]
-    public function player(#[CurrentUser] DiscordUser $visitor, string $discordId): Response
+    #[Route(
+        '/joueur/{discordId}/{slug}',
+        name: 'leaderboard_player',
+        requirements: ['discordId' => '\d+', 'slug' => '[a-z0-9-]+'],
+        defaults: ['slug' => null],
+    )]
+    public function player(#[CurrentUser] DiscordUser $visitor, string $discordId, ?string $slug = null): Response
     {
         // your own profile IS your collection page: one page, not two
         if ($visitor->getDiscordId() === $discordId) {
-            return $this->redirectToRoute('collection');
+            return $this->redirectToRoute('collection', ['slug' => $slug]);
         }
 
         $profile = $this->discordUserRepository->find($discordId);
@@ -50,10 +59,27 @@ class LeaderboardController extends AbstractController
             throw $this->createNotFoundException(\sprintf('Unknown player "%s".', $discordId));
         }
 
+        $comparison = $this->profileComparisonService->compare($profile, $visitor);
+        $currentExtension = $this->resolveExtensionFilter($comparison, $slug);
+
         return $this->render('pages/player_profile.html.twig', [
             'profile' => $profile,
             'entry' => $this->leaderboardService->getEntryFor($profile),
-            'comparison' => $this->profileComparisonService->compare($profile, $visitor),
+            'comparison' => $comparison,
+            // grid and filter chips follow the extension actually rendered
+            'visible' => $this->profileComparisonService->restrictTo($comparison, $currentExtension),
+            'strip' => $this->stripBuilder->build($comparison->universes),
+            'currentExtension' => $currentExtension,
         ]);
+    }
+
+    private function resolveExtensionFilter(ProfileComparison $comparison, ?string $slug): ?Extension
+    {
+        if (null === $slug || '' === $slug) {
+            return null;
+        }
+
+        return $comparison->extensionBySlug($slug)
+            ?? throw $this->createNotFoundException(\sprintf('Unknown extension "%s".', $slug));
     }
 }

--- a/src/Dto/ProfileComparison.php
+++ b/src/Dto/ProfileComparison.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Dto;
 
+use App\Entity\Extension;
+
 /**
  * The whole published catalogue compared between a visited profile and its
  * visitor, universe by universe, with the global counters of the filter bar.
@@ -21,5 +23,47 @@ final readonly class ProfileComparison
         public int $visitorOnly,
         public int $missingBoth,
     ) {
+    }
+
+    /**
+     * Distinct published cards the visited profile owns — the numerator of the
+     * completion bar and the sum of the strip tiles.
+     */
+    public function owned(): int
+    {
+        return $this->common + $this->profileOnly;
+    }
+
+    public function completionPct(): int
+    {
+        return $this->total > 0 ? (int) round($this->owned() / $this->total * 100) : 0;
+    }
+
+    /**
+     * Resolves a universe filter against the comparison already built: no extra
+     * Doctrine lookup, and the caller turns a null into its own 404.
+     */
+    public function extensionBySlug(string $slug): ?Extension
+    {
+        return $this->findExtension(static fn (Extension $extension): bool => $extension->getSlug() === $slug);
+    }
+
+    public function extensionById(string $id): ?Extension
+    {
+        return $this->findExtension(static fn (Extension $extension): bool => ((string) $extension->getId()) === $id);
+    }
+
+    /**
+     * @param callable(Extension): bool $matches
+     */
+    private function findExtension(callable $matches): ?Extension
+    {
+        foreach ($this->universes as $universe) {
+            if ($matches($universe->extension)) {
+                return $universe->extension;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Dto/ProfileUniverseComparison.php
+++ b/src/Dto/ProfileUniverseComparison.php
@@ -25,4 +25,19 @@ final readonly class ProfileUniverseComparison
         public int $missingBoth,
     ) {
     }
+
+    /**
+     * What the visited profile owns in this universe: the cards shared with the
+     * visitor plus the ones only they hold. On your own page profileOnly is
+     * always 0, so the formula holds there too.
+     */
+    public function owned(): int
+    {
+        return $this->common + $this->profileOnly;
+    }
+
+    public function completionPct(): int
+    {
+        return $this->total > 0 ? (int) round($this->owned() / $this->total * 100) : 0;
+    }
 }

--- a/src/Repository/UserCardRepository.php
+++ b/src/Repository/UserCardRepository.php
@@ -8,7 +8,10 @@ use App\Entity\DiscordUser;
 use App\Entity\Extension;
 use App\Entity\UserCard;
 use App\Enum\Entity\CardRarityEnum;
+use App\Enum\Entity\CardStatusEnum;
+use App\Enum\Entity\ExtensionStatusEnum;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -111,6 +114,10 @@ class UserCardRepository extends ServiceEntityRepository
      * cards, total copies (holos included) and holo copies — a single grouped
      * query instead of one per player.
      *
+     * Scoped to the published catalogue, the same denominator the completion is
+     * computed against: an unpublished card counting toward completion made the
+     * leaderboard and the profile header disagree.
+     *
      * @return array<string, array{distinct: int, total: int, holo: int}> discord id => stats
      */
     public function aggregateOwnedByUser(): array
@@ -125,7 +132,12 @@ class UserCardRepository extends ServiceEntityRepository
                 'COALESCE(SUM(uc.holoQuantity), 0) AS holoCount',
             )
             ->join('uc.card', 'c')
+            ->join('c.extension', 'e')
             ->andWhere('uc.quantity > 0 OR uc.holoQuantity > 0')
+            ->andWhere('c.status = :cardStatus')
+            ->andWhere('e.status = :extensionStatus')
+            ->setParameter('cardStatus', CardStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
+            ->setParameter('extensionStatus', ExtensionStatusEnum::PUBLISHED->value, ParameterType::INTEGER)
             ->groupBy('uc.discordUser')
             ->getQuery()
             ->getResult()

--- a/src/Service/Collection/CompletionStripBuilder.php
+++ b/src/Service/Collection/CompletionStripBuilder.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service\Collection;
+
+use App\Dto\ProfileUniverseComparison;
+use App\Entity\Extension;
+use App\Repository\CardRepository;
+
+/**
+ * The « complétion par univers » strip, shared by « Ma collection » and the
+ * public player profiles: one tile per universe, its owner's completion, and
+ * the artwork used as a background when the extension has no uploaded image.
+ */
+final readonly class CompletionStripBuilder
+{
+    public function __construct(
+        private CardRepository $cardRepository,
+    ) {
+    }
+
+    /**
+     * @param list<ProfileUniverseComparison> $universes
+     *
+     * @return list<array{extension: Extension, total: int, owned: int, percentage: int, coverImage: string|null}>
+     */
+    public function build(array $universes): array
+    {
+        $coverImages = $this->cardRepository->findCoverImageNamesByExtension();
+
+        return array_map(static fn (ProfileUniverseComparison $universe): array => [
+            'extension' => $universe->extension,
+            'total' => $universe->total,
+            'owned' => $universe->owned(),
+            'percentage' => $universe->completionPct(),
+            'coverImage' => $coverImages[(string) $universe->extension->getId()] ?? null,
+        ], $universes);
+    }
+}

--- a/src/Service/Leaderboard/ProfileComparisonService.php
+++ b/src/Service/Leaderboard/ProfileComparisonService.php
@@ -8,6 +8,7 @@ use App\Dto\ProfileCardComparison;
 use App\Dto\ProfileComparison;
 use App\Dto\ProfileUniverseComparison;
 use App\Entity\DiscordUser;
+use App\Entity\Extension;
 use App\Entity\UserCard;
 use App\Enum\ProfileCardStateEnum;
 use App\Repository\CardRepository;
@@ -97,6 +98,41 @@ final readonly class ProfileComparisonService
             visitorOnly: $totals['visitorOnly'],
             missingBoth: $totals['missingBoth'],
         );
+    }
+
+    /**
+     * The same comparison narrowed to a single universe: the grid and the filter
+     * counters must agree with what is actually rendered. A null extension is
+     * the unfiltered comparison, returned as is.
+     */
+    public function restrictTo(ProfileComparison $comparison, ?Extension $extension): ProfileComparison
+    {
+        if (!$extension instanceof Extension) {
+            return $comparison;
+        }
+
+        $universes = array_values(array_filter(
+            $comparison->universes,
+            static fn (ProfileUniverseComparison $universe): bool => $universe->extension->getId() === $extension->getId(),
+        ));
+
+        return new ProfileComparison(
+            universes: $universes,
+            total: $this->sum($universes, static fn (ProfileUniverseComparison $u): int => $u->total),
+            common: $this->sum($universes, static fn (ProfileUniverseComparison $u): int => $u->common),
+            profileOnly: $this->sum($universes, static fn (ProfileUniverseComparison $u): int => $u->profileOnly),
+            visitorOnly: $this->sum($universes, static fn (ProfileUniverseComparison $u): int => $u->visitorOnly),
+            missingBoth: $this->sum($universes, static fn (ProfileUniverseComparison $u): int => $u->missingBoth),
+        );
+    }
+
+    /**
+     * @param list<ProfileUniverseComparison>          $universes
+     * @param callable(ProfileUniverseComparison): int $counter
+     */
+    private function sum(array $universes, callable $counter): int
+    {
+        return array_sum(array_map($counter, $universes));
     }
 
     private function resolveState(bool $profileOwns, bool $visitorOwns): ProfileCardStateEnum

--- a/templates/pages/collection.html.twig
+++ b/templates/pages/collection.html.twig
@@ -25,11 +25,11 @@
                     <div class="mt-4 max-w-md" data-testid="global-completion">
                         <div class="chip-mono mb-1 flex justify-between text-ink-muted">
                             <span>Complétion</span>
-                            <span>{{ ownedTotalDistinct }} / {{ totalPublished }} cartes · {{ completionPct }}%</span>
+                            <span>{{ comparison.owned }} / {{ comparison.total }} cartes · {{ comparison.completionPct }}%</span>
                         </div>
                         <div class="h-2 border border-hairline bg-surface">
                             <div class="h-full bg-gradient-to-r from-primary to-magenta shadow-[0_0_10px_#a435f0]"
-                                 style="width: {{ completionPct }}%;"></div>
+                                 style="width: {{ comparison.completionPct }}%;"></div>
                         </div>
                     </div>
 
@@ -66,79 +66,19 @@
             </div>
         </section>
 
-        {# ----------------------------------------- Complétion par univers #}
-        <section class="border-b border-hairline px-6 py-8 lg:px-12">
-            <div class="mx-auto max-w-7xl" data-controller="carousel">
-                <div class="flex items-center justify-between">
-                    <p class="eyebrow">Complétion par univers</p>
-                    <div class="flex gap-1.5">
-                        <button type="button" data-action="carousel#prev" aria-label="Univers précédents"
-                                class="border border-hairline px-3 py-1 font-mono text-sm text-ink-muted transition-colors hover:border-primary hover:text-primary">◂</button>
-                        <button type="button" data-action="carousel#next" aria-label="Univers suivants"
-                                class="border border-hairline px-3 py-1 font-mono text-sm text-ink-muted transition-colors hover:border-primary hover:text-primary">▸</button>
-                    </div>
-                </div>
-
-                {# Tri par complétion décroissante : les univers les plus avancés en tête,
-                   la traîne des 0% (alphabétique) défile hors champ #}
-                <div class="carousel-track -mx-5 mt-4 flex snap-x gap-3 overflow-x-auto scroll-px-5 px-5 py-1"
-                     data-carousel-target="track"
-                     data-action="wheel->carousel#wheel:!passive"
-                     data-testid="completion-strip">
-                    {# Tuile « Tout » : retour à la collection complète + complétion globale #}
-                    <a href="{{ path('collection') }}"
-                       {{ currentExtension is null ? 'data-carousel-active' }}
-                       class="group relative h-36 w-44 shrink-0 snap-start overflow-hidden border bg-surface {{ currentExtension is null ? 'border-primary shadow-[0_0_14px_#a435f055]' : 'border-hairline hover:border-primary/60' }}">
-                        <div class="absolute inset-0 bg-gradient-to-br from-primary/35 via-[#2a0f44] to-magenta/40" aria-hidden="true"></div>
-                        <div class="absolute inset-0 bg-gradient-to-b from-black/60 via-black/20 to-black/90" aria-hidden="true"></div>
-
-                        <p class="absolute inset-x-3 top-2.5 truncate font-display text-[13px] font-bold uppercase leading-tight text-white">Tout</p>
-                        <div class="absolute inset-x-3 bottom-2.5">
-                            <p class="font-display text-3xl font-bold tracking-[-0.04em] text-primary [text-shadow:0_0_14px_#a435f077]">{{ completionPct }}%</p>
-                            <div class="mt-1.5 h-1 bg-white/15">
-                                <div class="h-full bg-gradient-to-r from-primary to-magenta" style="width: {{ completionPct }}%;"></div>
-                            </div>
-                            <p class="chip-mono mt-1.5 text-white/70">{{ ownedTotalDistinct }}/{{ totalPublished }} cartes</p>
-                        </div>
-                    </a>
-                    {% for universe in universes|sort((a, b) => (b.percentage - a.percentage) ?: (a.extension.name < b.extension.name ? -1 : 1)) %}
-                        {% set isActive = currentExtension is not null and currentExtension.id == universe.extension.id %}
-                        <a href="{{ path('collection', { slug: universe.extension.slug }) }}"
-                           {{ isActive ? 'data-carousel-active' }}
-                           class="group relative h-36 w-44 shrink-0 snap-start overflow-hidden border bg-surface {{ isActive ? 'border-primary shadow-[0_0_14px_#a435f055]' : 'border-hairline hover:border-primary/60' }}">
-                            {# fond de tuile : image uploadée de l'extension, sinon l'artwork de sa
-                               carte la plus rare, sinon le gradient seul (aussi le repli si 404) #}
-                            <div class="absolute inset-0 bg-gradient-to-br from-[#2a0f44] via-[#7a1f9c] to-magenta opacity-50" aria-hidden="true"></div>
-                            {% set coverUrl = universe.extension.imageName
-                                ? vich_uploader_asset(universe.extension)
-                                : (universe.coverImage ? asset('uploads/cards/' ~ universe.coverImage)) %}
-                            {% if coverUrl %}
-                                <img src="{{ coverUrl }}" alt="" loading="lazy" onerror="this.remove()"
-                                     class="absolute inset-0 h-full w-full object-cover object-top opacity-60 transition-opacity duration-300 group-hover:opacity-90">
-                            {% endif %}
-                            <div class="absolute inset-0 bg-gradient-to-b from-black/60 via-black/20 to-black/90" aria-hidden="true"></div>
-
-                            <p class="absolute inset-x-3 top-2.5 truncate font-display text-[13px] font-bold uppercase leading-tight text-white"
-                               title="{{ universe.extension.name }}">
-                                {{ universe.extension.name }}
-                            </p>
-                            <div class="absolute inset-x-3 bottom-2.5">
-                                <p class="font-display text-3xl font-bold tracking-[-0.04em] text-primary [text-shadow:0_0_14px_#a435f077]">{{ universe.percentage }}%</p>
-                                <div class="mt-1.5 h-1 bg-white/15">
-                                    <div class="h-full bg-gradient-to-r from-primary to-magenta" style="width: {{ universe.percentage }}%;"></div>
-                                </div>
-                                <p class="chip-mono mt-1.5 text-white/70">{{ universe.owned }}/{{ universe.total }} cartes</p>
-                            </div>
-                        </a>
-                    {% endfor %}
-                </div>
-            </div>
-        </section>
+        {{ include('parts/_completion_strip.html.twig', {
+            strip: strip,
+            currentExtension: currentExtension,
+            route: 'collection',
+            owned: comparison.owned,
+            total: comparison.total,
+            percentage: comparison.completionPct,
+        }) }}
 
         {# ---------------------------------------------------------- Grille #}
         <section class="px-6 pb-24 pt-8 lg:px-12" data-controller="profile-filter">
             <div class="mx-auto max-w-7xl">
-                {% if visibleOwned == 0 %}
+                {% if visible.owned == 0 %}
                     <div class="mb-10 border border-dashed border-hairline px-8 py-16 text-center text-ink-dim" data-testid="empty-state">
                         <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Vide.</p>
                         <p class="mt-3 text-sm">
@@ -148,12 +88,12 @@
                     </div>
                 {% endif %}
 
-                {% if visibleTotal > 0 %}
+                {% if visible.total > 0 %}
                     <div class="mb-8 flex flex-wrap items-center gap-2" role="group" aria-label="Filtrer la collection" data-testid="collection-filters">
                         {% for filter in [
-                            { state: 'all', label: 'Tout', count: visibleTotal },
-                            { state: 'common', label: 'Possédées', count: visibleOwned },
-                            { state: 'missing-both', label: 'Manquantes', count: visibleMissing },
+                            { state: 'all', label: 'Tout', count: visible.total },
+                            { state: 'common', label: 'Possédées', count: visible.owned },
+                            { state: 'missing-both', label: 'Manquantes', count: visible.missingBoth },
                         ] %}
                             {# un filtre à 0 n'a rien à montrer : il reste lisible mais inactif #}
                             <button type="button"
@@ -176,8 +116,10 @@
                 {# annonce le résultat du filtrage aux lecteurs d'écran #}
                 <p class="sr-only" aria-live="polite" data-profile-filter-target="status"></p>
 
-                {% for universe in visibleUniverses %}
+                {% for universe in visible.universes %}
                     <div class="mb-12" data-profile-filter-target="universe" data-testid="collection-universe">
+                        {# deux compteurs seulement : ils tiennent sur la ligne du titre,
+                           et repassent dessous d'eux-mêmes quand la place manque #}
                         <div class="flex flex-wrap items-baseline gap-x-4 gap-y-1">
                             <h2 class="font-display text-sm font-bold uppercase tracking-[.1em] text-ink-strong">
                                 <a href="{{ path('universes_show', { slug: universe.extension.slug }) }}"
@@ -189,14 +131,13 @@
                                   data-testid="universe-count">
                                 {{ universe.total }} carte{{ universe.total > 1 ? 's' }}
                             </span>
-                        </div>
-
-                        {# compteurs du catalogue complet : estompés dès qu'un filtre restreint la grille #}
-                        <div class="chip-mono mt-2 flex flex-wrap gap-x-5 gap-y-1.5 text-ink-muted transition-opacity"
-                             data-profile-filter-target="counters"
-                             data-testid="universe-compare">
-                            <span>◈ {{ universe.common }} possédée{{ universe.common > 1 ? 's' }}</span>
-                            <span>✕ {{ universe.missingBoth }} manquante{{ universe.missingBoth > 1 ? 's' }}</span>
+                            {# compteurs du catalogue complet : estompés dès qu'un filtre restreint la grille #}
+                            <span class="chip-mono flex flex-wrap gap-x-5 gap-y-1.5 text-ink-muted transition-opacity"
+                                  data-profile-filter-target="counters"
+                                  data-testid="universe-compare">
+                                <span>◈ {{ universe.owned }} possédée{{ universe.owned > 1 ? 's' }}</span>
+                                <span>✕ {{ universe.missingBoth }} manquante{{ universe.missingBoth > 1 ? 's' }}</span>
+                            </span>
                         </div>
 
                         <div class="mt-6 grid grid-cols-2 gap-6 md:grid-cols-3 xl:grid-cols-5" data-testid="collection-grid">

--- a/templates/pages/player_profile.html.twig
+++ b/templates/pages/player_profile.html.twig
@@ -26,11 +26,11 @@
                     <div class="mt-4 max-w-md" data-testid="profile-completion">
                         <div class="chip-mono mb-1 flex justify-between text-ink-muted">
                             <span>Complétion</span>
-                            <span>{{ entry.distinctCards }} cartes distinctes · {{ entry.completionPct }}%</span>
+                            <span>{{ comparison.owned }} / {{ comparison.total }} cartes · {{ comparison.completionPct }}%</span>
                         </div>
                         <div class="h-2 border border-hairline bg-surface">
                             <div class="h-full bg-gradient-to-r from-primary to-magenta shadow-[0_0_10px_#a435f0]"
-                                 style="width: {{ entry.completionPct }}%;"></div>
+                                 style="width: {{ comparison.completionPct }}%;"></div>
                         </div>
                     </div>
 
@@ -60,27 +60,37 @@
             </div>
         </section>
 
+        {{ include('parts/_completion_strip.html.twig', {
+            strip: strip,
+            currentExtension: currentExtension,
+            route: 'leaderboard_player',
+            routeParams: { discordId: profile.discordId },
+            owned: comparison.owned,
+            total: comparison.total,
+            percentage: comparison.completionPct,
+        }) }}
+
         {# --------------------------------------- Collection comparée par univers #}
         <section class="px-6 pb-24 pt-8 lg:px-12" data-controller="profile-filter">
             <div class="mx-auto max-w-7xl">
-                {% if entry.distinctCards == 0 %}
+                {% if comparison.owned == 0 %}
                     <div class="mb-10 border border-dashed border-hairline px-8 py-16 text-center text-ink-dim" data-testid="empty-state">
                         <p class="font-display text-lg font-bold uppercase tracking-[.15em]">Collection vide.</p>
                         <p class="mt-3 text-sm">Ce joueur n'a encore aucune carte.</p>
                     </div>
                 {% endif %}
 
-                {% if comparison.total > 0 %}
+                {% if visible.total > 0 %}
                     {# pseudo tronqué : un pseudo Discord long ferait déborder la barre en mobile #}
                     {% set shortName = profile.username|slice(0, 12) ~ (profile.username|length > 12 ? '…' : '') %}
 
                     <div class="mb-8 flex flex-wrap items-center gap-2" role="group" aria-label="Filtrer la collection" data-testid="profile-filters">
                         {% for filter in [
-                            { state: 'all', label: 'Tout', count: comparison.total },
-                            { state: 'common', label: 'En commun', count: comparison.common },
-                            { state: 'profile-only', label: 'Seulement ' ~ shortName, count: comparison.profileOnly },
-                            { state: 'visitor-only', label: 'Seulement toi', count: comparison.visitorOnly },
-                            { state: 'missing-both', label: 'Manquantes aux deux', count: comparison.missingBoth },
+                            { state: 'all', label: 'Tout', count: visible.total },
+                            { state: 'common', label: 'En commun', count: visible.common },
+                            { state: 'profile-only', label: 'Seulement ' ~ shortName, count: visible.profileOnly },
+                            { state: 'visitor-only', label: 'Seulement toi', count: visible.visitorOnly },
+                            { state: 'missing-both', label: 'Manquantes aux deux', count: visible.missingBoth },
                         ] %}
                             {# un filtre à 0 n'a rien à montrer : il reste lisible mais inactif #}
                             <button type="button"
@@ -104,11 +114,12 @@
                 {# annonce le résultat du filtrage aux lecteurs d'écran #}
                 <p class="sr-only" aria-live="polite" data-profile-filter-target="status"></p>
 
-                {% for universe in comparison.universes %}
+                {% for universe in visible.universes %}
                     <div class="mb-12" data-profile-filter-target="universe" data-testid="profile-universe">
                         <div class="flex flex-wrap items-baseline gap-x-4 gap-y-1">
                             <h2 class="font-display text-sm font-bold uppercase tracking-[.1em] text-ink-strong">
-                                {{ universe.extension.name }}
+                                <a href="{{ path('universes_show', { slug: universe.extension.slug }) }}"
+                                   class="transition-colors hover:text-primary">{{ universe.extension.name }}</a>
                             </h2>
                             <span class="chip-mono text-ink-muted"
                                   data-profile-filter-target="count"

--- a/templates/parts/_completion_strip.html.twig
+++ b/templates/parts/_completion_strip.html.twig
@@ -1,0 +1,71 @@
+{# Bandeau « complétion par univers », partagé par ma collection et les profils
+   joueur. Paramètres : strip (tuiles), currentExtension, route + routeParams du
+   lien de chaque tuile, owned/total/percentage pour la tuile « Tout ». #}
+{% set routeParams = routeParams|default({}) %}
+<section class="border-b border-hairline px-6 py-8 lg:px-12">
+    <div class="mx-auto max-w-7xl" data-controller="carousel">
+        <div class="flex items-center justify-between">
+            <p class="eyebrow">Complétion par univers</p>
+            <div class="flex gap-1.5">
+                <button type="button" data-action="carousel#prev" aria-label="Univers précédents"
+                        class="border border-hairline px-3 py-1 font-mono text-sm text-ink-muted transition-colors hover:border-primary hover:text-primary">◂</button>
+                <button type="button" data-action="carousel#next" aria-label="Univers suivants"
+                        class="border border-hairline px-3 py-1 font-mono text-sm text-ink-muted transition-colors hover:border-primary hover:text-primary">▸</button>
+            </div>
+        </div>
+
+        {# Tri par complétion décroissante : les univers les plus avancés en tête,
+           la traîne des 0% (alphabétique) défile hors champ #}
+        <div class="carousel-track -mx-5 mt-4 flex snap-x gap-3 overflow-x-auto scroll-px-5 px-5 py-1"
+             data-carousel-target="track"
+             data-action="wheel->carousel#wheel:!passive"
+             data-testid="completion-strip">
+            {# Tuile « Tout » : retour au catalogue complet + complétion globale #}
+            <a href="{{ path(route, routeParams) }}"
+               {{ currentExtension is null ? 'data-carousel-active' }}
+               class="group relative h-36 w-44 shrink-0 snap-start overflow-hidden border bg-surface {{ currentExtension is null ? 'border-primary shadow-[0_0_14px_#a435f055]' : 'border-hairline hover:border-primary/60' }}">
+                <div class="absolute inset-0 bg-gradient-to-br from-primary/35 via-[#2a0f44] to-magenta/40" aria-hidden="true"></div>
+                <div class="absolute inset-0 bg-gradient-to-b from-black/60 via-black/20 to-black/90" aria-hidden="true"></div>
+
+                <p class="absolute inset-x-3 top-2.5 truncate font-display text-[13px] font-bold uppercase leading-tight text-white">Tout</p>
+                <div class="absolute inset-x-3 bottom-2.5">
+                    <p class="font-display text-3xl font-bold tracking-[-0.04em] text-primary [text-shadow:0_0_14px_#a435f077]">{{ percentage }}%</p>
+                    <div class="mt-1.5 h-1 bg-white/15">
+                        <div class="h-full bg-gradient-to-r from-primary to-magenta" style="width: {{ percentage }}%;"></div>
+                    </div>
+                    <p class="chip-mono mt-1.5 text-white/70">{{ owned }}/{{ total }} cartes</p>
+                </div>
+            </a>
+            {% for universe in strip|sort((a, b) => (b.percentage - a.percentage) ?: (a.extension.name < b.extension.name ? -1 : 1)) %}
+                {% set isActive = currentExtension is not null and currentExtension.id == universe.extension.id %}
+                <a href="{{ path(route, routeParams|merge({ slug: universe.extension.slug })) }}"
+                   {{ isActive ? 'data-carousel-active' }}
+                   class="group relative h-36 w-44 shrink-0 snap-start overflow-hidden border bg-surface {{ isActive ? 'border-primary shadow-[0_0_14px_#a435f055]' : 'border-hairline hover:border-primary/60' }}">
+                    {# fond de tuile : image uploadée de l'extension, sinon l'artwork de sa
+                       carte la plus rare, sinon le gradient seul (aussi le repli si 404) #}
+                    <div class="absolute inset-0 bg-gradient-to-br from-[#2a0f44] via-[#7a1f9c] to-magenta opacity-50" aria-hidden="true"></div>
+                    {% set coverUrl = universe.extension.imageName
+                        ? vich_uploader_asset(universe.extension)
+                        : (universe.coverImage ? asset('uploads/cards/' ~ universe.coverImage)) %}
+                    {% if coverUrl %}
+                        <img src="{{ coverUrl }}" alt="" loading="lazy" onerror="this.remove()"
+                             class="absolute inset-0 h-full w-full object-cover object-top opacity-60 transition-opacity duration-300 group-hover:opacity-90">
+                    {% endif %}
+                    <div class="absolute inset-0 bg-gradient-to-b from-black/60 via-black/20 to-black/90" aria-hidden="true"></div>
+
+                    <p class="absolute inset-x-3 top-2.5 truncate font-display text-[13px] font-bold uppercase leading-tight text-white"
+                       title="{{ universe.extension.name }}">
+                        {{ universe.extension.name }}
+                    </p>
+                    <div class="absolute inset-x-3 bottom-2.5">
+                        <p class="font-display text-3xl font-bold tracking-[-0.04em] text-primary [text-shadow:0_0_14px_#a435f077]">{{ universe.percentage }}%</p>
+                        <div class="mt-1.5 h-1 bg-white/15">
+                            <div class="h-full bg-gradient-to-r from-primary to-magenta" style="width: {{ universe.percentage }}%;"></div>
+                        </div>
+                        <p class="chip-mono mt-1.5 text-white/70">{{ universe.owned }}/{{ universe.total }} cartes</p>
+                    </div>
+                </a>
+            {% endfor %}
+        </div>
+    </div>
+</section>

--- a/tests/Functional/PlayerProfileTest.php
+++ b/tests/Functional/PlayerProfileTest.php
@@ -63,7 +63,11 @@ final class PlayerProfileTest extends WebTestCase
         self::assertResponseIsSuccessful();
         $this->assertStringContainsString($this->rival->getUsername(), $crawler->filter('h1')->text());
         $this->assertStringContainsString('joueur depuis', $crawler->filter('main')->text());
-        $this->assertStringContainsString('3 cartes distinctes', $crawler->filter('[data-testid="profile-completion"]')->text());
+        // completion reads as a fraction of the published catalogue, like « Ma collection »
+        $this->assertMatchesRegularExpression(
+            '#\b3 / \d+ cartes · \d+%#',
+            $crawler->filter('[data-testid="profile-completion"]')->text(),
+        );
 
         $stats = $crawler->filter('[data-testid="profile-stats"]')->text();
         $this->assertStringContainsString('4 cartes au total', $stats);
@@ -205,6 +209,57 @@ final class PlayerProfileTest extends WebTestCase
         self::assertResponseRedirects('/collection');
     }
 
+    public function testCompletionStripShowsWhatTheProfileOwnsPerUniverse(): void
+    {
+        $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
+
+        self::assertResponseIsSuccessful();
+        $tile = $crawler->filter('[data-testid="completion-strip"] > a')->reduce(
+            fn (Crawler $node): bool => str_contains($node->text(), $this->extension->getName()),
+        );
+
+        $this->assertCount(1, $tile);
+        // the rival holds 3 of the 5 published cards — their completion, not what we share
+        $this->assertStringContainsString('3/5 cartes', $tile->text());
+        $this->assertStringContainsString('60%', $tile->text());
+    }
+
+    public function testStripTileNarrowsTheProfileToOneUniverse(): void
+    {
+        $crawler = $this->client->request('GET', \sprintf('/joueur/%s/%s', $this->rival->getDiscordId(), $this->extension->getSlug()));
+
+        self::assertResponseIsSuccessful();
+        $blocks = $crawler->filter('[data-testid="profile-universe"]');
+        $this->assertCount(1, $blocks);
+        $this->assertStringContainsString($this->extension->getName(), $blocks->filter('h2')->text());
+
+        // the active strip tile is the filtered universe
+        $this->assertStringContainsString(
+            $this->extension->getName(),
+            $crawler->filter('[data-testid="completion-strip"] a[data-carousel-active]')->text(),
+        );
+
+        // the filter counters follow the universe rendered, not the whole catalogue
+        $counts = $crawler->filter('[data-testid="profile-filters"] button')->each(
+            static fn (Crawler $node): string => (string) $node->filter('.filter-chip__count')->text(),
+        );
+        $this->assertSame(['5', '1', '2', '1', '1'], $counts);
+    }
+
+    public function testUnknownUniverseOnAProfileIsNotFound(): void
+    {
+        $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId() . '/this-universe-does-not-exist');
+
+        self::assertResponseStatusCodeSame(404);
+    }
+
+    public function testOwnProfileRedirectKeepsTheUniverseFilter(): void
+    {
+        $this->client->request('GET', \sprintf('/joueur/%s/%s', $this->user->getDiscordId(), $this->extension->getSlug()));
+
+        self::assertResponseRedirects('/collection/' . $this->extension->getSlug());
+    }
+
     public function testProfileLinksBackToTheVisitorsOwnCollection(): void
     {
         $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
@@ -271,6 +326,9 @@ final class PlayerProfileTest extends WebTestCase
         ;
         $hiddenCard->setImageName('default_card.png');
         $this->entityManager->persist($hiddenCard);
+        // owned copies of unpublished cards must not inflate any public count
+        $this->giveCard($this->rival, $draftCard, quantity: 5, holoQuantity: 2);
+        $this->giveCard($this->rival, $hiddenCard);
         $this->entityManager->flush();
 
         $crawler = $this->client->request('GET', '/joueur/' . $this->rival->getDiscordId());
@@ -278,6 +336,15 @@ final class PlayerProfileTest extends WebTestCase
         self::assertResponseIsSuccessful();
         // the draft card is not part of the published set of its (published) universe
         $this->assertStringContainsString('5 cartes', $this->universeBlock($crawler)->filter('[data-testid="universe-count"]')->text());
+
+        // completion and stats stay on the published catalogue: still 3 distinct cards
+        $this->assertMatchesRegularExpression(
+            '#\b3 / \d+ cartes#',
+            $crawler->filter('[data-testid="profile-completion"]')->text(),
+        );
+        $stats = $crawler->filter('[data-testid="profile-stats"]')->text();
+        $this->assertStringContainsString('4 cartes au total', $stats);
+        $this->assertStringContainsString('1 holo', $stats);
 
         $html = (string) $this->client->getResponse()->getContent();
         $this->assertStringNotContainsString($draftCard->getName(), $html);


### PR DESCRIPTION
Suite de #160, sur tes retours.

## 1. Bandeau d'univers sur les pages des autres joueurs

Il manquait complètement. Il est maintenant extrait dans `parts/_completion_strip.html.twig`, alimenté par un `CompletionStripBuilder` : ma collection et les profils joueur le partagent au lieu de le dupliquer.

- les tuiles montrent **la complétion du joueur visité** (`common + profileOnly`), pas ce que vous avez en commun
- cliquer une tuile filtre son profil sur cet univers : nouvelle route `/joueur/{discordId}/{slug}`
- les chips de filtre (`Tout` / `En commun` / `Seulement lui` / `Seulement toi` / `Manquantes aux deux`) suivent la grille réellement rendue, via `ProfileComparisonService::restrictTo()`
- le titre d'univers pointe vers `/univers/{slug}`, comme sur ma collection
- `/joueur/{moi}/{slug}` redirige vers `/collection/{slug}` — le filtre est conservé

## 2. Format de complétion aligné

Le hero du profil affichait `93 cartes distinctes · 47 %` là où ma collection affiche `151 / 197 cartes · 77 %`. Les deux disent maintenant `X / Y cartes · Z %`.

## 3. Compteurs d'univers inline sur ma collection

`◈ 9 possédées ✕ 1 manquante` remonte sur la ligne du titre (`BLEACH  10 cartes  ◈ 9 possédées  ✕ 1 manquante`). Le `flex-wrap` les fait repasser dessous quand la place manque. La page profil garde ses 4 compteurs sur leur propre ligne, elle s'affichait déjà bien.

## 4. Fix trouvé au passage

En posant le nouveau format de complétion, le classement affichait **93** et le profil **92** pour le même joueur. `UserCardRepository::aggregateOwnedByUser()` ne filtrait pas sur le statut publié : une carte en brouillon comptait dans la complétion et dans le total de cartes, alors que le dénominateur, lui, ne compte que le catalogue publié. Corrigé, avec un test qui donne des exemplaires de cartes non publiées à un joueur et vérifie qu'aucun compteur public ne bouge.

Effet de bord visible en dev : Barlito passe de 501 à 493 cartes au total et de 28 à 27 holos — les 8 exemplaires en trop étaient sur des cartes non publiées.

## Tests

- `PlayerProfileTest` : +4 tests (bandeau, filtre par univers, univers inconnu → 404, redirection self avec slug) et le test « contenu non publié » étendu aux compteurs du hero
- suite complète : **422 tests / 2939 assertions** ✅ · `make quality` ✅
- vérif Playwright : bandeau et filtre OK sur profil, compteurs bien inline sur ma collection, cohérence classement ↔ profil vérifiée sur le top 3, 0 erreur console, 0 débordement mobile

---

Note : la branche `feat/phase-14-fusion-collection-profil` est restée sur le remote après le merge de #160, je n'ai pas les droits pour la supprimer.