### PR TITLE
feat(boosters): chance de carte unique par slot

### DIFF
--- a/fixtures/dev/Booster.yaml
+++ b/fixtures/dev/Booster.yaml
@@ -1,5 +1,6 @@
 # Un booster par univers publié. Le dernier n'est pas réclamable :
 # il se distribue par code ou par récompense de streak.
+# Le dernier slot porte la chance carte unique (100 pour 10 000 = 1 %).
 App\Entity\Booster:
     booster_cyberpunk:
         name: 'Pack Cyberpunk 2077'
@@ -10,7 +11,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_kda:
         name: 'Pack K/DA'
         extension: '@extension_kda'
@@ -20,7 +21,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_w40k:
         name: 'Pack Warhammer 40K'
         extension: '@extension_w40k'
@@ -30,7 +31,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_bleach:
         name: 'Pack Bleach'
         extension: '@extension_bleach'
@@ -40,7 +41,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_magic:
         name: 'Pack Magic'
         extension: '@extension_magic'
@@ -50,7 +51,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_cosmos:
         name: 'Pack Cosmos'
         extension: '@extension_cosmos'
@@ -60,7 +61,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_dystopie:
         name: 'Pack Dystopie'
         extension: '@extension_dystopie'
@@ -70,7 +71,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_eldritch:
         name: 'Pack Cultes Anciens'
         extension: '@extension_eldritch'
@@ -80,7 +81,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_sot:
         name: 'Pack Storm of Time'
         extension: '@extension_sot'
@@ -90,7 +91,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_velirp:
         name: 'Pack VeliRP'
         extension: '@extension_velirp'
@@ -100,7 +101,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_psyche:
         name: 'Pack Psyché'
         extension: '@extension_psyche'
@@ -110,7 +111,7 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }
     booster_origines:
         name: 'Pack Origines'
         extension: '@extension_origines'
@@ -121,4 +122,4 @@ App\Entity\Booster:
             - { rarities: { common: 100 }, holoChance: 5 }
             - { rarities: { common: 70, uncommon: 30 }, holoChance: 15 }
             - { rarities: { uncommon: 70, rare: 30 }, holoChance: 30 }
-            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60 }
+            - { rarities: { rare: 80, legendary: 20 }, holoChance: 60, uniqueChance: 100 }

--- a/src/Controller/Admin/BoosterCrudController.php
+++ b/src/Controller/Admin/BoosterCrudController.php
@@ -151,9 +151,18 @@ class BoosterCrudController extends AbstractGuardedCrudController
         }
 
         $holoChance = $slot['holoChance'] ?? 0;
+        $uniqueChance = $slot['uniqueChance'] ?? 0;
         $summary = implode(' · ', $parts);
 
-        return \is_int($holoChance) && $holoChance > 0 ? $summary . ' — holo ' . $holoChance . ' %' : $summary;
+        if (\is_int($holoChance) && $holoChance > 0) {
+            $summary .= ' — holo ' . $holoChance . ' %';
+        }
+
+        if (\is_int($uniqueChance) && $uniqueChance > 0) {
+            $summary .= ' — unique ' . $this->formatUniqueRate($uniqueChance) . ' %';
+        }
+
+        return $summary;
     }
 
     /**
@@ -182,7 +191,7 @@ class BoosterCrudController extends AbstractGuardedCrudController
     }
 
     /**
-     * @return array{compact: bool, unavailable: list<string>, slots: list<array{rates: array<string, float>, weights: array<string, int>, holoChance: int}>}
+     * @return array{compact: bool, unavailable: list<string>, slots: list<array{rates: array<string, float>, weights: array<string, int>, holoChance: int, uniqueRate: string}>}
      */
     private function dropRatesData(mixed $entity, bool $compact): array
     {
@@ -198,6 +207,9 @@ class BoosterCrudController extends AbstractGuardedCrudController
                 'rates' => $slot['rates'],
                 'weights' => $rarityRates[$index]['rarities'] ?? [],
                 'holoChance' => $slot['holoChance'],
+                // '' when the slot cannot yield a unique: the template only
+                // prints the marker for a configured chance
+                'uniqueRate' => $slot['uniqueChance'] > 0 ? $this->formatUniqueRate($slot['uniqueChance']) : '',
             ];
         }
 
@@ -214,6 +226,15 @@ class BoosterCrudController extends AbstractGuardedCrudController
     private function formatPercentage(float $percentage): string
     {
         return rtrim(rtrim(number_format($percentage, 1, ',', ''), '0'), ',');
+    }
+
+    /**
+     * A uniqueChance setting as a percentage, keeping its 2 decimals (0,01 %
+     * is a meaningful 1/1 rate, unlike for the rarity weights).
+     */
+    private function formatUniqueRate(int $uniqueChance): string
+    {
+        return rtrim(rtrim(number_format(Booster::toUniquePercentage($uniqueChance), 2, ',', ''), '0'), ',');
     }
 
     #[\Override]

--- a/src/Entity/Booster.php
+++ b/src/Entity/Booster.php
@@ -22,6 +22,12 @@ class Booster implements \Stringable
     use TimestampableEntity;
 
     /**
+     * Denominator of a slot's uniqueChance: per 10 000, the smallest non-zero
+     * rate is 0,01 % instead of the 1 % a percentage would floor it at.
+     */
+    public const int UNIQUE_CHANCE_SCALE = 10_000;
+
+    /**
      * Optional display name ("Pack Full Rare", named after its drop rates…);
      * null falls back to the extension name everywhere.
      */
@@ -39,12 +45,15 @@ class Booster implements \Stringable
 
     /**
      * One slot per card the booster yields. Each slot carries its own rarity
-     * weight map (keys are CardRarityEnum values) and its own holo chance
-     * (0-100 %) rolled independently for the card drawn in that slot.
-     * Example for a 2-card booster:
-     * [{rarities: {common: 100}, holoChance: 5}, {rarities: {common: 60, rare: 40}, holoChance: 30}].
+     * weight map (keys are CardRarityEnum values), its own holo chance
+     * (0-100 %) and its own one-of-one chance (uniqueChance, per
+     * UNIQUE_CHANCE_SCALE), all rolled independently for the card drawn in
+     * that slot. Example for a 2-card booster:
+     * [{rarities: {common: 100}, holoChance: 5}, {rarities: {common: 60, rare: 40}, holoChance: 30, uniqueChance: 25}].
      *
-     * @var list<array{rarities: array<string, int>, holoChance: int}>
+     * uniqueChance is optional: slots stored before the option existed read as 0.
+     *
+     * @var list<array{rarities: array<string, int>, holoChance: int, uniqueChance?: int}>
      */
     #[ValidRarityRates]
     #[ORM\Column(type: Types::JSON, options: ['default' => '[]'])]
@@ -98,7 +107,7 @@ class Booster implements \Stringable
     }
 
     /**
-     * @return list<array{rarities: array<string, int>, holoChance: int}>
+     * @return list<array{rarities: array<string, int>, holoChance: int, uniqueChance?: int}>
      */
     public function getRarityRates(): array
     {
@@ -110,7 +119,7 @@ class Booster implements \Stringable
      * slots with their original keys (0, 2, 3…) once a slot is deleted, and a
      * gapped array would be stored as a JSON object instead of a list.
      *
-     * @param array<array-key, array{rarities: array<string, int>, holoChance: int}> $rarityRates
+     * @param array<array-key, array{rarities: array<string, int>, holoChance: int, uniqueChance?: int}> $rarityRates
      */
     public function setRarityRates(array $rarityRates): static
     {
@@ -126,20 +135,36 @@ class Booster implements \Stringable
 
     /**
      * Player-facing drop rates: per slot, the rarity weights normalised to
-     * percentages (1 decimal) plus the slot's holo chance. Pure projection of
-     * rarityRates — nothing new is stored.
+     * percentages (1 decimal), the slot's holo chance and its one-of-one
+     * chance both as raw setting (uniqueChance) and as a percentage
+     * (uniqueRate). Pure projection of rarityRates — nothing new is stored.
      *
-     * @return list<array{rates: array<string, float>, holoChance: int}>
+     * @return list<array{rates: array<string, float>, holoChance: int, uniqueChance: int, uniqueRate: float}>
      */
     public function getDropRates(): array
     {
         $slots = [];
 
         foreach ($this->rarityRates as $slot) {
-            $slots[] = ['rates' => self::toPercentages($slot['rarities']), 'holoChance' => $slot['holoChance']];
+            $uniqueChance = $slot['uniqueChance'] ?? 0;
+            $slots[] = [
+                'rates' => self::toPercentages($slot['rarities']),
+                'holoChance' => $slot['holoChance'],
+                'uniqueChance' => $uniqueChance,
+                'uniqueRate' => self::toUniquePercentage($uniqueChance),
+            ];
         }
 
         return $slots;
+    }
+
+    /**
+     * A uniqueChance setting turned into the percentage the player reads:
+     * 25 per 10 000 = 0,25 %.
+     */
+    public static function toUniquePercentage(int $uniqueChance): float
+    {
+        return round($uniqueChance / self::UNIQUE_CHANCE_SCALE * 100, 2);
     }
 
     /**

--- a/src/Form/BoosterSlotType.php
+++ b/src/Form/BoosterSlotType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Form;
 
+use App\Entity\Booster;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -13,9 +14,9 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * One booster slot = one card the booster yields. The form data is the very
  * array stored in Booster::$rarityRates, so no JSON is ever typed by hand:
- * {rarities: {<rarity>: <weight>}, holoChance: <0-100>}.
+ * {rarities: {<rarity>: <weight>}, holoChance: <0-100>, uniqueChance: <0-10000>}.
  *
- * @extends AbstractType<array{rarities: array<string, int>, holoChance: int}>
+ * @extends AbstractType<array{rarities: array<string, int>, holoChance: int, uniqueChance: int}>
  */
 final class BoosterSlotType extends AbstractType
 {
@@ -46,6 +47,21 @@ final class BoosterSlotType extends AbstractType
                         notInRangeMessage: 'La chance holo doit être comprise entre {{ min }} et {{ max }}.',
                         min: 0,
                         max: 100,
+                    ),
+                ],
+            ])
+            ->add('uniqueChance', IntegerType::class, [
+                'label' => 'Chance carte unique (pour 10 000)',
+                'required' => false,
+                'empty_data' => '0',
+                'help' => 'Probabilité que ce slot sorte une carte unique 1/1 encore non réclamée, tirée à part du poids par rareté : 25 = 0,25 %. À 0, aucune 1/1 ne peut sortir de ce slot.',
+                'attr' => ['min' => 0, 'max' => Booster::UNIQUE_CHANCE_SCALE],
+                'constraints' => [
+                    new Assert\NotNull(message: 'Renseigne une chance unique entre 0 et ' . Booster::UNIQUE_CHANCE_SCALE . '.'),
+                    new Assert\Range(
+                        notInRangeMessage: 'La chance unique doit être comprise entre {{ min }} et {{ max }}.',
+                        min: 0,
+                        max: Booster::UNIQUE_CHANCE_SCALE,
                     ),
                 ],
             ])

--- a/src/Service/Booster/BoosterRarityAvailability.php
+++ b/src/Service/Booster/BoosterRarityAvailability.php
@@ -14,8 +14,8 @@ use App\Repository\CardRepository;
  * them. CardDrawer silently falls back to the nearest tier in that case, so
  * the back-office warns instead of letting the misconfiguration go unnoticed.
  *
- * Availability is read from the very pool the draw uses (published cards,
- * claimed one-of-ones excluded) and memoised per extension: an admin index
+ * Availability is read from the very pool the rarity roll uses (published
+ * cards, uniques excluded) and memoised per extension: an admin index
  * lists many boosters sharing a handful of extensions.
  */
 final class BoosterRarityAvailability
@@ -71,7 +71,11 @@ final class BoosterRarityAvailability
             $rarities = [];
 
             foreach ($this->cardRepository->findDrawablePool($extension) as $card) {
-                $rarities[$card->getRarity()->value] = true;
+                // uniques are drawn by their own chance, never by the rarity
+                // roll: a tier holding nothing but a 1/1 is unavailable
+                if (!$card->isUnique()) {
+                    $rarities[$card->getRarity()->value] = true;
+                }
             }
 
             $this->drawableRaritiesByExtension[$key] = array_keys($rarities);

--- a/src/Service/Booster/CardDrawer.php
+++ b/src/Service/Booster/CardDrawer.php
@@ -15,9 +15,14 @@ use App\Repository\CardRepository;
 use App\Service\Random\RandomService;
 
 /**
- * Weighted card draw. Each booster slot rolls a rarity from its weight map,
- * then picks a card uniformly among the published cards of that rarity in
- * the booster's extension.
+ * Weighted card draw. Each booster slot first rolls its one-of-one chance,
+ * then — unless a unique came out — rolls a rarity from its weight map and
+ * picks a card uniformly among the published NON-unique cards of that rarity
+ * in the booster's extension.
+ *
+ * Uniques are kept out of the rarity pool on purpose: their drop rate is the
+ * slot's uniqueChance and nothing else, instead of drifting with the number
+ * of cards published in their tier.
  */
 final readonly class CardDrawer
 {
@@ -45,9 +50,9 @@ final readonly class CardDrawer
             );
         }
 
-        $pool = $this->loadPool($booster->getExtension());
+        ['pool' => $pool, 'uniques' => $uniques] = $this->loadPool($booster->getExtension());
 
-        if ([] === $pool) {
+        if ([] === $pool && [] === $uniques) {
             throw new NoCardAvailableException(
                 \sprintf('Extension "%s" has no published card to draw from.', $booster->getExtension()->getName()),
                 'Ce booster n\'a aucune carte à tirer pour le moment, réessaie plus tard.',
@@ -57,15 +62,48 @@ final readonly class CardDrawer
         $drawnCards = [];
 
         foreach ($booster->getRarityRates() as $slot) {
-            $rarity = $this->resolveAvailableRarity($pool, $this->drawRarity($slot['rarities']));
-            $candidates = $pool[$rarity->value];
-            $card = $candidates[$this->randomService->getInt(0, \count($candidates) - 1)];
+            $uniqueIndex = $this->rollUnique($slot['uniqueChance'] ?? 0, $pool, $uniques);
+
+            if (null !== $uniqueIndex) {
+                // taken out of the local list so a second slot cannot land on
+                // the very same 1/1 (it would be swapped out at claim time anyway)
+                [$card] = array_splice($uniques, $uniqueIndex, 1);
+                $rarity = $card->getRarity();
+            } else {
+                $rarity = $this->resolveAvailableRarity($pool, $this->drawRarity($slot['rarities']));
+                $candidates = $pool[$rarity->value];
+                $card = $candidates[$this->randomService->getInt(0, \count($candidates) - 1)];
+            }
+
             $holo = $card->isAlwaysHolo() || $this->randomService->getInt(1, 100) <= $slot['holoChance'];
 
             $drawnCards[] = new DrawnCard($card, $rarity, $holo);
         }
 
         return $drawnCards;
+    }
+
+    /**
+     * Index of the unique this slot pulls, or null for a regular rarity draw.
+     *
+     * A slot left at 0 never touches the RNG here. An extension whose only
+     * drawable cards are uniques skips the chance roll — there is nothing
+     * else left to hand out.
+     *
+     * @param array<string, non-empty-list<Card>> $pool
+     * @param list<Card>                          $uniques
+     */
+    private function rollUnique(int $uniqueChance, array $pool, array $uniques): ?int
+    {
+        if ([] === $uniques) {
+            return null;
+        }
+
+        if ([] !== $pool && ($uniqueChance <= 0 || $this->randomService->getInt(1, Booster::UNIQUE_CHANCE_SCALE) > $uniqueChance)) {
+            return null;
+        }
+
+        return $this->randomService->getInt(0, \count($uniques) - 1);
     }
 
     /**
@@ -80,7 +118,7 @@ final readonly class CardDrawer
      */
     public function drawReplacement(Booster $booster, CardRarityEnum $rarity, bool $holo = false): DrawnCard
     {
-        $pool = $this->loadPool($booster->getExtension(), excludeUniques: true);
+        ['pool' => $pool] = $this->loadPool($booster->getExtension());
 
         if ([] === $pool) {
             throw new NoCardAvailableException(
@@ -97,25 +135,28 @@ final readonly class CardDrawer
     }
 
     /**
-     * Published cards of the extension grouped by rarity, EXCLUDING claimed
-     * one-of-one uniques (filtered in SQL). With $excludeUniques every unique
-     * card is dropped — used to build a replacement pool free of uniques.
+     * The drawable cards of the extension (published, claimed one-of-ones
+     * filtered in SQL), split in two: the rarity pool, which never holds a
+     * unique, and the unclaimed uniques the slots roll for separately.
      *
-     * @return array<string, non-empty-list<Card>>
+     * @return array{pool: array<string, non-empty-list<Card>>, uniques: list<Card>}
      */
-    private function loadPool(Extension $extension, bool $excludeUniques = false): array
+    private function loadPool(Extension $extension): array
     {
         $pool = [];
+        $uniques = [];
 
         foreach ($this->cardRepository->findDrawablePool($extension) as $card) {
-            if ($excludeUniques && $card->isUnique()) {
+            if ($card->isUnique()) {
+                $uniques[] = $card;
+
                 continue;
             }
 
             $pool[$card->getRarity()->value][] = $card;
         }
 
-        return $pool;
+        return ['pool' => $pool, 'uniques' => $uniques];
     }
 
     /**

--- a/src/Validator/ValidRarityRates.php
+++ b/src/Validator/ValidRarityRates.php
@@ -15,4 +15,5 @@ final class ValidRarityRates extends Constraint
     public string $invalidRarityMessage = 'Slot #{{ slot }} uses unknown rarity "{{ rarity }}". Valid rarities: {{ rarities }}.';
     public string $invalidWeightMessage = 'Slot #{{ slot }}, rarity "{{ rarity }}": weight must be a positive integer.';
     public string $invalidHoloChanceMessage = 'Slot #{{ slot }}: "holoChance" must be an integer between 0 and 100.';
+    public string $invalidUniqueChanceMessage = 'Slot #{{ slot }}: "uniqueChance" must be an integer between 0 and {{ scale }}.';
 }

--- a/src/Validator/ValidRarityRatesValidator.php
+++ b/src/Validator/ValidRarityRatesValidator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Validator;
 
+use App\Entity\Booster;
 use App\Enum\Entity\CardRarityEnum;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -46,6 +47,8 @@ final class ValidRarityRatesValidator extends ConstraintValidator
 
         $this->validateRarities($constraint, $slotNumber, $slot['rarities']);
         $this->validateHoloChance($constraint, $slotNumber, $slot['holoChance']);
+        // optional key: slots stored before the option existed read as 0
+        $this->validateUniqueChance($constraint, $slotNumber, $slot['uniqueChance'] ?? 0);
     }
 
     private function validateRarities(ValidRarityRates $constraint, int $slotNumber, mixed $rarities): void
@@ -84,6 +87,17 @@ final class ValidRarityRatesValidator extends ConstraintValidator
         if (!\is_int($holoChance) || $holoChance < 0 || $holoChance > 100) {
             $this->context->buildViolation($constraint->invalidHoloChanceMessage)
                 ->setParameter('{{ slot }}', (string) $slotNumber)
+                ->addViolation()
+            ;
+        }
+    }
+
+    private function validateUniqueChance(ValidRarityRates $constraint, int $slotNumber, mixed $uniqueChance): void
+    {
+        if (!\is_int($uniqueChance) || $uniqueChance < 0 || $uniqueChance > Booster::UNIQUE_CHANCE_SCALE) {
+            $this->context->buildViolation($constraint->invalidUniqueChanceMessage)
+                ->setParameter('{{ slot }}', (string) $slotNumber)
+                ->setParameter('{{ scale }}', (string) Booster::UNIQUE_CHANCE_SCALE)
                 ->addViolation()
             ;
         }

--- a/templates/admin/field/booster_drop_rates.html.twig
+++ b/templates/admin/field/booster_drop_rates.html.twig
@@ -21,6 +21,9 @@
                 {% if slot.holoChance > 0 %}
                     <span class="text-muted">— holo {{ slot.holoChance }} %</span>
                 {% endif %}
+                {% if slot.uniqueRate is not empty %}
+                    <span class="text-muted" title="Chance que ce slot sorte une carte unique 1/1 non réclamée">— unique {{ slot.uniqueRate }} %</span>
+                {% endif %}
             </div>
         {% endfor %}
     </div>

--- a/templates/admin/guide.html.twig
+++ b/templates/admin/guide.html.twig
@@ -80,7 +80,7 @@
             <tr><th>Champ</th><th>Rôle</th></tr>
             <tr><td>Nom / Description</td><td>Le nom sert d'ordre alphabétique secondaire partout (le tri principal est la rareté).</td></tr>
             <tr><td>Rareté</td><td>4 paliers : <code>common</code> (gris), <code>uncommon</code> (vert), <code>rare</code> (bleu), <code>legendary</code> (orange). Détermine le glow par défaut et le classement visuel.</td></tr>
-            <tr><td>Unique (1/1)</td><td>Exemplaire unique <strong>global</strong> : le premier joueur qui la tire la verrouille pour tout le monde (champ <em>claimedBy</em> en détail). Une fois réclamée elle ne peut plus être tirée — les ouvertures suivantes reçoivent une carte de remplacement de même rareté. La page univers affiche « droppée / encore dans le pool », jamais le détenteur.</td></tr>
+            <tr><td>Unique (1/1)</td><td>Exemplaire unique <strong>global</strong> : le premier joueur qui la tire la verrouille pour tout le monde (champ <em>claimedBy</em> en détail). Une fois réclamée elle ne peut plus être tirée — les ouvertures suivantes reçoivent une carte de remplacement de même rareté. La page univers affiche « droppée / encore dans le pool », jamais le détenteur. <strong>Une 1/1 est exclue du tirage par rareté</strong> : elle ne sort que par la <em>chance carte unique</em> d'un slot de booster (cf. §7). Tant qu'aucun slot n'en configure une, elle est intirable.</td></tr>
             <tr><td>Always holo</td><td>La carte sort <em>toujours</em> en version holo, quel que soit le <code>holoChance</code> du slot du booster.</td></tr>
             <tr><td>Statut</td><td>Cf. §1. Publier = tirable + comptée dans la complétion.</td></tr>
         </table>
@@ -154,11 +154,12 @@
         </table>
         <h3>Les slots — le cœur du booster</h3>
         <p><strong>1 slot = 1 carte du pack</strong> (3 slots = booster de 3 cartes). Chaque slot s'édite
-        dans son propre bloc du formulaire, avec un poids par rareté et sa chance holo ; ajouter ou
-        supprimer un bloc change le nombre de cartes du pack.</p>
+        dans son propre bloc du formulaire, avec un poids par rareté, sa chance holo et sa chance
+        de carte unique ; ajouter ou supprimer un bloc change le nombre de cartes du pack.</p>
         <ul>
             <li><code>rarities</code> : des <strong>poids relatifs</strong> (pas forcément des %) — <code>{"common": 7, "rare": 3}</code> vaut <code>{"common": 70, "rare": 30}</code>. Ils sont normalisés pour l'affichage du panneau « Taux » côté joueur.</li>
             <li><code>holoChance</code> : probabilité (0–100) que la carte de CE slot sorte en holo.</li>
+            <li><code>uniqueChance</code> : probabilité <strong>pour 10 000</strong> (25 = 0,25 %) que CE slot sorte une carte unique 1/1 encore non réclamée de l'univers, tirée au hasard parmi elles. Elle se joue <em>avant</em> le poids par rareté et le remplace : les 1/1 ne sont jamais dans le pool des raretés, leur taux ne dépend donc pas du nombre de cartes publiées dans leur palier. À 0 (défaut) aucune 1/1 ne peut sortir de ce slot.</li>
             <li>Un slot doit porter au moins une rareté pondérée, sinon le formulaire le refuse avec un message précis.</li>
             <li>Si une rareté tirée n'a aucune carte publiée dans l'extension, le tirage retombe automatiquement sur le palier le plus proche qui en a — l'admin te le signale par un avertissement, sans t'empêcher d'enregistrer.</li>
         </ul>

--- a/templates/components/BoosterHub.html.twig
+++ b/templates/components/BoosterHub.html.twig
@@ -296,6 +296,9 @@
                                                             {% if slot.holoChance > 0 %}
                                                                 <span class="text-magenta">✦ Holo {{ slot.holoChance }}%</span>
                                                             {% endif %}
+                                                            {% if slot.uniqueChance > 0 %}
+                                                                <span class="text-magenta" title="Chance de tirer une carte unique 1/1 encore non réclamée">◆ Unique {{ slot.uniqueRate == slot.uniqueRate|round ? slot.uniqueRate|round : slot.uniqueRate }}%</span>
+                                                            {% endif %}
                                                         </div>
                                                     {% endfor %}
                                                 </div>

--- a/tests/Functional/AdminBoosterCrudTest.php
+++ b/tests/Functional/AdminBoosterCrudTest.php
@@ -40,7 +40,7 @@ final class AdminBoosterCrudTest extends WebTestCase
 
         $booster = $this->createBooster([
             ['rarities' => ['common' => 70, 'rare' => 30], 'holoChance' => 20],
-            ['rarities' => ['rare' => 100], 'holoChance' => 100],
+            ['rarities' => ['rare' => 100], 'holoChance' => 100, 'uniqueChance' => 25],
         ]);
 
         $crawler = $client->request('GET', self::CRUD_URL . '/' . $booster->getId() . '/edit');
@@ -58,6 +58,9 @@ final class AdminBoosterCrudTest extends WebTestCase
         $this->assertSame('', (string) $crawler->filter('input[name="Booster[rarityRates][0][rarities][legendary]"]')->attr('value'));
         $this->assertSame('20', $crawler->filter('input[name="Booster[rarityRates][0][holoChance]"]')->attr('value'));
         $this->assertSame('100', $crawler->filter('input[name="Booster[rarityRates][1][rarities][rare]"]')->attr('value'));
+        // slot #1 predates the unique option: blank input, no crash
+        $this->assertSame('', (string) $crawler->filter('input[name="Booster[rarityRates][0][uniqueChance]"]')->attr('value'));
+        $this->assertSame('25', $crawler->filter('input[name="Booster[rarityRates][1][uniqueChance]"]')->attr('value'));
     }
 
     public function testSubmittingTheFormStoresACleanSlotList(): void
@@ -80,8 +83,8 @@ final class AdminBoosterCrudTest extends WebTestCase
         // slot #2 deleted in the browser and a new one appended: the submitted
         // keys are gapped, the stored JSON must still be a list
         $values['Booster']['rarityRates'] = [
-            0 => ['rarities' => ['common' => '80', 'uncommon' => '', 'rare' => '20', 'legendary' => ''], 'holoChance' => '15'],
-            2 => ['rarities' => ['common' => '', 'uncommon' => '', 'rare' => '', 'legendary' => '1'], 'holoChance' => ''],
+            0 => ['rarities' => ['common' => '80', 'uncommon' => '', 'rare' => '20', 'legendary' => ''], 'holoChance' => '15', 'uniqueChance' => ''],
+            2 => ['rarities' => ['common' => '', 'uncommon' => '', 'rare' => '', 'legendary' => '1'], 'holoChance' => '', 'uniqueChance' => '25'],
         ];
         $client->request('POST', $form->getUri(), $values);
         self::assertResponseIsSuccessful();
@@ -92,8 +95,8 @@ final class AdminBoosterCrudTest extends WebTestCase
         \assert($saved instanceof Booster);
 
         $this->assertSame([
-            ['rarities' => ['common' => 80, 'rare' => 20], 'holoChance' => 15],
-            ['rarities' => ['legendary' => 1], 'holoChance' => 0],
+            ['rarities' => ['common' => 80, 'rare' => 20], 'holoChance' => 15, 'uniqueChance' => 0],
+            ['rarities' => ['legendary' => 1], 'holoChance' => 0, 'uniqueChance' => 25],
         ], $saved->getRarityRates());
         $this->assertSame(2, $saved->getCardCount());
     }
@@ -131,7 +134,7 @@ final class AdminBoosterCrudTest extends WebTestCase
         $client->followRedirects();
         $this->authenticateClient($client);
 
-        $booster = $this->createBooster([['rarities' => ['common' => 60, 'rare' => 40], 'holoChance' => 25]]);
+        $booster = $this->createBooster([['rarities' => ['common' => 60, 'rare' => 40], 'holoChance' => 25, 'uniqueChance' => 25]]);
 
         $crawler = $client->request('GET', self::CRUD_URL . '/' . $booster->getId());
 
@@ -141,6 +144,22 @@ final class AdminBoosterCrudTest extends WebTestCase
         $this->assertStringContainsString('Rare 40 %', $rates);
         $this->assertStringContainsString('poids 60', $rates);
         $this->assertStringContainsString('holo 25 %', $rates);
+        // 25 per 10 000 read back as the percentage the player will see
+        $this->assertStringContainsString('unique 0,25 %', $rates);
+    }
+
+    public function testASlotWithoutUniqueChanceShowsNoUniqueMarker(): void
+    {
+        $client = self::createClient();
+        $client->followRedirects();
+        $this->authenticateClient($client);
+
+        $booster = $this->createBooster([['rarities' => ['common' => 100], 'holoChance' => 0]]);
+
+        $crawler = $client->request('GET', self::CRUD_URL . '/' . $booster->getId());
+
+        self::assertResponseIsSuccessful();
+        $this->assertStringNotContainsString('unique', $crawler->filter('.booster-drop-rates')->text());
     }
 
     public function testIndexPageShowsADropRatesColumn(): void
@@ -181,8 +200,8 @@ final class AdminBoosterCrudTest extends WebTestCase
     }
 
     /**
-     * @param list<array{rarities: array<string, int>, holoChance: int}> $rarityRates
-     * @param list<CardRarityEnum>                                       $publishedRarities
+     * @param list<array{rarities: array<string, int>, holoChance: int, uniqueChance?: int}> $rarityRates
+     * @param list<CardRarityEnum>                                                           $publishedRarities
      */
     private function createBooster(array $rarityRates, array $publishedRarities = []): Booster
     {

--- a/tests/Functional/BoosterHubComponentTest.php
+++ b/tests/Functional/BoosterHubComponentTest.php
@@ -114,6 +114,25 @@ final class BoosterHubComponentTest extends WebTestCase
         $this->assertStringContainsString('Taux par carte', $rendered);
         // every fixture slot weight map normalises to percentages
         $this->assertStringContainsString('%', $rendered);
+        // no fixture slot advertises a one-of-one chance
+        $this->assertStringNotContainsString('◆ Unique', $rendered);
+    }
+
+    public function testDropRatesPanelAdvertisesTheUniqueChance(): void
+    {
+        $client = static::createClient();
+        $this->authenticateClient($client, self::USER_WITHOUT_INVENTORY);
+
+        $entityManager = static::getContainer()->get(EntityManagerInterface::class);
+        $this->firstPublishedBooster()->setRarityRates([
+            ['rarities' => ['common' => 100], 'holoChance' => 0, 'uniqueChance' => 25],
+        ]);
+        $entityManager->flush();
+
+        $rendered = (string) $this->createLiveComponent(BoosterHub::class, client: $client)->render();
+
+        // 25 per 10 000 read by the player as a percentage
+        $this->assertStringContainsString('◆ Unique 0.25%', $rendered);
     }
 
     private function createEventBooster(): \App\Entity\Booster

--- a/tests/Integration/Service/BoosterOpeningServiceTest.php
+++ b/tests/Integration/Service/BoosterOpeningServiceTest.php
@@ -165,7 +165,8 @@ final class BoosterOpeningServiceTest extends KernelTestCase
         $this->entityManager->persist($extension);
 
         // The only RARE card is a one-of-one; a filler COMMON gives the draw a
-        // fallback once the unique is claimed.
+        // fallback once the unique is claimed. The 1/1 is out of the rarity
+        // pool: only the slot's uniqueChance can hand it out.
         $unique = new Card()
             ->setName('One of one')
             ->setDescription('Test card')
@@ -189,7 +190,7 @@ final class BoosterOpeningServiceTest extends KernelTestCase
 
         $booster = new Booster()
             ->setExtension($extension)
-            ->setRarityRates([['rarities' => ['rare' => 100], 'holoChance' => 0]])
+            ->setRarityRates([['rarities' => ['rare' => 100], 'holoChance' => 0, 'uniqueChance' => Booster::UNIQUE_CHANCE_SCALE]])
         ;
         $booster->setImageName('default_card.png');
         $this->entityManager->persist($booster);
@@ -202,10 +203,11 @@ final class BoosterOpeningServiceTest extends KernelTestCase
         }
         $this->entityManager->flush();
 
-        // Alice opens first: the RARE slot draws the only rare card (the unique) and claims it.
+        // Alice opens first: the slot always rolls its unique chance, draws the
+        // only unclaimed 1/1 and claims it.
         $this->openingService->open($alice, $booster);
         // Bob opens next: the claimed unique is filtered out of the pool, so the
-        // RARE slot falls back to the common — Bob can never get the 1/1.
+        // slot falls back to the rarity draw — Bob can never get the 1/1.
         $this->openingService->open($bob, $booster);
 
         $this->entityManager->clear();

--- a/tests/Unit/Entity/BoosterTest.php
+++ b/tests/Unit/Entity/BoosterTest.php
@@ -39,10 +39,31 @@ final class BoosterTest extends TestCase
         ]);
 
         $this->assertSame([
-            ['rates' => ['common' => 100.0], 'holoChance' => 5],
-            ['rates' => ['common' => 60.0, 'rare' => 30.0, 'legendary' => 10.0], 'holoChance' => 30],
-            ['rates' => ['common' => 33.3, 'rare' => 66.7], 'holoChance' => 0],
+            ['rates' => ['common' => 100.0], 'holoChance' => 5, 'uniqueChance' => 0, 'uniqueRate' => 0.0],
+            ['rates' => ['common' => 60.0, 'rare' => 30.0, 'legendary' => 10.0], 'holoChance' => 30, 'uniqueChance' => 0, 'uniqueRate' => 0.0],
+            ['rates' => ['common' => 33.3, 'rare' => 66.7], 'holoChance' => 0, 'uniqueChance' => 0, 'uniqueRate' => 0.0],
         ], $booster->getDropRates());
+    }
+
+    public function testDropRatesExposeTheUniqueChanceAsAPercentage(): void
+    {
+        $booster = new Booster()->setRarityRates([
+            ['rarities' => ['common' => 100], 'holoChance' => 0, 'uniqueChance' => 25],
+            ['rarities' => ['rare' => 100], 'holoChance' => 0, 'uniqueChance' => 10_000],
+            ['rarities' => ['rare' => 100], 'holoChance' => 0, 'uniqueChance' => 1],
+        ]);
+
+        $this->assertSame([0.25, 100.0, 0.01], array_column($booster->getDropRates(), 'uniqueRate'));
+        $this->assertSame([25, 10_000, 1], array_column($booster->getDropRates(), 'uniqueChance'));
+    }
+
+    public function testSlotStoredBeforeTheUniqueOptionReadsAsZero(): void
+    {
+        // the key is optional on purpose: no data migration was needed
+        $booster = new Booster()->setRarityRates([['rarities' => ['common' => 100], 'holoChance' => 5]]);
+
+        $this->assertSame(0, $booster->getDropRates()[0]['uniqueChance']);
+        $this->assertSame(0.0, $booster->getDropRates()[0]['uniqueRate']);
     }
 
     public function testSlotsAreReindexedSoTheJsonStaysAList(): void

--- a/tests/Unit/Form/BoosterSlotTypeTest.php
+++ b/tests/Unit/Form/BoosterSlotTypeTest.php
@@ -35,12 +35,13 @@ final class BoosterSlotTypeTest extends TestCase
         $form->submit([
             'rarities' => ['common' => '60', 'uncommon' => '', 'rare' => '40', 'legendary' => ''],
             'holoChance' => '25',
+            'uniqueChance' => '25',
         ]);
 
         $this->assertTrue($form->isSynchronized());
         $this->assertTrue($form->isValid(), $this->errorsAsString($form));
         $this->assertSame(
-            ['rarities' => ['common' => 60, 'rare' => 40], 'holoChance' => 25],
+            ['rarities' => ['common' => 60, 'rare' => 40], 'holoChance' => 25, 'uniqueChance' => 25],
             $form->getData(),
         );
     }
@@ -50,6 +51,7 @@ final class BoosterSlotTypeTest extends TestCase
         $form = $this->factory->create(BoosterSlotType::class, [
             'rarities' => ['rare' => 30, 'legendary' => 10],
             'holoChance' => 40,
+            'uniqueChance' => 25,
         ]);
 
         $weights = $form->get('rarities');
@@ -58,6 +60,42 @@ final class BoosterSlotTypeTest extends TestCase
         $this->assertSame(30, $weights->get('rare')->getData());
         $this->assertSame(10, $weights->get('legendary')->getData());
         $this->assertSame(40, $form->get('holoChance')->getData());
+        $this->assertSame(25, $form->get('uniqueChance')->getData());
+    }
+
+    public function testSlotStoredBeforeTheUniqueOptionOpensOnABlankField(): void
+    {
+        // uniqueChance is an optional key: editing a booster saved before the
+        // option must not blow up on the missing index
+        $form = $this->factory->create(BoosterSlotType::class, [
+            'rarities' => ['common' => 100],
+            'holoChance' => 5,
+        ]);
+
+        $this->assertNull($form->get('uniqueChance')->getData());
+
+        $form->submit(['rarities' => ['common' => '100'], 'holoChance' => '5']);
+
+        $this->assertTrue($form->isValid(), $this->errorsAsString($form));
+        $this->assertSame(0, $form->getData()['uniqueChance']);
+    }
+
+    public function testBlankUniqueChanceFallsBackToZero(): void
+    {
+        $form = $this->factory->create(BoosterSlotType::class);
+        $form->submit(['rarities' => ['common' => '100'], 'holoChance' => '0', 'uniqueChance' => '']);
+
+        $this->assertTrue($form->isValid(), $this->errorsAsString($form));
+        $this->assertSame(0, $form->getData()['uniqueChance']);
+    }
+
+    public function testUniqueChanceOutOfBoundsIsRejected(): void
+    {
+        $form = $this->factory->create(BoosterSlotType::class);
+        $form->submit(['rarities' => ['common' => '100'], 'holoChance' => '0', 'uniqueChance' => '10001']);
+
+        $this->assertFalse($form->isValid());
+        $this->assertStringContainsString('chance unique', $this->errorsAsString($form));
     }
 
     public function testWeightsKeepTheRarityScaleOrderWhateverTheInputOrder(): void

--- a/tests/Unit/Service/BoosterRarityAvailabilityTest.php
+++ b/tests/Unit/Service/BoosterRarityAvailabilityTest.php
@@ -44,6 +44,27 @@ final class BoosterRarityAvailabilityTest extends TestCase
         $this->assertSame([], $availability->findUnavailableRarities($booster));
     }
 
+    public function testATierHoldingOnlyAUniqueIsReportedAsUnavailable(): void
+    {
+        // uniques never come out of the rarity roll: weighting legendary while
+        // the only legendary is a 1/1 is the same misconfiguration as an empty tier
+        $cardRepository = $this->createStub(CardRepository::class);
+        $cardRepository->method('findDrawablePool')->willReturn([
+            new Card()->setRarity(CardRarityEnum::COMMON),
+            new Card()->setRarity(CardRarityEnum::LEGENDARY)->setUnique(true),
+        ]);
+
+        $booster = new Booster()
+            ->setExtension(new Extension()->setName('Bleach'))
+            ->setRarityRates([['rarities' => ['common' => 90, 'legendary' => 10], 'holoChance' => 0]])
+        ;
+
+        $this->assertSame(
+            [CardRarityEnum::LEGENDARY],
+            new BoosterRarityAvailability($cardRepository)->findUnavailableRarities($booster),
+        );
+    }
+
     public function testABoosterWithoutExtensionIsNotChecked(): void
     {
         $cardRepository = $this->createMock(CardRepository::class);

--- a/tests/Unit/Service/CardDrawerTest.php
+++ b/tests/Unit/Service/CardDrawerTest.php
@@ -145,6 +145,160 @@ final class CardDrawerTest extends TestCase
         }
     }
 
+    public function testUniqueIsNeverDrawnByTheRarityRoll(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Unique rare', CardRarityEnum::RARE)->setUnique(true),
+            $this->card('Plain rare', CardRarityEnum::RARE),
+        ]);
+        $booster = $this->booster([['rare' => 100]]);
+
+        for ($i = 0; $i < 300; ++$i) {
+            $this->assertSame('Plain rare', $drawer->draw($booster)[0]->card->getName());
+        }
+    }
+
+    public function testFullUniqueChanceAlwaysDrawsAUnique(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Unique rare', CardRarityEnum::RARE)->setUnique(true),
+            $this->card('Plain common', CardRarityEnum::COMMON),
+        ]);
+        $booster = $this->booster([['common' => 100]], uniqueChance: Booster::UNIQUE_CHANCE_SCALE);
+
+        for ($i = 0; $i < 200; ++$i) {
+            $drawnCard = $drawer->draw($booster)[0];
+
+            $this->assertSame('Unique rare', $drawnCard->card->getName());
+            // the unique brings its own rarity, the slot weights are bypassed
+            $this->assertSame(CardRarityEnum::RARE, $drawnCard->rarity);
+        }
+    }
+
+    public function testUniqueChanceDistributionOverManyDraws(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Unique rare', CardRarityEnum::RARE)->setUnique(true),
+            $this->card('Plain common', CardRarityEnum::COMMON),
+        ]);
+        // 1 000 per 10 000 = 10 %
+        $booster = $this->booster([['common' => 100]], uniqueChance: 1_000);
+
+        $draws = 10_000;
+        $uniques = 0;
+
+        for ($i = 0; $i < $draws; ++$i) {
+            $uniques += $drawer->draw($booster)[0]->card->isUnique() ? 1 : 0;
+        }
+
+        $this->assertEqualsWithDelta(0.10, $uniques / $draws, 0.02);
+    }
+
+    public function testUniqueChanceIsResolvedPerSlot(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Unique rare', CardRarityEnum::RARE)->setUnique(true),
+            $this->card('Plain common', CardRarityEnum::COMMON),
+        ]);
+        $booster = new Booster()
+            ->setExtension($this->extension())
+            ->setRarityRates([
+                ['rarities' => ['common' => 100], 'holoChance' => 0, 'uniqueChance' => 0],
+                ['rarities' => ['common' => 100], 'holoChance' => 0, 'uniqueChance' => Booster::UNIQUE_CHANCE_SCALE],
+            ])
+        ;
+
+        for ($i = 0; $i < 200; ++$i) {
+            $drawnCards = $drawer->draw($booster);
+
+            $this->assertFalse($drawnCards[0]->card->isUnique());
+            $this->assertTrue($drawnCards[1]->card->isUnique());
+        }
+    }
+
+    public function testUniqueStillRollsTheSlotHoloChance(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Unique rare', CardRarityEnum::RARE)->setUnique(true),
+            $this->card('Plain common', CardRarityEnum::COMMON),
+        ]);
+
+        $always = $this->booster([['common' => 100]], holoChance: 100, uniqueChance: Booster::UNIQUE_CHANCE_SCALE);
+        $never = $this->booster([['common' => 100]], holoChance: 0, uniqueChance: Booster::UNIQUE_CHANCE_SCALE);
+
+        for ($i = 0; $i < 100; ++$i) {
+            $this->assertTrue($drawer->draw($always)[0]->holo);
+            $this->assertFalse($drawer->draw($never)[0]->holo);
+        }
+    }
+
+    public function testFallsBackToTheRarityDrawWhenNoUniqueIsLeft(): void
+    {
+        // a claimed one-of-one is already filtered out of the drawable pool
+        $drawer = $this->createDrawer([$this->card('Plain common', CardRarityEnum::COMMON)]);
+        $booster = $this->booster([['common' => 100]], uniqueChance: Booster::UNIQUE_CHANCE_SCALE);
+
+        for ($i = 0; $i < 100; ++$i) {
+            $this->assertSame('Plain common', $drawer->draw($booster)[0]->card->getName());
+        }
+    }
+
+    public function testTwoUniqueSlotsCannotLandOnTheSameUnique(): void
+    {
+        $drawer = $this->createDrawer([
+            $this->card('Unique A', CardRarityEnum::RARE)->setUnique(true),
+            $this->card('Unique B', CardRarityEnum::RARE)->setUnique(true),
+            $this->card('Plain common', CardRarityEnum::COMMON),
+        ]);
+        $booster = $this->booster([['common' => 100], ['common' => 100]], uniqueChance: Booster::UNIQUE_CHANCE_SCALE);
+
+        for ($i = 0; $i < 200; ++$i) {
+            $names = array_map(static fn ($drawnCard): string => $drawnCard->card->getName(), $drawer->draw($booster));
+
+            $this->assertCount(2, array_unique($names));
+        }
+    }
+
+    public function testDrawsAUniqueWhenTheExtensionHasNothingElseToOffer(): void
+    {
+        // no regular card at all: the slot cannot fall back on a rarity roll,
+        // so the unique goes out whatever the configured chance
+        $drawer = $this->createDrawer([$this->card('Unique rare', CardRarityEnum::RARE)->setUnique(true)]);
+
+        $this->assertSame('Unique rare', $drawer->draw($this->booster([['common' => 100]]))[0]->card->getName());
+    }
+
+    public function testAUniqueInThePoolDoesNotShiftTheSeededRarityDraw(): void
+    {
+        $cards = [
+            $this->card('Common A', CardRarityEnum::COMMON),
+            $this->card('Common B', CardRarityEnum::COMMON),
+            $this->card('Plain rare', CardRarityEnum::RARE),
+        ];
+        $booster = $this->booster([['common' => 70, 'rare' => 30], ['common' => 70, 'rare' => 30]]);
+
+        $names = static fn (array $drawnCards): array => array_map(
+            static fn ($drawnCard): string => $drawnCard->card->getName() . ($drawnCard->holo ? '*' : ''),
+            $drawnCards,
+        );
+
+        // A slot that configures no unique chance rolls nothing for it, so an
+        // unclaimed 1/1 sitting in the extension shifts neither the RNG stream
+        // nor the candidate lists of the other slots.
+        $withoutUnique = new RandomService();
+        $withoutUnique->seed(20260812);
+        $reference = $names(new CardDrawer($this->repositoryWith($cards), $withoutUnique)->draw($booster));
+
+        $withUnique = new RandomService();
+        $withUnique->seed(20260812);
+        $drawer = new CardDrawer(
+            $this->repositoryWith([...$cards, $this->card('Unique rare', CardRarityEnum::RARE)->setUnique(true)]),
+            $withUnique,
+        );
+
+        $this->assertSame($reference, $names($drawer->draw($booster)));
+    }
+
     public function testThrowsWhenRarityRatesAreEmpty(): void
     {
         // The guard must fire before any pool load or roll: an empty slot list
@@ -300,13 +454,17 @@ final class CardDrawerTest extends TestCase
     /**
      * Wraps plain rarity weight maps into the per-slot shape
      * ({rarities, holoChance}), applying the same holo chance to every slot.
+     * uniqueChance is only written when asked for, so the default booster is
+     * exactly the pre-option shape.
      *
      * @param list<array<string, int>> $raritySlots
      */
-    private function booster(array $raritySlots, int $holoChance = 10): Booster
+    private function booster(array $raritySlots, int $holoChance = 10, ?int $uniqueChance = null): Booster
     {
         $rarityRates = array_map(
-            static fn (array $rarities): array => ['rarities' => $rarities, 'holoChance' => $holoChance],
+            static fn (array $rarities): array => null === $uniqueChance
+                ? ['rarities' => $rarities, 'holoChance' => $holoChance]
+                : ['rarities' => $rarities, 'holoChance' => $holoChance, 'uniqueChance' => $uniqueChance],
             $raritySlots,
         );
 

--- a/tests/Unit/Validator/ValidRarityRatesValidatorTest.php
+++ b/tests/Unit/Validator/ValidRarityRatesValidatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Validator;
 
+use App\Entity\Booster;
 use App\Enum\Entity\CardRarityEnum;
 use App\Validator\ValidRarityRates;
 use App\Validator\ValidRarityRatesValidator;
@@ -159,6 +160,41 @@ final class ValidRarityRatesValidatorTest extends ConstraintValidatorTestCase
         yield 'below zero' => [-1];
         yield 'above one hundred' => [101];
         yield 'not an integer' => ['10'];
+    }
+
+    #[DataProvider('provideInvalidUniqueChances')]
+    public function testInvalidUniqueChanceIsRejected(mixed $uniqueChance): void
+    {
+        $this->validator->validate([
+            ['rarities' => ['common' => 100], 'holoChance' => 10, 'uniqueChance' => $uniqueChance],
+        ], $this->rarityRatesConstraint);
+
+        $this->buildViolation($this->rarityRatesConstraint->invalidUniqueChanceMessage)
+            ->setParameter('{{ slot }}', '1')
+            ->setParameter('{{ scale }}', (string) Booster::UNIQUE_CHANCE_SCALE)
+            ->assertRaised()
+        ;
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function provideInvalidUniqueChances(): iterable
+    {
+        yield 'below zero' => [-1];
+        yield 'above the scale' => [Booster::UNIQUE_CHANCE_SCALE + 1];
+        yield 'not an integer' => ['25'];
+    }
+
+    public function testSlotWithoutUniqueChanceStaysValid(): void
+    {
+        // the key is optional: slots stored before the option must not break
+        $this->validator->validate([
+            ['rarities' => ['common' => 100], 'holoChance' => 10],
+            ['rarities' => ['rare' => 100], 'holoChance' => 0, 'uniqueChance' => Booster::UNIQUE_CHANCE_SCALE],
+        ], $this->rarityRatesConstraint);
+
+        $this->assertNoViolation();
     }
 
     public function testUnknownRarityWithInvalidWeightRaisesBothViolations(): void


### PR DESCRIPTION
## Ce que ça change

Les cartes uniques 1/1 étaient jusqu'ici mélangées au pool des raretés : leur taux de sortie dépendait du nombre de cartes publiées dans leur palier, donc il bougeait à chaque carte ajoutée à l'univers, sans qu'on puisse le régler.

Chaque **slot** de booster porte maintenant sa propre `uniqueChance` :

- exprimée **pour 10 000** (`Booster::UNIQUE_CHANCE_SCALE`) — le plus petit palier utile est 0,01 %, pas 1 % ;
- jouée **avant** le poids par rareté et le remplaçant : une 1/1 n'est plus jamais dans le pool des raretés ;
- à **0** (valeur par défaut, y compris pour les slots enregistrés avant l'option) aucune 1/1 ne peut sortir de ce slot.

## Détails de comportement

- le slot garde son roll holo normal, même quand il sort une unique ;
- l'unique apporte sa propre rareté (les poids du slot sont court-circuités) ;
- deux slots d'un même pack ne peuvent pas tomber sur la même 1/1 ;
- si l'univers n'a plus que des uniques à offrir, elles sortent quel que soit le réglage — il n'y a rien d'autre à distribuer ;
- un slot laissé à 0 ne consomme aucun aléa supplémentaire : la présence d'une 1/1 non réclamée dans l'univers ne décale ni le flux RNG ni les listes de candidats des autres slots ;
- le remplacement d'une unique déjà réclamée par un autre joueur (side stream RNG) est inchangé.

## Admin & joueur

- champ **« Chance carte unique (pour 10 000) »** dans chaque bloc de slot, borné 0–10 000, validé côté contrainte `ValidRarityRates` ;
- taux affiché en % (2 décimales) sur les écrans admin — `25` → `0,25 %` ;
- panneau **« Taux »** du hub : marqueur `◆ Unique 0.25%` sur les slots concernés uniquement ;
- guide admin mis à jour (§ cartes et § boosters) : une 1/1 est **intirable** tant qu'aucun slot ne configure de chance.

## Tests

`make quality` vert, `make phpunit` vert (443 tests, 4586 assertions) sur base de test recréée à neuf.

Nouveaux tests : exclusion des uniques du tirage par rareté, chance à 100 %, distribution sur 10 000 tirages, résolution par slot, roll holo conservé, repli quand il n'y a plus d'unique, pas de doublon entre deux slots, univers sans autre carte, non-régression du tirage seedé, aller-retour du formulaire admin, rendu du panneau joueur, validateur.